### PR TITLE
WIP: Fix validation of endpoint with multiple "produces" mimetypes.

### DIFF
--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -268,16 +268,21 @@ def test_get_bad_default_response(simple_app):
 
     resp = app_client.get('/v1.0/get_bad_default_response/202')
     assert resp.status_code == 500
-    
+
 def test_get_several_mimetypes(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/get_several_mimetypes',
       headers={ 'Accept': 'application/json' })
-    
     assert resp.status_code == 200
     assert resp.content_type == 'application/json'
+
+    resp = app_client.get('/v1.0/get_several_mimetypes',
+      headers={ 'Accept': 'text/html' })
+    assert resp.status_code == 200
+    assert resp.content_type == 'text/html'
 
     resp = app_client.get('/v1.0/get_several_mimetypes',
       headers={ 'Accept': 'text/plain' })
     assert resp.status_code == 200
     assert resp.content_type == 'text/plain'
+

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -268,3 +268,16 @@ def test_get_bad_default_response(simple_app):
 
     resp = app_client.get('/v1.0/get_bad_default_response/202')
     assert resp.status_code == 500
+    
+def test_get_several_mimetypes(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_several_mimetypes',
+      headers={ 'Accept': 'application/json' })
+    
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/json'
+
+    resp = app_client.get('/v1.0/get_several_mimetypes',
+      headers={ 'Accept': 'text/plain' })
+    assert resp.status_code == 200
+    assert resp.content_type == 'text/plain'

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -447,7 +447,10 @@ def get_bad_default_response(response_code):
 
 
 def get_several_mimetypes():
-    if connexion.request.headers['Accept'].find('json') != -1:
+    accept_header = connexion.request.headers['Accept']
+    if accept_header.find('json') != -1:
         return {}, 200
+    elif accept_header.find('html') != -1:
+        return "<html><body>An html</body></html>", 200, {'Content-Type': 'text/plain'}
     else:
-        return "A text", 200
+        return "A text", 200, {'Content-Type': 'text/plain'}

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -444,3 +444,10 @@ def get_httpstatus_response():
 
 def get_bad_default_response(response_code):
     return {}, response_code
+
+
+def get_several_mimetypes():
+    if connexion.request.headers['Accept'].find('json') != -1:
+        return {}, 200
+    else:
+        return "A text", 200

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -867,10 +867,11 @@ paths:
       produces:
         - "application/json"
         - "text/plain"
+        - "text/html"
       responses:
         200:
           description: |-
-            This endpoint produces either json or txt depending on 
+            This endpoint produces multiple responses depending on 
             Accept header
           schema:
             type: object

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -860,6 +860,20 @@ paths:
             type: array
             items:
               type: integer
+              
+  /get_several_mimetypes:
+    get:
+      operationId: fakeapi.hello.get_several_mimetypes
+      produces:
+        - "application/json"
+        - "text/plain"
+      responses:
+        200:
+          description: |-
+            This endpoint produces either json or txt depending on 
+            Accept header
+          schema:
+            type: object
 
 definitions:
   new_stack:


### PR DESCRIPTION
This will fix #593 .

Changes proposed in this pull request:
 - response validator does not validate responses of non-json types against schema if they are listed along with json in `produces` stanza of spec.
