### PR TITLE
Pluggable converter for input parameters based on property format

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -37,7 +37,8 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
     def __init__(self, specification, base_path=None, arguments=None,
                  validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False, resolver_error_handler=None,
-                 validator_map=None, pythonic_params=False, pass_context_arg_name=None, options=None):
+                 validator_map=None, format_converters=None,
+                 pythonic_params=False, pass_context_arg_name=None, options=None):
         """
         :type specification: pathlib.Path | dict
         :type base_path: str | None
@@ -48,6 +49,8 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         :type debug: bool
         :param validator_map: Custom validators for the types "parameter", "body" and "response".
         :type validator_map: dict
+        :param format_converters: Custom value converters based on the schema format of properties.
+        :type format_converters: dict
         :param resolver: Callable that maps operationID to a function
         :param resolver_error_handler: If given, a callable that generates an
             Operation used for handling ResolveErrors
@@ -63,6 +66,7 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         """
         self.debug = debug
         self.validator_map = validator_map
+        self.format_converters = format_converters
         self.resolver_error_handler = resolver_error_handler
 
         logger.debug('Loading specification: %s', specification,
@@ -167,6 +171,7 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
             self.resolver,
             validate_responses=self.validate_responses,
             validator_map=self.validator_map,
+            format_converters=self.format_converters,
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -86,7 +86,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
                 auth_all_paths=None, validate_responses=False,
                 strict_validation=False, resolver=None, resolver_error=None,
                 pythonic_params=False, pass_context_arg_name=None, options=None,
-                validator_map=None):
+                validator_map=None, format_converters=None):
         """
         Adds an API to the application based on a swagger file or API dict
 
@@ -115,6 +115,8 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type pass_context_arg_name: str | None
         :param validator_map: map of validators
         :type validator_map: dict
+        :param format_converters: Custom value converters based on the schema format of properties.
+        :type format_converters: dict
         :rtype: AbstractAPI
         """
         # Turn the resolver_error code into a handler object
@@ -148,6 +150,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
                            auth_all_paths=auth_all_paths,
                            debug=self.debug,
                            validator_map=validator_map,
+                           format_converters=format_converters,
                            pythonic_params=pythonic_params,
                            pass_context_arg_name=pass_context_arg_name,
                            options=api_options.as_dict())

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -40,6 +40,7 @@ def make_type(value, _type):
     return type_func(value)
 
 
+
 def deep_merge(a, b):
     """ merges b into a
         in case of conflict the value from b is used

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -482,7 +482,7 @@ def test_custom_format_converters_body(spec):
     app_client = simple_app_with_custom_format_converters(spec).app.test_client()
 
     res = app_client.post('/v1.0/test-custom-format-converter',
-                          data=json.dumps({'creation_day': '2020-01-01'}),
+                          data=json.dumps({'creation_day': '2020-01-01', 'creation_time': 'ignored'}),
                           content_type='application/json') # type: flask.Response
 
     assert res.status_code == 200

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -210,8 +210,8 @@ def schema_format():
     return ''
 
 
-def test_parameter_validation():
-    return ''
+def test_parameter_validation(date=None):
+    return type(date).__name__ if date else ''
 
 
 def test_required_query_param():
@@ -538,6 +538,14 @@ def post_user(body):
     body['user_id'] = 8
     body.pop('password', None)
     return body
+
+
+def test_custom_format_converter(body):
+    creation_day = body.get('creation_day')
+    if creation_day:
+        body['creation_day_type'] = type(creation_day).__name__
+    return body
+
 
 def post_multipart_form(body):
     x = body['x']

--- a/tests/fixtures/json_validation/openapi.yaml
+++ b/tests/fixtures/json_validation/openapi.yaml
@@ -24,6 +24,9 @@ components:
         password:
           type: string
           writeOnly: true
+        creation_day:
+          type: string
+          format: date
     X:
       type: object
       properties:

--- a/tests/fixtures/json_validation/swagger.yaml
+++ b/tests/fixtures/json_validation/swagger.yaml
@@ -20,6 +20,9 @@ definitions:
       password:
         type: string
         x-writeOnly: true
+      creation_day:
+        type: string
+        format: date
 
 paths:
   /minlength:

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1182,6 +1182,10 @@ components:
         creation_day:
           type: string
           format: date
+        creation_time:
+          type: string
+          format: date-time
+
   parameters:
     Name:
       name: name

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -277,6 +277,19 @@ paths:
               $ref: '#/components/schemas/new_stack'
               default:
                 image_version: default_image
+  /test-custom-format-converter:
+    post:
+      summary: Test that body parameters can be converted based on the format
+      operationId: fakeapi.hello.test_custom_format_converter
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              x-body-name: body
+              $ref: '#/components/schemas/with_date_property'
   /test-default-integer-body:
     post:
       summary: Test if default integer body param is passed to handler.
@@ -1163,6 +1176,12 @@ components:
           description: Docker image version to deploy
       required:
         - image_version
+    with_date_property:
+      type: object
+      properties:
+        creation_day:
+          type: string
+          format: date
   parameters:
     Name:
       name: name

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -1025,6 +1025,9 @@ definitions:
       creation_day:
         type: string
         format: date
+      creation_time:
+        type: string
+        format: date-time
 
 securityDefinitions:
     api_key:

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -182,6 +182,19 @@ paths:
         200:
           description: OK
 
+  /test-custom-format-converter:
+    post:
+      summary: Test that body parameters can be converted based on the format
+      operationId: fakeapi.hello.test_custom_format_converter
+      parameters:
+      - name: body
+        in: body
+        schema:
+          $ref: '#/definitions/with_date_property'
+      responses:
+        '200':
+          description: OK
+
   /test-default-integer-body:
     post:
       summary: Test if default integer body param is passed to handler.
@@ -1006,6 +1019,12 @@ definitions:
         description: Docker image version to deploy
     required:
       - image_version
+  with_date_property:
+    type: object
+    properties:
+      creation_day:
+        type: string
+        format: date
 
 securityDefinitions:
     api_key:


### PR DESCRIPTION
The open API spec states that

> Tools can use the format to validate the input or to map the value to a specific type in the chosen programming language. Tools that do not support a specific format may default back to the type alone, as if the format is not specified.

In this pull review, we are adding a pluggable mechanism to convert input values for query parameters or request body (openapi API, not implemented for swagger) to be converted to custom types based on the format property.

The motivating example is the ability to convert inputs with format "date" to python's datetime.date and input with format "date-time" to python's "datetime.datetime". This PR does not include any custom converters in itself and is thus backwards compatible as it doesn't affect the behavior of applications which don't define custom converters.

A future change might add converters for widely used format specifiers (date, date-time, uri, ...), but given the complexity around date/date-time validation (jsonschema soft dependency on GPL libraries), simply providing the pluggable mechanism solves 99% of the challenge for our use case (without this pull request, we have to monkey patch connexion or use decorators/before_request to intercept the input to the API handler).

At this point, the review contains the code change and unit tests. If the maintainers accept the idea of this pull request, I'll include documentation update.