### PR TITLE
WIP Harmonize serialization between aiohttp and flask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ htmlcov/
 *.swp
 .tox/
 .idea/
+.vscode/
 venv/
+src/

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -420,7 +420,9 @@ class AbstractAPI(object):
     def _serialize_data(cls, data, mimetype):
         # TODO: Harmonize with flask_api. Currently this is the backwards compatible with aiohttp_api._cast_body.
         if not isinstance(data, bytes):
-            if isinstance(mimetype, str) and is_json_mimetype(mimetype):
+            # assume mimetype is json if mimetype is None and it looks like json
+            if (mimetype is None and isinstance(data, (dict, list, tuple))) \
+                    or (isinstance(mimetype, str) and is_json_mimetype(mimetype)):
                 body = cls.jsonifier.dumps(data)
             elif isinstance(data, str):
                 body = data

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -401,7 +401,7 @@ class AbstractAPI(object):
             status_code = status_code.value
 
         if data is not None:
-            body = cls._jsonify_data(data, mimetype)
+            body, mimetype = cls._serialize_data(data, mimetype)
         else:
             body = data
 
@@ -414,10 +414,11 @@ class AbstractAPI(object):
                          **extra_context
                      })
 
-        return body, status_code
+        return body, status_code, mimetype
 
     @classmethod
-    def _jsonify_data(cls, data, mimetype):
+    def _serialize_data(cls, data, mimetype):
+        # TODO: Harmonize with flask_api. Currently this is the backwards compatible with aiohttp_api._cast_body.
         if not isinstance(data, bytes):
             if isinstance(mimetype, str) and is_json_mimetype(mimetype):
                 body = cls.jsonifier.dumps(data)
@@ -427,7 +428,7 @@ class AbstractAPI(object):
                 body = str(data)
         else:
             body = data
-        return body
+        return body, mimetype
 
     def json_loads(self, data):
         return self.jsonifier.loads(data)

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -326,7 +326,7 @@ class AbstractAPI(object):
         if isinstance(response, ConnexionResponse):
             # If body in ConnexionResponse is not byte, it may not pass schema validation.
             # In this case, rebuild response with aiohttp to have consistency
-            if response.body is None or isinstance(response.body, six.binary_type):
+            if response.body is None or isinstance(response.body, bytes):
                 return response
             else:
                 response = cls._build_response(
@@ -395,10 +395,10 @@ class AbstractAPI(object):
 
     @classmethod
     def _jsonify_data(cls, data, mimetype):
-        if not isinstance(data, six.binary_type):
-            if isinstance(mimetype, six.string_types) and is_json_mimetype(mimetype):
+        if not isinstance(data, bytes):
+            if isinstance(mimetype, str) and is_json_mimetype(mimetype):
                 body = cls.jsonifier.dumps(data)
-            elif isinstance(data, six.text_type):
+            elif isinstance(data, str):
                 body = data
             else:
                 body = str(data)

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -312,6 +312,9 @@ class AbstractAPI(object):
 
         if isinstance(response, tuple):
             len_response = len(response)
+            if len_response == 1:
+                data, = response
+                return cls._build_response(mimetype=mimetype, data=data, extra_context=extra_context)
             if len_response == 2:
                 if isinstance(response[1], (int, Enum)):
                     data, status_code = response

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -238,7 +238,9 @@ class AbstractAPI(object):
     @abc.abstractmethod
     def get_response(self, response, mimetype=None, request=None):
         """
-        This method converts the ConnexionResponse to a user framework response.
+        This method converts a handler response to a framework response.
+        The response can be a ConnexionResponse, an operation handler, a framework response or a tuple.
+        Other type than ConnexionResponse are handled by `cls._response_from_handler`
         :param response: A response to cast.
         :param mimetype: The response mimetype.
         :param request: The request associated with this response (the user framework request).
@@ -249,10 +251,31 @@ class AbstractAPI(object):
 
     @classmethod
     @abc.abstractmethod
+    def _response_from_handler(cls, response, mimetype):
+        """
+        Create a framework response from the operation handler data.
+        An operation handler can return:
+        - a framework response
+        - a body (str / binary / dict / list), a response will be created
+            with a status code 200 by default and empty headers.
+        - a tuple of (body: str, status_code: int)
+        - a tuple of (body: str, status_code: int, headers: dict)
+        :param response: A response from an operation handler.
+        :type response Union[Response, str, Tuple[str, int], Tuple[str, int, dict]]
+        :param mimetype: The response mimetype.
+        :type mimetype: str
+        :return A framwork response.
+        :rtype Response
+        """
+
+    @classmethod
+    @abc.abstractmethod
     def get_connexion_response(cls, response, mimetype=None):
         """
         This method converts the user framework response to a ConnexionResponse.
+        It is used after the user returned a response to give it to response validators.
         :param response: A response to cast.
+        :param mimetype: The response mimetype.
         """
 
     def json_loads(self, data):

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -245,12 +245,10 @@ class AbstractAPI(object):
         This method converts a handler response to a framework response.
         This method should just retrieve response from handler then call `cls._get_response`.
         It is mainly here to handle AioHttp async handler.
-        :param response: A response to cast.
+        :param response: A response to cast (tuple, framework response, etc).
         :param mimetype: The response mimetype.
+        :type mimetype: Union[None, str]
         :param request: The request associated with this response (the user framework request).
-
-        :type response: Framework Response
-        :type mimetype: str
         """
 
     @classmethod
@@ -259,12 +257,11 @@ class AbstractAPI(object):
         This method converts a handler response to a framework response.
         The response can be a ConnexionResponse, an operation handler, a framework response or a tuple.
         Other type than ConnexionResponse are handled by `cls._response_from_handler`
-        :param response: A response to cast.
+        :param response: A response to cast (tuple, framework response, etc).
         :param mimetype: The response mimetype.
+        :type mimetype: Union[None, str]
         :param extra_context: dict of extra details, like url, to include in logs
-
-        :type response: Framework Response
-        :type mimetype: str
+        :type extra_context: Union[None, dict]
         """
         if extra_context is None:
             extra_context = {}
@@ -299,7 +296,7 @@ class AbstractAPI(object):
         - a tuple of (body: str, status_code: int)
         - a tuple of (body: str, status_code: int, headers: dict)
         :param response: A response from an operation handler.
-        :type response Union[Response, str, Tuple[str, int], Tuple[str, int, dict]]
+        :type response Union[Response, str, Tuple[str,], Tuple[str, int], Tuple[str, int, dict]]
         :param mimetype: The response mimetype.
         :type mimetype: str
         :param extra_context: dict of extra details, like url, to include in logs

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -440,14 +440,14 @@ class AbstractAPI(object):
                 body = cls.jsonifier.dumps(data)
             elif isinstance(data, str):
                 body = data
-            elif mimetype is None:
+            elif mimetype in [None, "text/plain"]:
                 try:
                     # try as json by default
                     body = cls.jsonifier.dumps(data)
                 except TypeError:
                     # or let objects self-serialize
                     body = str(data)
-                    logger.debug('_serialize_data mimetype=None and str()')
+                    logger.debug('_serialize_data mimetype={} and jsonify failed and str()'.format(mimetype))
                 else:
                     mimetype = DEFAULT_MIMETYPE
             else:

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -447,9 +447,11 @@ class AbstractAPI(object):
                 except TypeError:
                     # or let objects self-serialize
                     body = str(data)
+                    logger.debug('_serialize_data mimetype=None and str()')
                 else:
                     mimetype = DEFAULT_MIMETYPE
             else:
+                logger.debug('_serialize_data mimetype={} and str()'.format(mimetype))
                 body = str(data)
         else:
             body = data

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -2,9 +2,9 @@ import abc
 import logging
 import pathlib
 import sys
+from enum import Enum
 
 import six
-from enum import Enum
 
 from ..decorators.produces import NoContent
 from ..exceptions import ResolverError

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -346,7 +346,7 @@ class AioHttpApi(AbstractAPI):
         if cls._is_framework_response(data):
             raise TypeError("Cannot return web.StreamResponse in tuple. Only raw data can be returned in tuple.")
 
-        data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code, extra_context=extra_context)
+        data, status_code, serialized_mimetype = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code, extra_context=extra_context)
 
         if isinstance(data, str):
             text = data
@@ -355,7 +355,7 @@ class AioHttpApi(AbstractAPI):
             text = None
             body = data
 
-        content_type = content_type or mimetype
+        content_type = content_type or mimetype or serialized_mimetype
         return web.Response(body=body, text=text, headers=headers, status=status_code, content_type=content_type)
 
     @classmethod

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -310,13 +310,7 @@ class AioHttpApi(AbstractAPI):
 
         url = str(request.url) if request else ''
 
-        response = cls._get_response(response, mimetype=mimetype, url=url)
-
-        # TODO: I let this log here for full compatibility. But if we can modify it, it can go to _get_response()
-        logger.debug('Got stream response with status code (%d)',
-                     response.status, extra={'url': url})
-
-        return response
+        return cls._get_response(response, mimetype=mimetype, extra_context={"url": url})
 
     @classmethod
     def _is_framework_response(cls, response):
@@ -335,22 +329,23 @@ class AioHttpApi(AbstractAPI):
         )
 
     @classmethod
-    def _connexion_to_framework_response(cls, response, mimetype):
+    def _connexion_to_framework_response(cls, response, mimetype, extra_context=None):
         """ Cast ConnexionResponse to framework response class """
         return cls._build_response(
             mimetype=response.mimetype or mimetype,
             status_code=response.status_code,
             content_type=response.content_type,
             headers=response.headers,
-            data=response.body
+            data=response.body,
+            extra_context=extra_context,
         )
 
     @classmethod
-    def _build_response(cls, data, mimetype, content_type=None, headers=None, status_code=None):
+    def _build_response(cls, data, mimetype, content_type=None, headers=None, status_code=None, extra_context=None):
         if isinstance(data, web.StreamResponse):
             raise TypeError("Cannot return web.StreamResponse in tuple. Only raw data can be returned in tuple.")
 
-        data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code)
+        data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code, extra_context=extra_context)
 
         if isinstance(data, str):
             text = data

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -303,6 +303,7 @@ class AioHttpApi(AbstractAPI):
         """Get response.
         This method is used in the lifecycle decorators
 
+        :type response: aiohttp.web.StreamResponse | (Any,) | (Any, int) | (Any, dict) | (Any, int, dict)
         :rtype: aiohttp.web.Response
         """
         while asyncio.iscoroutine(response):

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -342,7 +342,7 @@ class AioHttpApi(AbstractAPI):
 
     @classmethod
     def _build_response(cls, data, mimetype, content_type=None, headers=None, status_code=None, extra_context=None):
-        if isinstance(data, web.StreamResponse):
+        if cls._is_framework_response(data):
             raise TypeError("Cannot return web.StreamResponse in tuple. Only raw data can be returned in tuple.")
 
         data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code, extra_context=extra_context)

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -17,7 +17,7 @@ from connexion.handlers import AuthErrorHandler
 from connexion.jsonifier import JSONEncoder, Jsonifier
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
 from connexion.problem import problem
-from connexion.utils import is_json_mimetype, yamldumper
+from connexion.utils import yamldumper
 from werkzeug.exceptions import HTTPException as werkzeug_HTTPException
 
 

--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -319,7 +319,7 @@ class AioHttpApi(AbstractAPI):
         if isinstance(response, ConnexionResponse):
             response = cls._get_aiohttp_response_from_connexion(response, mimetype)
         else:
-            response = cls._get_aiohttp_response(response, mimetype)
+            response = cls._response_from_handler(response, mimetype)
 
         logger.debug('Got stream response with status code (%d)',
                      response.status, extra={'url': url})
@@ -337,7 +337,7 @@ class AioHttpApi(AbstractAPI):
                 response = cls._get_aiohttp_response_from_connexion(response, mimetype)
 
         if not isinstance(response, web.StreamResponse):
-            response = cls._get_aiohttp_response(response, mimetype)
+            response = cls._response_from_handler(response, mimetype)
 
         return ConnexionResponse(
             status_code=response.status,
@@ -359,9 +359,11 @@ class AioHttpApi(AbstractAPI):
         )
 
     @classmethod
-    def _get_aiohttp_response(cls, response, mimetype):
+    def _response_from_handler(cls, response, mimetype):
         if isinstance(response, web.StreamResponse):
             return response
+        elif isinstance(response, tuple) and isinstance(response[0], web.StreamResponse):
+            raise RuntimeError("Cannot return web.StreamResponse in tuple. Only raw data can be returned in tuple.")
 
         elif isinstance(response, tuple) and len(response) == 3:
             data, status_code, headers = response

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -169,7 +169,7 @@ class FlaskApi(AbstractAPI):
 
     @classmethod
     def _build_response(cls, mimetype, content_type=None, headers=None, status_code=None, data=None, extra_context=None):
-        if flask_utils.is_flask_response(data):
+        if cls._is_framework_response(data):
             return flask.current_app.make_response((data, status_code, headers))
 
         data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code, extra_context=extra_context)

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -185,16 +185,6 @@ class FlaskApi(AbstractAPI):
         return flask.current_app.response_class(**kwargs)  # type: flask.Response
 
     @classmethod
-    def _serialize_data(cls, data, mimetype):
-        # TODO: harmonize flask and aiohttp serialization when mimetype=None or mimetype is not JSON
-        #       (cases where it might not make sense to jsonify the data)
-        if (isinstance(mimetype, str) and is_json_mimetype(mimetype)) \
-                or not (isinstance(data, bytes) or isinstance(data, str)):
-            return cls.jsonifier.dumps(data), mimetype
-
-        return data, mimetype
-
-    @classmethod
     def get_request(cls, *args, **params):
         # type: (*Any, **Any) -> ConnexionRequest
         """Gets ConnexionRequest instance for the operation handler

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -132,7 +132,7 @@ class FlaskApi(AbstractAPI):
         If the returned object is a flask.Response then it will just
         pass the information needed to recreate it.
 
-        :type operation_handler_result: flask.Response | (flask.Response, int) | (flask.Response, int, dict)
+        :type response: flask.Response | (flask.Response,) | (flask.Response, int) | (flask.Response, dict) | (flask.Response, int, dict)
         :rtype: ConnexionResponse
         """
         return cls._get_response(response, mimetype=mimetype, extra_context={"url": flask.request.url})

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -146,7 +146,7 @@ class FlaskApi(AbstractAPI):
         if isinstance(response, ConnexionResponse):
             flask_response = cls._get_flask_response_from_connexion(response, mimetype)
         else:
-            flask_response = cls._get_flask_response(response, mimetype)
+            flask_response = cls._response_from_handler(response, mimetype)
 
         logger.debug('Got data and status code (%d)',
                      flask_response.status_code,
@@ -207,7 +207,7 @@ class FlaskApi(AbstractAPI):
         return data
 
     @classmethod
-    def _get_flask_response(cls, response, mimetype):
+    def _response_from_handler(cls, response, mimetype):
         if flask_utils.is_flask_response(response):
             return response
 

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -5,7 +5,6 @@ import six
 import werkzeug.exceptions
 from connexion.apis import flask_utils
 from connexion.apis.abstract import AbstractAPI
-from connexion.decorators.produces import NoContent
 from connexion.handlers import AuthErrorHandler
 from connexion.jsonifier import Jsonifier
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
@@ -54,9 +53,9 @@ class FlaskApi(AbstractAPI):
         self.blueprint.add_url_rule(
             openapi_spec_path_yaml,
             endpoint_name,
-            lambda: FlaskApi._build_flask_response(
+            lambda: FlaskApi._build_response(
                 status_code=200,
-                content_type="text/yaml",
+                mimetype="text/yaml",
                 data=yamldumper(self.specification.raw)
             )
         )
@@ -136,105 +135,26 @@ class FlaskApi(AbstractAPI):
         :type operation_handler_result: flask.Response | (flask.Response, int) | (flask.Response, int, dict)
         :rtype: ConnexionResponse
         """
-        logger.debug('Getting data and status code',
-                     extra={
-                         'data': response,
-                         'data_type': type(response),
-                         'url': flask.request.url
-                     })
+        flask_response = cls._get_response(response, mimetype=mimetype, url=flask.request.url)
 
-        if isinstance(response, ConnexionResponse):
-            flask_response = cls._get_flask_response_from_connexion(response, mimetype)
-        else:
-            flask_response = cls._response_from_handler(response, mimetype)
-
+        # TODO: I let this log here for full compatibility. But if we can modify it, it can go to _get_response()
         logger.debug('Got data and status code (%d)',
                      flask_response.status_code,
                      extra={
                          'data': response,
-                         'datatype': type(response),
                          'url': flask.request.url
                      })
 
         return flask_response
 
     @classmethod
-    def _get_flask_response_from_connexion(cls, response, mimetype):
-        data = response.body
-        status_code = response.status_code
-        mimetype = response.mimetype or mimetype
-        content_type = response.content_type or mimetype
-        headers = response.headers
-
-        flask_response = cls._build_flask_response(mimetype, content_type,
-                                                   headers, status_code, data)
-
-        return flask_response
+    def _is_framework_response(cls, response):
+        """ Return True if provided response is a framework type """
+        return flask_utils.is_flask_response(response)
 
     @classmethod
-    def _build_flask_response(cls, mimetype=None, content_type=None,
-                              headers=None, status_code=None, data=None):
-        kwargs = {
-            'mimetype': mimetype,
-            'content_type': content_type,
-            'headers': headers
-        }
-        kwargs = {k: v for k, v in six.iteritems(kwargs) if v is not None}
-        flask_response = flask.current_app.response_class(**kwargs)  # type: flask.Response
-
-        if status_code is not None:
-            # If we got an enum instead of an int, extract the value.
-            if hasattr(status_code, "value"):
-                status_code = status_code.value
-
-            flask_response.status_code = status_code
-
-        if data is not None and data is not NoContent:
-            data = cls._jsonify_data(data, mimetype)
-            flask_response.set_data(data)
-
-        elif data is NoContent:
-            flask_response.set_data('')
-
-        return flask_response
-
-    @classmethod
-    def _jsonify_data(cls, data, mimetype):
-        if (isinstance(mimetype, six.string_types) and is_json_mimetype(mimetype)) \
-                or not (isinstance(data, six.binary_type) or isinstance(data, six.text_type)):
-            return cls.jsonifier.dumps(data)
-
-        return data
-
-    @classmethod
-    def _response_from_handler(cls, response, mimetype):
-        if flask_utils.is_flask_response(response):
-            return response
-
-        elif isinstance(response, tuple) and flask_utils.is_flask_response(response[0]):
-            return flask.current_app.make_response(response)
-
-        elif isinstance(response, tuple) and len(response) == 3:
-            data, status_code, headers = response
-            return cls._build_flask_response(mimetype, None,
-                                             headers, status_code, data)
-
-        elif isinstance(response, tuple) and len(response) == 2:
-            data, status_code = response
-            return cls._build_flask_response(mimetype, None, None,
-                                             status_code, data)
-
-        else:
-            return cls._build_flask_response(mimetype=mimetype, data=response)
-
-    @classmethod
-    def get_connexion_response(cls, response, mimetype=None):
-        if isinstance(response, ConnexionResponse):
-            return response
-
-        if not isinstance(response, flask.current_app.response_class):
-            response = cls.get_response(response, mimetype)
-
+    def _framework_to_connexion_response(cls, response, mimetype):
+        """ Cast framework response class to ConnexionResponse used for schema validation """
         return ConnexionResponse(
             status_code=response.status_code,
             mimetype=response.mimetype,
@@ -242,6 +162,45 @@ class FlaskApi(AbstractAPI):
             headers=response.headers,
             body=response.get_data(),
         )
+
+    @classmethod
+    def _connexion_to_framework_response(cls, response, mimetype):
+        """ Cast ConnexionResponse to framework response class """
+        flask_response = cls._build_response(
+            mimetype=response.mimetype or mimetype,
+            content_type=response.content_type,
+            headers=response.headers,
+            status_code=response.status_code,
+            data=response.body
+            )
+
+        return flask_response
+
+    @classmethod
+    def _build_response(cls, mimetype, content_type=None, headers=None, status_code=None, data=None):
+        if flask_utils.is_flask_response(data):
+            return flask.current_app.make_response((data, status_code, headers))
+
+        data, status_code = cls._prepare_body_and_status_code(data=data, mimetype=mimetype, status_code=status_code)
+
+        kwargs = {
+            'mimetype': mimetype,
+            'content_type': content_type,
+            'headers': headers,
+            'response': data,
+            'status': status_code
+        }
+        kwargs = {k: v for k, v in six.iteritems(kwargs) if v is not None}
+        return flask.current_app.response_class(**kwargs)  # type: flask.Response
+
+    @classmethod
+    def _jsonify_data(cls, data, mimetype):
+        # TODO: to discuss: Using jsonifier for all type of data, even when mimetype is not json is strange. Why ?
+        if (isinstance(mimetype, six.string_types) and is_json_mimetype(mimetype)) \
+                or not (isinstance(data, six.binary_type) or isinstance(data, six.text_type)):
+            return cls.jsonifier.dumps(data)
+
+        return data
 
     @classmethod
     def get_request(cls, *args, **params):

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -196,8 +196,8 @@ class FlaskApi(AbstractAPI):
     @classmethod
     def _jsonify_data(cls, data, mimetype):
         # TODO: to discuss: Using jsonifier for all type of data, even when mimetype is not json is strange. Why ?
-        if (isinstance(mimetype, six.string_types) and is_json_mimetype(mimetype)) \
-                or not (isinstance(data, six.binary_type) or isinstance(data, six.text_type)):
+        if (isinstance(mimetype, str) and is_json_mimetype(mimetype)) \
+                or not (isinstance(data, bytes) or isinstance(data, str)):
             return cls.jsonifier.dumps(data)
 
         return data

--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -12,7 +12,8 @@ NoContent = object()
 
 
 class BaseSerializer(BaseDecorator):
-    def __init__(self, mimetype='text/plain'):
+    #def __init__(self, mimetype='text/plain'):
+    def __init__(self, mimetype='application/json'):
         """
         :type mimetype: str
         """

--- a/connexion/jsonifier.py
+++ b/connexion/jsonifier.py
@@ -49,11 +49,11 @@ class Jsonifier(object):
         """ Central point where JSON deserialization happens inside
         Connexion.
         """
-        if isinstance(data, six.binary_type):
+        if isinstance(data, bytes):
             data = data.decode()
 
         try:
             return self.json.loads(data)
         except Exception:
-            if isinstance(data, six.string_types):
+            if isinstance(data, str):
                 return data

--- a/connexion/operations/__init__.py
+++ b/connexion/operations/__init__.py
@@ -2,6 +2,7 @@ from .abstract import AbstractOperation  # noqa
 from .openapi import OpenAPIOperation  # noqa
 from .secure import SecureOperation  # noqa
 from .swagger2 import Swagger2Operation  # noqa
+from .mimetype import DEFAULT_MIMETYPE  # noqa
 
 
 def make_operation(spec, *args, **kwargs):

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -4,6 +4,7 @@ import logging
 import six
 from connexion.operations.secure import SecureOperation
 
+from .mimetype import DEFAULT_MIMETYPE
 from ..decorators.metrics import UWSGIMetricsCollector
 from ..decorators.parameter import parameter_to_arg
 from ..decorators.produces import BaseSerializer, Produces
@@ -12,8 +13,6 @@ from ..decorators.validation import ParameterValidator, RequestBodyValidator
 from ..utils import all_json, is_nullable
 
 logger = logging.getLogger('connexion.operations.abstract')
-
-DEFAULT_MIMETYPE = 'application/json'
 
 VALIDATOR_MAP = {
     'parameter': ParameterValidator,

--- a/connexion/operations/mimetype.py
+++ b/connexion/operations/mimetype.py
@@ -1,0 +1,1 @@
+DEFAULT_MIMETYPE = 'application/json'

--- a/connexion/operations/secure.py
+++ b/connexion/operations/secure.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 
+from .mimetype import DEFAULT_MIMETYPE
 from ..decorators.decorator import RequestResponseDecorator
 from ..decorators.security import (get_apikeyinfo_func, get_basicinfo_func,
                                    get_bearerinfo_func,
@@ -10,8 +11,6 @@ from ..decorators.security import (get_apikeyinfo_func, get_basicinfo_func,
                                    verify_oauth, verify_security)
 
 logger = logging.getLogger("connexion.operations.secure")
-
-DEFAULT_MIMETYPE = 'application/json'
 
 
 class SecureOperation(object):

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -265,7 +265,9 @@ def test_response_with_non_str_and_non_json_body(aiohttp_app, aiohttp_client):
         '/v1.0/aiohttp_non_str_non_json_response'
     )
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'1234'
+    # \n comes from jsonifier.dumps. text/plain gets serialized as json if possible
+    # as that json representation should generally be more useful then python literals.
+    assert (yield from get_bye.read()) == b'1234\n'
 
 
 @asyncio.coroutine

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -283,7 +283,7 @@ def test_validate_responses(aiohttp_app, aiohttp_client):
     app_client = yield from aiohttp_client(aiohttp_app.app)
     get_bye = yield from app_client.get('/v1.0/aiohttp_validate_responses')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'{"validate": true}'
+    assert (yield from get_bye.read()) == b'{"validate":true}'
 
 
 @asyncio.coroutine

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 import yaml
 
-import aiohttp.web
 from conftest import TEST_FOLDER
 from connexion import AioHttpApp
 
@@ -283,7 +282,7 @@ def test_validate_responses(aiohttp_app, aiohttp_client):
     app_client = yield from aiohttp_client(aiohttp_app.app)
     get_bye = yield from app_client.get('/v1.0/aiohttp_validate_responses')
     assert get_bye.status == 200
-    assert (yield from get_bye.read()) == b'{"validate":true}'
+    assert (yield from get_bye.json()) == {"validate": True}
 
 
 @asyncio.coroutine

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -61,6 +61,13 @@ def test_get_response_from_string_status_headers(api):
 
 
 @asyncio.coroutine
+def test_get_response_from_tuple_error(api):
+    with pytest.raises(RuntimeError) as e:
+        yield from api.get_response((web.Response(text='foo', status=201, headers={'X-header': 'value'}), 200))
+    assert str(e.value) == "Cannot return web.StreamResponse in tuple. Only raw data can be returned in tuple."
+
+
+@asyncio.coroutine
 def test_get_response_from_dict(api):
     response = yield from api.get_response({'foo': 'bar'})
     assert isinstance(response, web.Response)

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -1,7 +1,9 @@
 import asyncio
-from aiohttp import web
-import pytest
 import json
+
+import pytest
+
+from aiohttp import web
 from connexion.apis.aiohttp_api import AioHttpApi
 from connexion.lifecycle import ConnexionResponse
 
@@ -83,7 +85,7 @@ def test_get_response_from_dict_json(api):
     response = yield from api.get_response({'foo': 'bar'}, mimetype='application/json')
     assert isinstance(response, web.Response)
     assert response.status == 200
-    assert json.loads(response.body) == {"foo": "bar"}
+    assert json.loads(response.body.decode()) == {"foo": "bar"}
     assert response.content_type == 'application/json'
     assert dict(response.headers) == {'Content-Type': 'application/json; charset=utf-8'}
 
@@ -103,7 +105,7 @@ def test_get_response_binary_json(api):
     response = yield from api.get_response(b'{"foo":"bar"}', mimetype='application/json')
     assert isinstance(response, web.Response)
     assert response.status == 200
-    assert json.loads(response.body) == {"foo": "bar"}
+    assert json.loads(response.body.decode()) == {"foo": "bar"}
     assert response.content_type == 'application/json'
     assert dict(response.headers) == {'Content-Type': 'application/json'}
 
@@ -146,5 +148,3 @@ def test_get_connexion_response_from_tuple(api):
     assert response.body == b'foo'
     assert response.content_type == 'text/plain'
     assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
-
-

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -1,0 +1,142 @@
+import asyncio
+from aiohttp import web
+import pytest
+from connexion.apis.aiohttp_api import AioHttpApi
+from connexion.lifecycle import ConnexionResponse
+
+
+@pytest.fixture(scope='module')
+def api(aiohttp_api_spec_dir):
+    yield AioHttpApi(specification=aiohttp_api_spec_dir / 'swagger_secure.yaml')
+
+
+@asyncio.coroutine
+def test_get_response_from_aiohttp_response(api):
+    response = yield from api.get_response(web.Response(text='foo', status=201, headers={'X-header': 'value'}))
+    assert isinstance(response, web.Response)
+    assert response.status == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+
+@asyncio.coroutine
+def test_get_response_from_connexion_response(api):
+    response = yield from api.get_response(ConnexionResponse(status_code=201, mimetype='text/plain', body='foo', headers={'X-header': 'value'}))
+    assert isinstance(response, web.Response)
+    assert response.status == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+
+@asyncio.coroutine
+def test_get_response_from_string(api):
+    response = yield from api.get_response('foo')
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+@asyncio.coroutine
+def test_get_response_from_string_status(api):
+    response = yield from api.get_response(('foo', 201))
+    assert isinstance(response, web.Response)
+    assert response.status == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+@asyncio.coroutine
+def test_get_response_from_string_status_headers(api):
+    response = yield from api.get_response(('foo', 201, {'X-header': 'value'}))
+    assert isinstance(response, web.Response)
+    assert response.status == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+
+@asyncio.coroutine
+def test_get_response_from_dict(api):
+    response = yield from api.get_response({'foo': 'bar'})
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b"{'foo': 'bar'}"
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+@asyncio.coroutine
+def test_get_response_from_dict_json(api):
+    response = yield from api.get_response({'foo': 'bar'}, mimetype='application/json')
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'{"foo":"bar"}'
+    assert response.content_type == 'application/json'
+    assert dict(response.headers) == {'Content-Type': 'application/json; charset=utf-8'}
+
+
+@asyncio.coroutine
+def test_get_response_no_data(api):
+    response = yield from api.get_response(None, mimetype='application/json')
+    assert isinstance(response, web.Response)
+    assert response.status == 204
+    assert response.body is None
+    assert response.content_type == 'application/octet-stream'
+    assert dict(response.headers) == {}
+
+
+@asyncio.coroutine
+def test_get_response_binary_json(api):
+    response = yield from api.get_response(b'{"foo":"bar"}', mimetype='application/json')
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'{"foo":"bar"}'
+    assert response.content_type == 'application/json'
+    assert dict(response.headers) == {'Content-Type': 'application/json'}
+
+
+@asyncio.coroutine
+def test_get_response_binary_no_mimetype(api):
+    response = yield from api.get_response(b'{"foo":"bar"}')
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'{"foo":"bar"}'
+    assert response.content_type == 'application/octet-stream'
+    assert dict(response.headers) == {}
+
+
+@asyncio.coroutine
+def test_get_connexion_response_from_aiohttp_response(api):
+    response = api.get_connexion_response(web.Response(text='foo', status=201, headers={'X-header': 'value'}))
+    assert isinstance(response, ConnexionResponse)
+    assert response.status_code == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+
+@asyncio.coroutine
+def test_get_connexion_response_from_connexion_response(api):
+    response = api.get_connexion_response(ConnexionResponse(status_code=201, content_type='text/plain', body='foo', headers={'X-header': 'value'}))
+    assert isinstance(response, ConnexionResponse)
+    assert response.status_code == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+
+@asyncio.coroutine
+def test_get_connexion_response_from_tuple(api):
+    response = api.get_connexion_response(('foo', 201, {'X-header': 'value'}))
+    assert isinstance(response, ConnexionResponse)
+    assert response.status_code == 201
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
+
+

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -92,12 +92,12 @@ def test_get_response_from_tuple_error(api):
 
 @asyncio.coroutine
 def test_get_response_from_dict(api):
+    # mimetype=None => assume json
     response = yield from api.get_response({'foo': 'bar'})
     assert isinstance(response, web.Response)
     assert response.status == 200
-    # odd, yes. but backwards compatible. see test_response_with_non_str_and_non_json_body in tests/aiohttp/test_aiohttp_simple_api.py
-    # TODO: This should be made into JSON when aiohttp and flask serialization can be harmonized.
-    assert response.body == b"{'foo': 'bar'}"
+    assert json.loads(response.body.decode()) == {"foo": "bar"}
+    # get_response does not modify the mimetype or content_type magically. It only simplifies serialization.
     assert response.content_type == 'text/plain'
     assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
 

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -97,9 +97,8 @@ def test_get_response_from_dict(api):
     assert isinstance(response, web.Response)
     assert response.status == 200
     assert json.loads(response.body.decode()) == {"foo": "bar"}
-    # get_response does not modify the mimetype or content_type magically. It only simplifies serialization.
-    assert response.content_type == 'text/plain'
-    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+    assert response.content_type == 'application/json'
+    assert dict(response.headers) == {'Content-Type': 'application/json; charset=utf-8'}
 
 
 @asyncio.coroutine

--- a/tests/aiohttp/test_get_response.py
+++ b/tests/aiohttp/test_get_response.py
@@ -44,6 +44,16 @@ def test_get_response_from_string(api):
 
 
 @asyncio.coroutine
+def test_get_response_from_string_tuple(api):
+    response = yield from api.get_response(('foo',))
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+@asyncio.coroutine
 def test_get_response_from_string_status(api):
     response = yield from api.get_response(('foo', 201))
     assert isinstance(response, web.Response)
@@ -51,6 +61,16 @@ def test_get_response_from_string_status(api):
     assert response.body == b'foo'
     assert response.content_type == 'text/plain'
     assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+@asyncio.coroutine
+def test_get_response_from_string_headers(api):
+    response = yield from api.get_response(('foo', {'X-header': 'value'}))
+    assert isinstance(response, web.Response)
+    assert response.status == 200
+    assert response.body == b'foo'
+    assert response.content_type == 'text/plain'
+    assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8', 'X-header': 'value'}
 
 
 @asyncio.coroutine
@@ -75,6 +95,8 @@ def test_get_response_from_dict(api):
     response = yield from api.get_response({'foo': 'bar'})
     assert isinstance(response, web.Response)
     assert response.status == 200
+    # odd, yes. but backwards compatible. see test_response_with_non_str_and_non_json_body in tests/aiohttp/test_aiohttp_simple_api.py
+    # TODO: This should be made into JSON when aiohttp and flask serialization can be harmonized.
     assert response.body == b"{'foo': 'bar'}"
     assert response.content_type == 'text/plain'
     assert dict(response.headers) == {'Content-Type': 'text/plain; charset=utf-8'}

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -90,7 +90,7 @@ def test_not_content_response(simple_app):
 
     get_no_content_response = app_client.get('/v1.0/test_no_content_response')
     assert get_no_content_response.status_code == 204
-    assert get_no_content_response.content_length in [0, None]
+    assert get_no_content_response.content_length is None
 
 
 def test_pass_through(simple_app):
@@ -310,6 +310,7 @@ def test_get_enum_response(simple_app):
     app_client = simple_app.app.test_client()
     resp = app_client.get('/v1.0/get_enum_response')
     assert resp.status_code == 200
+
 
 def test_get_httpstatus_response(simple_app):
     app_client = simple_app.app.test_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def simple_api_spec_dir():
     return FIXTURES_FOLDER / 'simple'
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def aiohttp_api_spec_dir():
     return FIXTURES_FOLDER / 'aiohttp'
 

--- a/tests/fakeapi/aiohttp_handlers.py
+++ b/tests/fakeapi/aiohttp_handlers.py
@@ -16,50 +16,50 @@ def get_bye(name):
 
 @asyncio.coroutine
 def aiohttp_str_response():
-    return ConnexionResponse(body='str response')
+    return 'str response'
 
 
 @asyncio.coroutine
 def aiohttp_non_str_non_json_response():
-    return ConnexionResponse(body=1234)
+    return 1234
 
 
 @asyncio.coroutine
 def aiohttp_bytes_response():
-    return ConnexionResponse(body=b'bytes response')
+    return b'bytes response'
 
 
 @asyncio.coroutine
 def aiohttp_validate_responses():
-    return ConnexionResponse(body=b'{"validate": true}')
+    return {"validate": True}
 
 
 @asyncio.coroutine
 def aiohttp_post_greeting(name, **kwargs):
     data = {'greeting': 'Hello {name}'.format(name=name)}
-    return ConnexionResponse(body=data)
+    return data
 
 
 @asyncio.coroutine
 def aiohttp_access_request_context(request_ctx):
     assert request_ctx is not None
     assert isinstance(request_ctx, aiohttp.web.Request)
-    return ConnexionResponse(status_code=204)
+    return None
 
 
 @asyncio.coroutine
 def aiohttp_query_parsing_str(query):
-    return ConnexionResponse(body={'query': query})
+    return {'query': query}
 
 
 @asyncio.coroutine
 def aiohttp_query_parsing_array(query):
-    return ConnexionResponse(body={'query': query})
+    return {'query': query}
 
 
 @asyncio.coroutine
 def aiohttp_query_parsing_array_multi(query):
-    return ConnexionResponse(body={'query': query})
+    return {'query': query}
 
 
 USERS = [


### PR DESCRIPTION
Was part of #849. Please refer to the long chain of discussion there for background behind this PR.
Please note that many of the commits here come from #849. Once that is merged the remaining commits will be easier to review.

@dtkav and I discussed quite a bit about what the right interface would be for users so that it is not surprising when things are or are not serialized as json. But, harmonizing them ends up breaking tests for aiohttp, flask, or both depending on which set of assumptions we prefer.

So, we would like for the interface to be more sane and jsonify data for both text/plain and application/json or if mimetype is not defined. But we'd also like to prevent jsonification for mimetypes where that does not make sense. Eventually, `_serialize_data()` should become pluggable, possibly where a chain of serializers can vote on which mimetypes they can handle.