### PR TITLE
WIP: redo validation by content type

### DIFF
--- a/connexion/content_types.py
+++ b/connexion/content_types.py
@@ -3,12 +3,11 @@ import re
 
 from jsonschema import ValidationError
 
-from ..exceptions import ExtraParameterProblem, BadRequestProblem
-from ..problem import problem
-from ..types import coerce_type
-from ..utils import is_null
+from .exceptions import ExtraParameterProblem, BadRequestProblem
+from .types import coerce_type
+from .utils import is_null
 
-logger = logging.getLogger('connexion.serialization.deserializers')
+logger = logging.getLogger('connexion.content_types')
 
 
 class ContentHandler(object):
@@ -120,7 +119,7 @@ class MultiPartFormDataContentHandler(FormDataContentHandler):
     )
 
 
-DEFAULT_DESERIALIZERS = (
+KNOWN_CONTENT_TYPES = (
     StreamingContentHandler,
     JSONContentHandler,
     FormDataContentHandler,

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -6,9 +6,8 @@ import re
 import inflection
 import six
 
-from ..http_facts import FORM_CONTENT_TYPES
 from ..lifecycle import ConnexionRequest  # NOQA
-from ..utils import all_json
+from ..utils import is_form_mimetype, is_json_mimetype
 
 try:
     import builtins
@@ -73,7 +72,6 @@ def parameter_to_arg(operation, function, pythonic_params=False,
     request context will be passed as that argument.
     :type pass_context_arg_name: str|None
     """
-    consumes = operation.consumes
 
     def sanitized(name):
         return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z_]', '', name))
@@ -91,9 +89,9 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         logger.debug('Function Arguments: %s', arguments)
         kwargs = {}
 
-        if all_json(consumes):
+        if is_json_mimetype(request.content_type):
             request_body = request.json
-        elif consumes[0] in FORM_CONTENT_TYPES:
+        elif is_form_mimetype(request.content_type):
             request_body = {sanitize(k): v for k, v in request.form.items()}
         else:
             request_body = request.body

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import FileStorage
 from ..exceptions import ExtraParameterProblem, BadRequestProblem, UnsupportedMediaTypeProblem
 from ..http_facts import FORM_CONTENT_TYPES
 from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
-from ..serialization.deserializers import DEFAULT_DESERIALIZERS
+from ..content_types import KNOWN_CONTENT_TYPES
 from ..types import TypeValidationError, coerce_type
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
@@ -56,7 +56,7 @@ class RequestBodyValidator(object):
             de(self.validator,
                self.schema,
                self.strict_validation,
-               self.is_null_value_valid) for de in DEFAULT_DESERIALIZERS
+               self.is_null_value_valid) for de in KNOWN_CONTENT_TYPES
         ]
 
     def register_content_handler(self, cv):
@@ -69,7 +69,8 @@ class RequestBodyValidator(object):
     def lookup_content_handler(self, request):
         matches = [
             v for v in self._content_handlers
-            if v.regex.match(request.content_type)
+            if request.content_type is not None and
+               v.regex.match(request.content_type)
         ]
         if len(matches) > 1:
             logger.warning("Content could be handled by multiple validators")
@@ -85,7 +86,10 @@ class RequestBodyValidator(object):
         @functools.wraps(function)
         def wrapper(request):
             content_handler = self.lookup_content_handler(request)
-            exact_match = request.content_type in self.consumes
+            exact_match = (
+                request.content_type is not None and
+                request.content_type in self.consumes
+            )
             partial_match = content_handler and content_handler.name in self.consumes
             if not (exact_match or partial_match):
                 raise UnsupportedMediaTypeProblem(

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -60,7 +60,11 @@ class RequestBodyValidator(object):
         ]
 
     def register_content_handler(self, cv):
-        self._content_handlers += [cv]
+        deser = cv(self.validator,
+                   self.schema,
+                   self.strict_validation,
+                   self.is_null_value_valid)
+        self._content_handlers += [deser]
 
     def lookup_content_handler(self, request):
         matches = [

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -13,6 +13,8 @@ from werkzeug.datastructures import FileStorage
 from ..exceptions import ExtraParameterProblem, BadRequestProblem, UnsupportedMediaTypeProblem
 from ..http_facts import FORM_CONTENT_TYPES
 from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
+from ..serialization.deserializers import DEFAULT_DESERIALIZERS
+from ..types import TypeValidationError, coerce_type
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
 _jsonschema_3_or_newer = pkg_resources.parse_version(
@@ -20,77 +22,6 @@ _jsonschema_3_or_newer = pkg_resources.parse_version(
     pkg_resources.parse_version("3.0.0")
 
 logger = logging.getLogger('connexion.decorators.validation')
-
-TYPE_MAP = {
-    'integer': int,
-    'number': float,
-    'boolean': boolean,
-    'object': dict
-}
-
-
-class TypeValidationError(Exception):
-    def __init__(self, schema_type, parameter_type, parameter_name):
-        """
-        Exception raise when type validation fails
-
-        :type schema_type: str
-        :type parameter_type: str
-        :type parameter_name: str
-        :return:
-        """
-        self.schema_type = schema_type
-        self.parameter_type = parameter_type
-        self.parameter_name = parameter_name
-
-    def __str__(self):
-        msg = "Wrong type, expected '{schema_type}' for {parameter_type} parameter '{parameter_name}'"
-        return msg.format(**vars(self))
-
-
-def coerce_type(param, value, parameter_type, parameter_name=None):
-
-    def make_type(value, type_literal):
-        type_func = TYPE_MAP.get(type_literal)
-        return type_func(value)
-
-    param_schema = param.get("schema", param)
-    if is_nullable(param_schema) and is_null(value):
-        return None
-
-    param_type = param_schema.get('type')
-    parameter_name = parameter_name if parameter_name else param.get('name')
-    if param_type == "array":
-        converted_params = []
-        for v in value:
-            try:
-                converted = make_type(v, param_schema["items"]["type"])
-            except (ValueError, TypeError):
-                converted = v
-            converted_params.append(converted)
-        return converted_params
-    elif param_type == 'object':
-        if param_schema.get('properties'):
-            def cast_leaves(d, schema):
-                if type(d) is not dict:
-                    try:
-                        return make_type(d, schema['type'])
-                    except (ValueError, TypeError):
-                        return d
-                for k, v in d.items():
-                    if k in schema['properties']:
-                        d[k] = cast_leaves(v, schema['properties'][k])
-                return d
-
-            return cast_leaves(value, param_schema)
-        return value
-    else:
-        try:
-            return make_type(value, param_type)
-        except ValueError:
-            raise TypeValidationError(param_type, parameter_type, parameter_name)
-        except TypeError:
-            return value
 
 
 def validate_parameter_list(request_params, spec_params):
@@ -121,11 +52,25 @@ class RequestBodyValidator(object):
         self.validator = validatorClass(schema, format_checker=draft4_format_checker)
         self.api = api
         self.strict_validation = strict_validation
+        self._content_handlers = [
+            de(self.validator,
+               self.schema,
+               self.strict_validation,
+               self.is_null_value_valid) for de in DEFAULT_DESERIALIZERS
+        ]
 
-    def validate_formdata_parameter_list(self, request):
-        request_params = request.form.keys()
-        spec_params = self.schema.get('properties', {}).keys()
-        return validate_parameter_list(request_params, spec_params)
+    def register_content_handler(self, cv):
+        self._content_handlers += [cv]
+
+    def lookup_content_handler(self, request):
+        matches = [
+            v for v in self._content_handlers
+            if v.regex.match(request.content_type)
+        ]
+        if len(matches) > 1:
+            logger.warning("Content could be handled by multiple validators")
+        if matches:
+            return matches[0]
 
     def __call__(self, function):
         """
@@ -135,80 +80,28 @@ class RequestBodyValidator(object):
 
         @functools.wraps(function)
         def wrapper(request):
-            if all_json(self.consumes):
-                data = request.json
+            content_handler = self.lookup_content_handler(request)
+            exact_match = request.content_type in self.consumes
+            partial_match = content_handler and content_handler.name in self.consumes
+            if not (exact_match or partial_match):
+                raise UnsupportedMediaTypeProblem(
+                    "Invalid Content-type ({content_type}), expected JSON data".format(
+                        content_type=request.headers.get("Content-Type", "")
+                    ))
 
-                empty_body = not(request.body or request.form or request.files)
-                if data is None and not empty_body and not self.is_null_value_valid:
-                    try:
-                        ctype_is_json = is_json_mimetype(request.headers.get("Content-Type", ""))
-                    except ValueError:
-                        ctype_is_json = False
+            if content_handler:
+                error = content_handler.validate(request)
+                if error:
+                    return error
 
-                    if ctype_is_json:
-                        # Content-Type is json but actual body was not parsed
-                        raise BadRequestProblem(detail="Request body is not valid JSON")
-                    else:
-                        # the body has contents that were not parsed as JSON
-                        raise UnsupportedMediaTypeProblem(
-                                       "Invalid Content-type ({content_type}), expected JSON data".format(
-                                           content_type=request.headers.get("Content-Type", "")
-                                       ))
-
-                logger.debug("%s validating schema...", request.url)
-                if data is not None or not self.has_default:
-                    self.validate_schema(data, request.url)
-            elif self.consumes[0] in FORM_CONTENT_TYPES:
-                data = dict(request.form.items()) or (request.body if len(request.body) > 0 else {})
-                data.update(dict.fromkeys(request.files, ''))  # validator expects string..
-                logger.debug('%s validating schema...', request.url)
-
-                if self.strict_validation:
-                    formdata_errors = self.validate_formdata_parameter_list(request)
-                    if formdata_errors:
-                        raise ExtraParameterProblem(formdata_errors, [])
-
-                if data:
-                    props = self.schema.get("properties", {})
-                    errs = []
-                    for k, param_defn in props.items():
-                        if k in data:
-                            try:
-                                data[k] = coerce_type(param_defn, data[k], 'requestBody', k)
-                            except TypeValidationError as e:
-                                errs += [str(e)]
-                                print(errs)
-                    if errs:
-                        raise BadRequestProblem(detail=errs)
-
-                self.validate_schema(data, request.url)
+            elif self.strict_validation:
+                logger.warning("No handler for ({content_type})".format(
+                    content_type=request.content_type))
 
             response = function(request)
             return response
 
         return wrapper
-
-    def validate_schema(self, data, url):
-        # type: (dict, AnyStr) -> Union[ConnexionResponse, None]
-        if self.is_null_value_valid and is_null(data):
-            return None
-
-        try:
-            self.validator.validate(data)
-        except ValidationError as exception:
-            error_path = '.'.join(str(item) for item in exception.path)
-            error_path_msg = " - '{path}'".format(path=error_path) \
-                if error_path else ""
-            logger.error(
-                "{url} validation error: {error}{error_path_msg}".format(
-                    url=url, error=exception.message,
-                    error_path_msg=error_path_msg),
-                extra={'validator': 'body'})
-            raise BadRequestProblem(detail="{message}{error_path_msg}".format(
-                               message=exception.message,
-                               error_path_msg=error_path_msg))
-
-        return None
 
 
 class ResponseBodyValidator(object):

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -20,7 +20,10 @@ class ConnexionRequest(object):
         self.json_getter = json_getter
         self.files = files
         self.context = context if context is not None else {}
-        self.content_type = self.headers.get("Content-Type", "")
+
+    @property
+    def content_type(self):
+        return self.headers.get("Content-Type")
 
     @property
     def json(self):

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -1,4 +1,3 @@
-
 class ConnexionRequest(object):
     def __init__(self,
                  url,
@@ -21,6 +20,7 @@ class ConnexionRequest(object):
         self.json_getter = json_getter
         self.files = files
         self.context = context if context is not None else {}
+        self.content_type = self.headers.get("Content-Type", "")
 
     @property
     def json(self):

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -340,8 +340,29 @@ class AbstractOperation(SecureOperation):
 
     @property
     def function(self):
-        """
-        Operation function with decorators
+        """ Operation function with decorators
+
+        request comes in -> connexionrequest (framework generic)
+        API metrics recorded
+        API security applied
+
+        arrays are deserialized (spec dependent)
+         - query params
+         - form params
+         - path params
+
+        body is deserialized (spec dependent, content dependent)
+
+        validation is applied (spec dependent, content dependent)
+         - query params
+         - form params
+         - body params
+         - path params ?
+
+        parameter_to_arg (handler, what to call it)
+
+        json serializer is applied
+        response is validated if json
 
         :rtype: types.FunctionType
         """

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -272,7 +272,7 @@ class OpenAPIOperation(AbstractOperation):
             res = self._get_typed_body_values(body_arg, body_props, additional_props)
 
         if x_body_name in arguments or has_kwargs:
-            return {x_body_name: res}
+            return {x_body_name: body_arg}
         return {}
 
     def _get_typed_body_values(self, body_arg, body_props, additional_props):

--- a/connexion/serialization/deserializers.py
+++ b/connexion/serialization/deserializers.py
@@ -108,7 +108,7 @@ class FormDataContentHandler(ContentHandler):
             for k, param_defn in props.items():
                 if k in data:
                     data[k] = coerce_type(param_defn, data[k], 'requestBody', k)
-
+            request.form = data
         return data
 
 

--- a/connexion/serialization/deserializers.py
+++ b/connexion/serialization/deserializers.py
@@ -1,0 +1,123 @@
+import logging
+import re
+
+from jsonschema import ValidationError
+
+from ..exceptions import ExtraParameterProblem
+from ..problem import problem
+from ..types import coerce_type
+from ..utils import is_null
+
+logger = logging.getLogger('connexion.serialization.deserializers')
+
+
+class ContentHandler(object):
+
+    def __init__(self, validator, schema, strict, is_null_value_valid):
+        self.schema = schema
+        self.strict_validation = strict
+        self.is_null_value_valid = is_null_value_valid
+        self.validator = validator
+        self.has_default = schema.get('default', False)
+
+    def validate_schema(self, data, url):
+        # type: (dict, AnyStr) -> Union[ConnexionResponse, None]
+        if self.is_null_value_valid and is_null(data):
+            return None
+
+        try:
+            self.validator.validate(data)
+        except ValidationError as exception:
+            logger.error("{url} validation error: {error}".format(url=url,
+                                                                  error=exception.message),
+                         extra={'validator': 'body'})
+            return problem(400, 'Bad Request', str(exception.message))
+
+        return None
+
+    def _deser(self, request):
+        return request.body
+
+    def validate(self, request):
+        data = self._deser(request)
+        errors = self.validate_schema(data, request.url)
+        if errors and not self.has_default:
+            return errors
+
+
+class StreamingContentHandler(ContentHandler):
+    name = "application/octet-stream"
+    regex = re.compile(r'^application\/octet-stream.*')
+
+    def validate(self, request):
+        # Don't validate, leave stream for user to read
+        pass
+
+
+class JSONContentHandler(ContentHandler):
+    name = "application/json"
+    regex = re.compile(r'^application\/json.*|^.*\+json$')
+
+    def _deser(self, request):
+        data = request.json
+        empty_body = not(request.body or request.form or request.files)
+        if data is None and not empty_body and not self.is_null_value_valid:
+            # Content-Type is json but actual body was not parsed
+            return problem(400,
+                           "Bad Request",
+                           "Request body is not valid JSON"
+                           )
+        return data
+
+
+def validate_parameter_list(request_params, spec_params):
+    request_params = set(request_params)
+    spec_params = set(spec_params)
+
+    return request_params.difference(spec_params)
+
+
+class FormDataContentHandler(ContentHandler):
+    name = "application/x-www-form-urlencoded"
+    regex = re.compile(
+        r'^application\/x-www-form-urlencoded.*'
+    )
+
+    def validate_formdata_parameter_list(self, request):
+        request_params = request.form.keys()
+        spec_params = self.schema.get('properties', {}).keys()
+        return validate_parameter_list(request_params, spec_params)
+
+    def _deser(self, request):
+        data = dict(request.form.items()) or \
+                   (request.body if len(request.body) > 0 else {})
+        data.update(dict.fromkeys(request.files, ''))  # validator expects string..
+        logger.debug('%s validating schema...', request.url)
+
+        if self.strict_validation:
+            formdata_errors = self.validate_formdata_parameter_list(request)
+            if formdata_errors:
+                raise ExtraParameterProblem(formdata_errors, [])
+
+        if data:
+            props = self.schema.get("properties", {})
+            for k, param_defn in props.items():
+                if k in data:
+                    data[k] = coerce_type(param_defn, data[k], 'requestBody', k)
+
+        return data
+
+
+class MultiPartFormDataContentHandler(FormDataContentHandler):
+    name = "multipart/form-data"
+    regex = re.compile(
+        r'^multipart\/form-data.*'
+    )
+
+
+DEFAULT_DESERIALIZERS = [
+    StreamingContentHandler,
+    JSONContentHandler,
+    FormDataContentHandler,
+    MultiPartFormDataContentHandler
+]

--- a/connexion/types.py
+++ b/connexion/types.py
@@ -1,0 +1,71 @@
+from .utils import boolean, is_null, is_nullable
+
+TYPE_MAP = {
+    'integer': int,
+    'number': float,
+    'boolean': boolean
+}
+
+
+class TypeValidationError(Exception):
+    def __init__(self, schema_type, parameter_type, parameter_name):
+        """
+        Exception raise when type validation fails
+
+        :type schema_type: str
+        :type parameter_type: str
+        :type parameter_name: str
+        :return:
+        """
+        self.schema_type = schema_type
+        self.parameter_type = parameter_type
+        self.parameter_name = parameter_name
+
+    def __str__(self):
+        msg = "Wrong type, expected '{schema_type}' for {parameter_type} parameter '{parameter_name}'"
+        return msg.format(**vars(self))
+
+
+def coerce_type(param, value, parameter_type, parameter_name=None):
+
+    def make_type(value, type_literal):
+        type_func = TYPE_MAP.get(type_literal)
+        return type_func(value)
+
+    param_schema = param.get("schema", param)
+    if is_nullable(param_schema) and is_null(value):
+        return None
+
+    param_type = param_schema.get('type')
+    parameter_name = parameter_name if parameter_name else param.get('name')
+    if param_type == "array":
+        converted_params = []
+        for v in value:
+            try:
+                converted = make_type(v, param_schema["items"]["type"])
+            except (ValueError, TypeError):
+                converted = v
+            converted_params.append(converted)
+        return converted_params
+    elif param_type == 'object':
+        if param_schema.get('properties'):
+            def cast_leaves(d, schema):
+                if type(d) is not dict:
+                    try:
+                        return make_type(d, schema['type'])
+                    except (ValueError, TypeError):
+                        return d
+                for k, v in d.items():
+                    if k in schema['properties']:
+                        d[k] = cast_leaves(v, schema['properties'][k])
+                return d
+
+            return cast_leaves(value, param_schema)
+        return value
+    else:
+        try:
+            return make_type(value, param_type)
+        except ValueError:
+            raise TypeValidationError(param_type, parameter_type, parameter_name)
+        except TypeError:
+            return value

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -118,7 +118,7 @@ def is_form_mimetype(mimetype):
     try:
         mimetype = mimetype.split(";")[0]
         maintype, subtype = mimetype.split('/')  # type: str, str
-    except ValueError:
+    except (ValueError, AttributeError):
         return False
 
     multipart = maintype == 'multipart' and subtype.startswith("form-data")
@@ -133,7 +133,7 @@ def is_json_mimetype(mimetype):
     """
     try:
         maintype, subtype = mimetype.split('/')  # type: str, str
-    except ValueError:
+    except (ValueError, AttributeError):
         return False
     return maintype == 'application' and (subtype == 'json' or subtype.endswith('+json'))
 

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -114,12 +114,27 @@ def get_function_from_name(function_name):
     return function
 
 
+def is_form_mimetype(mimetype):
+    try:
+        mimetype = mimetype.split(";")[0]
+        maintype, subtype = mimetype.split('/')  # type: str, str
+    except ValueError:
+        return False
+
+    multipart = maintype == 'multipart' and subtype.startswith("form-data")
+    urlenc = maintype == 'application' and subtype.startswith("x-www-form-urlencoded")
+    return multipart or urlenc
+
+
 def is_json_mimetype(mimetype):
     """
     :type mimetype: str
     :rtype: bool
     """
-    maintype, subtype = mimetype.split('/')  # type: str, str
+    try:
+        maintype, subtype = mimetype.split('/')  # type: str, str
+    except ValueError:
+        return False
     return maintype == 'application' and (subtype == 'json' or subtype.endswith('+json'))
 
 

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -301,7 +301,7 @@ def test_get_users(aiohttp_client, aiohttp_app):
 def test_create_user(aiohttp_client, aiohttp_app):
     app_client = yield from aiohttp_client(aiohttp_app.app)
     user = {'name': 'Maksim'}
-    resp = yield from app_client.post('/v1.0/users', json=user, headers={'Content-type': 'application/json'})
+    resp = yield from app_client.post('/v1.0/users', json=user)
     assert resp.status == 201
 
 

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -159,9 +159,11 @@ def test_falsy_param(simple_app):
 
 
 def test_formdata_param(simple_app):
+    headers = {'Content-Type': 'multipart/form-data'}
     app_client = simple_app.app.test_client()
     resp = app_client.post('/v1.0/test-formData-param',
-                           data={'formData': 'test'})
+                           data={'formData': 'test'},
+                           headers=headers)
     assert resp.status_code == 200
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 'test'
@@ -169,7 +171,8 @@ def test_formdata_param(simple_app):
 
 def test_formdata_bad_request(simple_app):
     app_client = simple_app.app.test_client()
-    resp = app_client.post('/v1.0/test-formData-param')
+    headers = {'Content-Type': 'multipart/form-data'}
+    resp = app_client.post('/v1.0/test-formData-param', headers=headers)
     assert resp.status_code == 400
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] in [
@@ -187,17 +190,21 @@ def test_formdata_missing_param(simple_app):
 
 def test_formdata_extra_param(simple_app):
     app_client = simple_app.app.test_client()
+    headers = {'content-type': 'multipart/form-data'}
     resp = app_client.post('/v1.0/test-formData-param',
                            data={'formData': 'test',
-                                 'extra_formData': 'test'})
+                                 'extra_formData': 'test'},
+                           headers=headers)
     assert resp.status_code == 200
 
 
 def test_strict_formdata_extra_param(strict_app):
     app_client = strict_app.app.test_client()
+    headers = {'content-type': 'multipart/form-data'}
     resp = app_client.post('/v1.0/test-formData-param',
                            data={'formData': 'test',
-                                 'extra_formData': 'test'})
+                                 'extra_formData': 'test'},
+                           headers=headers)
     assert resp.status_code == 400
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] == "Extra formData parameter(s) extra_formData not in spec"
@@ -225,7 +232,8 @@ def test_formdata_multiple_file_upload(simple_app):
 
 def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.app.test_client()
-    resp = app_client.post('/v1.0/test-formData-file-upload')
+    headers = {'Content-Type': 'multipart/form-data'}
+    resp = app_client.post('/v1.0/test-formData-file-upload', headers=headers)
     assert resp.status_code == 400
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['detail'] in [
@@ -367,19 +375,21 @@ def test_args_kwargs(simple_app):
 
 def test_param_sanitization(simple_app):
     app_client = simple_app.app.test_client()
-    resp = app_client.post('/v1.0/param-sanitization')
+    headers = {'content-type': 'multipart/form-data'}
+    resp = app_client.post('/v1.0/param-sanitization', headers=headers)
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8', 'replace')) == {}
 
+    headers = {'content-type': 'application/x-www-form-urlencoded'}
     resp = app_client.post('/v1.0/param-sanitization?$query=queryString',
-            data={'$form': 'formString'})
+                           data={'$form': 'formString'}, headers=headers)
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8', 'replace')) == {
             'query': 'queryString',
             'form': 'formString',
             }
 
-    body = { 'body1': 'bodyString', 'body2': 'otherString' }
+    body = {'body1': 'bodyString', 'body2': 'otherString'}
     resp = app_client.post(
         '/v1.0/body-sanitization',
         data=json.dumps(body),

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -354,10 +354,10 @@ def test_nullable_parameter(simple_app):
     resp = app_client.get('/v1.0/nullable-parameters?time_start=None')
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
-    #time_start = 1010
-    #resp = app_client.get(
-    #    '/v1.0/nullable-parameters?time_start={}'.format(time_start))
-    #assert json.loads(resp.data.decode('utf-8', 'replace')) == time_start
+    time_start = 1010
+    resp = app_client.get(
+        '/v1.0/nullable-parameters?time_start={}'.format(time_start))
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == time_start
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'None'})
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -285,6 +285,17 @@ def test_bool_param(simple_app):
     assert response is False
 
 
+def test_empty_object_body(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.post(
+        '/v1.0/test-empty-object-body',
+        data=json.dumps({}),
+        headers={'Content-Type': 'application/json'})
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
+    assert response['stack'] == {}
+
+
 def test_bool_array_param(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/test-bool-array-param?thruthiness=true,true,true')
@@ -343,10 +354,10 @@ def test_nullable_parameter(simple_app):
     resp = app_client.get('/v1.0/nullable-parameters?time_start=None')
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'
 
-    time_start = 1010
-    resp = app_client.get(
-        '/v1.0/nullable-parameters?time_start={}'.format(time_start))
-    assert json.loads(resp.data.decode('utf-8', 'replace')) == time_start
+    #time_start = 1010
+    #resp = app_client.get(
+    #    '/v1.0/nullable-parameters?time_start={}'.format(time_start))
+    #assert json.loads(resp.data.decode('utf-8', 'replace')) == time_start
 
     resp = app_client.post('/v1.0/nullable-parameters', data={"post_param": 'None'})
     assert json.loads(resp.data.decode('utf-8', 'replace')) == 'it was None'

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -158,12 +158,13 @@ def test_redirect_response_endpoint(simple_app):
 
 def test_default_object_body(simple_app):
     app_client = simple_app.app.test_client()
-    resp = app_client.post('/v1.0/test-default-object-body')
+    headers = {'content-type': 'application/json'}
+    resp = app_client.post('/v1.0/test-default-object-body', headers=headers)
     assert resp.status_code == 200
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['stack'] == {'image_version': 'default_image'}
 
-    resp = app_client.post('/v1.0/test-default-integer-body')
+    resp = app_client.post('/v1.0/test-default-integer-body', headers=headers)
     assert resp.status_code == 200
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response == 1
@@ -238,8 +239,8 @@ def test_bad_operations(bad_operations_app):
 
 def test_text_request(simple_app):
     app_client = simple_app.app.test_client()
-
-    resp = app_client.post('/v1.0/text-request', data='text')
+    headers = {'content-type': 'text/plain'}
+    resp = app_client.post('/v1.0/text-request', data='text', headers=headers)
     assert resp.status_code == 200
 
 

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -34,6 +34,10 @@ def post():
     return ''
 
 
+def test_empty_object_body(stack):
+    return {"stack": stack}
+
+
 def post_greeting(name, **kwargs):
     data = {'greeting': 'Hello {name}'.format(name=name)}
     return data

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -770,6 +770,19 @@ paths:
                 type: array
                 items:
                   type: string
+  /test-empty-object-body:
+    post:
+      summary: Test if empty object body param is passed to handler.
+      operationId: fakeapi.hello.test_empty_object_body
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: stack
+              type: object
   /nullable-parameters:
     post:
       operationId: fakeapi.hello.test_nullable_param_post3

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -540,7 +540,7 @@ paths:
           description: OK
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          multipart/form-data:
             schema:
               type: object
               properties:
@@ -904,6 +904,20 @@ paths:
                 type: object
       requestBody:
         content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                'form$':
+                  description: Just a testing parameter in the form data
+                  type: string
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                'form$':
+                  description: Just a testing parameter in the form data
+                  type: string
           multipart/form-data:
             schema:
               type: object

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -63,7 +63,18 @@ paths:
           description: Name of the person to greet.
           required: true
           type: string
-
+  /test-empty-object-body:
+    post:
+      summary: Test if empty object body param is passed to handler.
+      operationId: fakeapi.hello.test_empty_object_body
+      parameters:
+        - name: stack
+          in: body
+          schema:
+            type: object
+      responses:
+        200:
+          description: OK
   /bye/{name}:
     get:
       summary: Generate goodbye


### PR DESCRIPTION
This is a WIP, I'd like to make this a bit more pluggable, so that it is straightforward to add content-type validation handlers.

Related to #655 #755 

Changes proposed in this pull request:
 - remove `all_json` requirement that caused any non-json content types to preclude validating json
