### PR TITLE
WIP: Parse dont validate

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -89,7 +89,7 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         if all_json(consumes):
             request_body = request.json
         elif consumes[0] in FORM_CONTENT_TYPES:
-            request_body = {sanitize(k): v for k, v in request.form.items()}
+            request_body = {k: v for k, v in request.form.items()}
         else:
             request_body = request.body
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -1,4 +1,3 @@
-import collections
 import copy
 import functools
 import logging
@@ -230,8 +229,9 @@ class ParameterValidator(object):
         :param api: api that the validator is attached to
         :param strict_validation: Flag indicating if parameters not in spec are allowed
         """
-        self.parameters = collections.defaultdict(list)
+        self.parameters = {}
         for p in parameters:
+            self.parameters.setdefault(p['in'], [])
             self.parameters[p['in']].append(p)
 
         self.api = api
@@ -295,7 +295,7 @@ class ParameterValidator(object):
         try:
             spec_params = [x['name'] for x in self.parameters['formData']]
         except KeyError:
-            # OAS 3
+            # OAS 3, rely on additionalProperties validation
             return set()
         return validate_parameter_list(request_params, spec_params)
 

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -281,7 +281,7 @@ class OpenAPIOperation(AbstractOperation):
         for key, value in body_arg.items():
             try:
                 prop_defn = body_props[key]
-                res[key] = self._get_val_from_param(value, prop_defn)
+                res[key] = value
             except KeyError:  # pragma: no cover
                 if not additional_props:
                     logger.error("Body property '{}' not defined in body schema".format(key))
@@ -337,7 +337,4 @@ class OpenAPIOperation(AbstractOperation):
         if is_nullable(query_schema) and is_null(value):
             return None
 
-        if query_schema["type"] == "array":
-            return [make_type(part, query_schema["items"]["type"]) for part in value]
-        else:
-            return make_type(value, query_schema["type"])
+        return value

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -264,34 +264,6 @@ class OpenAPIOperation(AbstractOperation):
 
         return {x_body_name: body}
 
-    def _get_typed_body_values(self, body_arg, body_props, additional_props):
-        """
-        Return a copy of the provided body_arg dictionary
-        whose values will have the appropriate types
-        as defined in the provided schemas.
-
-        :type body_arg: type dict
-        :type body_props: dict
-        :type additional_props: dict|bool
-        :rtype: dict
-        """
-        additional_props_defn = {"schema": additional_props} if isinstance(additional_props, dict) else None
-        res = {}
-
-        for key, value in body_arg.items():
-            try:
-                prop_defn = body_props[key]
-                res[key] = value
-            except KeyError:  # pragma: no cover
-                if not additional_props:
-                    logger.error("Body property '{}' not defined in body schema".format(key))
-                    continue
-                if additional_props_defn is not None:
-                    value = self._get_val_from_param(value, additional_props_defn)
-                res[key] = value
-
-        return res
-
     def _get_default_obj(self, schema):
         try:
             return deepcopy(schema["default"])

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -279,9 +279,4 @@ class Swagger2Operation(AbstractOperation):
         if is_nullable(query_defn) and is_null(value):
             return None
 
-        query_schema = query_defn
-
-        if query_schema["type"] == "array":
-            return [make_type(part, query_defn["items"]["type"]) for part in value]
-        else:
-            return make_type(value, query_defn["type"])
+        return value

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -364,18 +364,18 @@ def test_args_kwargs(simple_app):
     assert json.loads(resp.data.decode('utf-8', 'replace')) == {'foo': 'a'}
 
 
-def test_param_sanitization(simple_app):
-    app_client = simple_app.app.test_client()
+def test_param_sanitization(strict_app):
+    app_client = strict_app.app.test_client()
     resp = app_client.post('/v1.0/param-sanitization')
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode('utf-8', 'replace')) == {}
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {'body': None, 'query': None}
 
     resp = app_client.post('/v1.0/param-sanitization?$query=queryString',
             data={'$form': 'formString'})
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8', 'replace')) == {
             'query': 'queryString',
-            'form': 'formString',
+            'body': 'formString',
             }
 
     body = { 'body1': 'bodyString', 'body2': 'otherString' }
@@ -384,6 +384,7 @@ def test_param_sanitization(simple_app):
         data=json.dumps(body),
         headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
+    print(resp.json)
     assert json.loads(resp.data.decode('utf-8', 'replace')) == body
 
     body = { 'body1': 'bodyString', 'body2': 12, 'body3': {'a':'otherString' }}

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -384,7 +384,6 @@ def test_param_sanitization(strict_app):
         data=json.dumps(body),
         headers={'Content-Type': 'application/json'})
     assert resp.status_code == 200
-    print(resp.json)
     assert json.loads(resp.data.decode('utf-8', 'replace')) == body
 
     body = { 'body1': 'bodyString', 'body2': 12, 'body3': {'a':'otherString' }}

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -142,7 +142,7 @@ def test_empty(simple_app):
 def test_exploded_deep_object_param_endpoint_openapi_simple(simple_openapi_app):
     app_client = simple_openapi_app.app.test_client()
 
-    response = app_client.get('/v1.0/exploded-deep-object-param?id[foo]=bar&id[foofoo]=barbar')  # type: flask.Response
+    response = app_client.get('/v1.0/exploded-deep-object-param?id[foo]=bar')  # type: flask.Response
     assert response.status_code == 200
     response_data = json.loads(response.data.decode('utf-8', 'replace'))
     assert response_data == {'foo': 'bar', 'foo4': 'blubb'}
@@ -164,6 +164,13 @@ def test_exploded_deep_object_param_endpoint_openapi_additional_properties(simpl
     assert response.status_code == 200
     response_data = json.loads(response.data.decode('utf-8', 'replace'))
     assert response_data == {'foo': 'bar', 'fooint': '2'}
+
+
+def test_exploded_deep_object_param_endpoint_openapi_additional_properties_false(simple_openapi_app):
+    app_client = simple_openapi_app.app.test_client()
+
+    response = app_client.get('/v1.0/exploded-deep-object-param?id[foo]=bar&id[foofoo]=barbar')  # type: flask.Response
+    assert response.status_code == 400
 
 
 def test_exploded_deep_object_param_endpoint_openapi_with_dots(simple_openapi_app):
@@ -218,6 +225,17 @@ def test_empty_object_body(simple_app):
     assert resp.status_code == 200
     response = json.loads(resp.data.decode('utf-8', 'replace'))
     assert response['stack'] == {}
+
+
+def test_nested_additional_properties(simple_openapi_app):
+    app_client = simple_openapi_app.app.test_client()
+    resp = app_client.post(
+        '/v1.0/test-nested-additional-properties',
+        data=json.dumps({"nested": {"object": True}}),
+        headers={'Content-Type': 'application/json'})
+    assert resp.status_code == 200
+    response = json.loads(resp.data.decode('utf-8', 'replace'))
+    assert response == {"nested": {"object": True}}
 
 
 def test_custom_encoder(simple_app):

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -188,7 +188,7 @@ def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
     response = app_client.get('/v1.0/nested-exploded-deep-object-param?id[foo][foo2]=bar&id[foofoo]=barbar')  # type: flask.Response
     assert response.status_code == 200
     response_data = json.loads(response.data.decode('utf-8', 'replace'))
-    assert response_data == {'foo': {'foo2': 'bar', 'foo3': 'blubb'}, 'foofoo': 'barbar'}
+    assert response_data == {'foo': {'foo2': 'bar', 'foo3': 'blubb'}, 'foo4': 'blubb', 'foofoo': 'barbar'}
 
 
 def test_redirect_endpoint(simple_app):

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -188,7 +188,7 @@ def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
     response = app_client.get('/v1.0/nested-exploded-deep-object-param?id[foo][foo2]=bar&id[foofoo]=barbar')  # type: flask.Response
     assert response.status_code == 200
     response_data = json.loads(response.data.decode('utf-8', 'replace'))
-    assert response_data == {'foo': {'foo2': 'bar', 'foo3': 'blubb'}, 'foo4': 'blubb', 'foofoo': 'barbar'}
+    assert response_data == {'foo': {'foo2': 'bar', 'foo3': 'blubb'}, 'foofoo': 'barbar'}
 
 
 def test_redirect_endpoint(simple_app):

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -281,6 +281,8 @@ def test_default_param(name):
 def test_default_object_body(stack):
     return {"stack": stack}
 
+def test_nested_additional_properties(body):
+    return body
 
 def test_default_integer_body(stack_version):
     return stack_version

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -462,21 +462,18 @@ def test_args_kwargs(*args, **kwargs):
 
 
 def test_param_sanitization(query=None, form=None):
-    result = {}
-    if query:
-        result['query'] = query
-    if form:
-        result['form'] = form
-    return result
+    return {
+        "query": query,
+        "body": form
+    }
 
 
 def test_param_sanitization3(query=None, body=None):
-    result = {}
-    if query:
-        result['query'] = query
-    if body:
-        result['form'] = body["form"]
-    return result
+    body = body.get("$form")
+    return {
+        "query": query,
+        "body": body
+    }
 
 
 def test_body_sanitization(body=None):

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -163,6 +163,7 @@ paths:
           explode: true
           schema:
             type: object
+            additionalProperties: false
             properties:
               foo:
                 type: string
@@ -277,6 +278,24 @@ paths:
               $ref: '#/components/schemas/new_stack'
               default:
                 image_version: default_image
+  /test-nested-additional-properties:
+    post:
+      summary: Test if nested additionalProperties are cast
+      operationId: fakeapi.hello.test_nested_additional_properties
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nested:
+                  type: object
+                  properties: {}
+                  additionalProperties:
+                    type: boolean
   /test-default-integer-body:
     post:
       summary: Test if default integer body param is passed to handler.

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -928,8 +928,9 @@ paths:
           multipart/form-data:
             schema:
               type: object
+              additionalProperties: false
               properties:
-                'form$':
+                '$form':
                   description: Just a testing parameter in the form data
                   type: string
   /body-sanitization:


### PR DESCRIPTION
Changes proposed in this pull request:
 - move type coercion into one place (with validation)
 - move sanitization to just before populating function arguments to avoid over-matching (like "$abc" and "abc$")
 - refactor + simplify notorious `_get_body_argument()` function.