### PR TITLE
Validate the headers returned against the schema specification.

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -162,6 +162,27 @@ class ResponseBodyValidator(object):
         return None
 
 
+class ResponseHeaderValidator(object):
+    def __init__(self, schema, validator=None):
+        """
+        :param schema: The schema of the response header
+        :param validator: Validator class that should be used to validate passed data
+                          against API schema. Default is jsonschema.Draft4Validator.
+        :type validator: jsonschema.IValidator
+        """
+        ValidatorClass = validator or Draft4Validator
+        self.validator = ValidatorClass(schema, format_checker=draft4_format_checker)
+
+    def validate_schema(self, data, url):
+        # type: (dict, AnyStr) -> Union[ConnexionResponse, None]
+        try:
+            self.validator.validate(data)
+        except ValidationError as exception:
+            logger.error("{url} validation error: {error}".format(url=url,
+                                                                  error=exception))
+            six.reraise(*sys.exc_info())
+
+
 class ParameterValidator(object):
     def __init__(self, parameters, api, strict_validation=False):
         """

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -49,6 +49,11 @@ For example
     def my_endpoint():
         return 'Not Found', 404, {'x-error': 'not found'}
 
+Header Validation
+^^^^^^^^^^^^^^^^^
+
+By default, headers are validated against OpenAPI schema via
+``connexion.decorators.validation.ResponseHeaderValidator``
 
 Response Validation
 -------------------

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -17,6 +17,36 @@ def test_headers_produces(simple_app):
     assert response.headers["Location"] == "http://localhost/my/uri"
 
 
+def test_headers_incorrect_length(simple_app):
+    app_client = simple_app.app.test_client()
+
+    response = app_client.post('/v1.0/goodnight/a', data={})  # type: flask.Response
+    assert response.status_code == 500
+    data = json.loads(response.data.decode('utf-8', 'replace'))
+    assert data['type'] == 'about:blank'
+    assert data['title'] == 'Response headers do not conform to specification'
+    assert data['detail'].find("'a' is too short") != -1
+    assert data['status'] == 500
+
+    response = app_client.post('/v1.0/goodnight/abcdeabcdeabcde', data={})  # type: flask.Response
+    assert response.status_code == 500
+    data = json.loads(response.data.decode('utf-8', 'replace'))
+    assert data['type'] == 'about:blank'
+    assert data['title'] == 'Response headers do not conform to specification'
+    assert data['detail'].find("'abcdeabcdeabcde' is too long") != -1
+    assert data['status'] == 500
+
+    response = app_client.post('/v1.0/goodnight/abcde', data={})  # type: flask.Response
+    assert response.status_code == 201
+
+
+def test_headers_incorrect_type(simple_app):
+    app_client = simple_app.app.test_client()
+
+    response = app_client.post('/v1.0/alldark', data={})  # type: flask.Response
+    assert response.status_code == 500
+
+
 def test_header_not_returned(simple_app):
     app_client = simple_app.app.test_client()
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -58,6 +58,25 @@ def post_goodevening(name):
     return data, 201, headers
 
 
+def post_goodnight(name):
+    import sys
+    data = 'Good night {name}'.format(name=name)
+    headers = {}
+    sys.stderr.write("YO NAME WAS %s type %s\n" % (name, type(name)))
+    try:
+        intvalue = int(name)
+        headers["X-Name"] = intvalue
+    except ValueError:
+        headers["X-Name"] = name
+    return data, 201, headers
+
+
+def post_alldark():
+    data = 'All dark'
+    headers = {"X-Result": 12345}
+    return data, 201, headers
+
+
 def get_list(name):
     data = ['hello', name]
     return data

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -516,6 +516,48 @@ paths:
           required: true
           type: string
 
+  /goodnight/{name}:
+    post:
+      summary: Generate good night
+      description: |
+        Generates a good night message.  Sets the name in the header.
+      operationId: fakeapi.hello.post_goodnight
+      produces:
+        - text/plain
+      responses:
+        201:
+          description: goodnight response
+          headers:
+            X-Name:
+              type: string
+              minLength: 4
+              maxLength: 10
+              description: The name of the person to say good night.
+          schema:
+            type: string
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say good evening.
+          required: true
+          type: string
+
+  /alldark:
+    post:
+      summary: Generate all dark message.
+      description: Sets a string as a header, when an integer is expected.
+      operationId: fakeapi.hello.post_alldark
+      produces:
+        - text/plain
+      responses:
+        201:
+          description: alldark response
+          headers:
+            X-Result:
+              type: integer
+          schema:
+            type: string
+
   /test-204-with-headers:
     get:
       summary: Tests that response code 204 can have headers set


### PR DESCRIPTION
Changes proposed in this pull request:

According to http://swagger.io/specification/#header-object-68, the headers should be validated.  This adds a simple test for incorrect type (header returns a string where an integer is expected), and positive and negative tests against string length.