### PR TITLE
Create a ConnexionHeaders type

### DIFF
--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -34,4 +34,31 @@ class ConnexionResponse(object):
         self.mimetype = mimetype
         self.content_type = content_type
         self.body = body
-        self.headers = headers or {}
+        self.headers = ConnexionHeaders(headers)
+
+
+class ConnexionHeaders(object):
+    def __init__(self, headers):
+        self.headers = headers or list()
+
+    def getlist(self, name):
+        """
+        Given a header name, return the list of values that was sent with that
+        name.
+        """
+        return [v
+                for n, v in self.headers
+                if n == name]
+
+    def getfirst(self, name, defaultvalue=None):
+        """
+        Given a header name, return the first value that was sent with that
+        name.  If the header name is not found, return `defaultvalue`.
+        """
+        for n, v in self.headers:
+            if n == name:
+                return v
+        return defaultvalue
+
+    def __iter__(self):
+        return self.headers.__iter__()

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -21,7 +21,7 @@ def problem(status, title, detail, type=None, instance=None, headers=None, ext=N
                      further information if dereferenced.
     :type instance: str
     :param headers: HTTP headers to include in the response
-    :type headers: dict | None
+    :type headers: list | None
     :param ext: Extension members to include in the body
     :type ext: dict | None
     :return: error response

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -93,7 +93,7 @@ def with_problem():
                    detail='Something went wrong somewhere',
                    status=418,
                    instance='instance1',
-                   headers={'x-Test-Header': 'In Test'})
+                   headers=[('x-Test-Header', 'In Test')])
 
 
 def with_problem_txt():


### PR DESCRIPTION
Changes proposed in this pull request:

 -headers should be a list of name, value tuples, because multiple headers can be sent down with the same name.
 -The flask response construction expects either a dictionary (less flexible) or an iterable yielding (name, value) tuples.  The `__iter__` method in `ConnexionHeaders` dispatches to the inner list for that.
