### PR TITLE
Fix: not handling file parameters properly

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -144,7 +144,7 @@ class RequestBodyValidator(object):
                     return error
             elif self.consumes[0] in FORM_CONTENT_TYPES:
                 data = dict(request.form.items()) or (request.body if len(request.body) > 0 else {})
-                data.update(dict.fromkeys(request.files, ''))  # validator expects string..
+                data.update({k: "" for k, v in request.files.items() if v})
                 logger.debug('%s validating schema...', request.url)
 
                 if self.strict_validation:

--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -54,6 +54,9 @@ def validate_type(validator, types, instance, schema):
     if instance is None and (schema.get('x-nullable') is True or schema.get('nullable')):
         return
 
+    if types == "file":
+        types = "string"
+
     types = _utils.ensure_list(types)
 
     if not any(validator.is_type(instance, type) for type in types):


### PR DESCRIPTION
Connexion is not handling properly parameters of type "file" in multipart/form routes.

I attach a simple application to test the bug:
[testing_connexion.zip](https://github.com/zalando/connexion/files/3439265/testing_connexion.zip)

The bug is reproducible with the current master branch both on win and unix on a python 3.7 environment.

It was not easy to figure out what was the problem and I am not sure this is the best way of fixing it.