### PR TITLE
Setting default values in JSON bodies is the default behaviour

### DIFF
--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -1,4 +1,3 @@
-
 class ConnexionRequest(object):
     def __init__(self,
                  url,
@@ -24,7 +23,9 @@ class ConnexionRequest(object):
 
     @property
     def json(self):
-        return self.json_getter()
+        if not hasattr(self, '_json'):
+            self._json = self.json_getter()
+        return self._json
 
 
 class ConnexionResponse(object):

--- a/examples/openapi3/enforcedefaults_aiohttp/README.rst
+++ b/examples/openapi3/enforcedefaults_aiohttp/README.rst
@@ -1,0 +1,16 @@
+========================
+Custom Validator Example
+========================
+
+In this example we fill-in non-provided properties with their defaults.
+Validator code is based on example from `python-jsonschema docs`_.
+
+Running:
+
+.. code-block:: bash
+
+    $ ./enforcedefaults.py
+
+Now open your browser and go to http://localhost:8080/v1/ui/ to see the Swagger
+UI. If you send a ``POST`` request with empty body ``{}``, you should receive
+echo with defaults filled-in.

--- a/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults-api.yaml
+++ b/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults-api.yaml
@@ -1,0 +1,39 @@
+openapi: '3.0.0'
+info:
+  version: '1'
+  title: Custom Validator Example
+servers:
+  - url: http://localhost:8080/{basePath}
+    variables:
+      basePath:
+        default: api
+paths:
+  /echo:
+    post:
+      description: Echo passed data
+      operationId: enforcedefaults.echo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data'
+      responses:
+        '200':
+          description: Data with defaults filled in by validator
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Data:
+      type: object
+      properties:
+        foo:
+          type: string
+          default: foo
+    Error:
+      type: string

--- a/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults.py
+++ b/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults.py
@@ -11,36 +11,6 @@ async def echo(body):
     return body
 
 
-# via https://python-jsonschema.readthedocs.io/
-def extend_with_set_default(validator_class):
-    validate_properties = validator_class.VALIDATORS['properties']
-
-    def set_defaults(validator, properties, instance, schema):
-        for property, subschema in six.iteritems(properties):
-            if 'default' in subschema:
-                instance.setdefault(property, subschema['default'])
-
-        for error in validate_properties(
-                validator, properties, instance, schema):
-            yield error
-
-    return jsonschema.validators.extend(
-        validator_class, {'properties': set_defaults})
-
-DefaultsEnforcingDraft4Validator = extend_with_set_default(Draft4RequestValidator)
-
-
-class DefaultsEnforcingRequestBodyValidator(RequestBodyValidator):
-    def __init__(self, *args, **kwargs):
-        super(DefaultsEnforcingRequestBodyValidator, self).__init__(
-            *args, validator=DefaultsEnforcingDraft4Validator, **kwargs)
-
-
-validator_map = {
-    'body': DefaultsEnforcingRequestBodyValidator
-}
-
-
 if __name__ == '__main__':
     app = connexion.AioHttpApp(
         __name__,
@@ -50,7 +20,5 @@ if __name__ == '__main__':
     )
     app.add_api(
         'enforcedefaults-api.yaml',
-        arguments={'title': 'Hello World Example'},
-        validator_map=validator_map,
     )
     app.run()

--- a/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults.py
+++ b/examples/openapi3/enforcedefaults_aiohttp/enforcedefaults.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import connexion
+import jsonschema
+import six
+from connexion.decorators.validation import RequestBodyValidator
+from connexion.json_schema import Draft4RequestValidator
+
+
+async def echo(body):
+    return body
+
+
+# via https://python-jsonschema.readthedocs.io/
+def extend_with_set_default(validator_class):
+    validate_properties = validator_class.VALIDATORS['properties']
+
+    def set_defaults(validator, properties, instance, schema):
+        for property, subschema in six.iteritems(properties):
+            if 'default' in subschema:
+                instance.setdefault(property, subschema['default'])
+
+        for error in validate_properties(
+                validator, properties, instance, schema):
+            yield error
+
+    return jsonschema.validators.extend(
+        validator_class, {'properties': set_defaults})
+
+DefaultsEnforcingDraft4Validator = extend_with_set_default(Draft4RequestValidator)
+
+
+class DefaultsEnforcingRequestBodyValidator(RequestBodyValidator):
+    def __init__(self, *args, **kwargs):
+        super(DefaultsEnforcingRequestBodyValidator, self).__init__(
+            *args, validator=DefaultsEnforcingDraft4Validator, **kwargs)
+
+
+validator_map = {
+    'body': DefaultsEnforcingRequestBodyValidator
+}
+
+
+if __name__ == '__main__':
+    app = connexion.AioHttpApp(
+        __name__,
+        port=8080,
+        specification_dir='.',
+        options={'swagger_ui': True}
+    )
+    app.add_api(
+        'enforcedefaults-api.yaml',
+        arguments={'title': 'Hello World Example'},
+        validator_map=validator_map,
+    )
+    app.run()

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -237,3 +237,10 @@ def test_global_response_definitions(schema_app):
     app_client = schema_app.app.test_client()
     resp = app_client.get('/v1.0/define_global_response')
     assert json.loads(resp.data.decode('utf-8', 'replace')) == ['general', 'list']
+
+
+def test_defaults_insertion(schema_app):
+    app_client = schema_app.app.test_client()
+    headers = {'Content-type': 'application/json'}
+    resp = app_client.post('/v1.0/defaults_insertion', data='{"data": {}}', headers=headers)
+    assert json.loads(resp.data.decode('utf-8', 'replace')) == {'prop': 'prop_default'}

--- a/tests/fakeapi/hello.py
+++ b/tests/fakeapi/hello.py
@@ -491,6 +491,12 @@ def test_body_sanitization_additional_properties_defined(body):
 def test_body_not_allowed_additional_properties(body):
     return body
 
+def test_defaults_insertion_openapi(body):
+    return body['data']
+
+def test_defaults_insertion_swagger(data):
+    return data['data']
+
 def post_wrong_content_type():
     return "NOT OK"
 

--- a/tests/fixtures/different_schemas/openapi.yaml
+++ b/tests/fixtures/different_schemas/openapi.yaml
@@ -264,6 +264,27 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/GeneralList'
+  /defaults_insertion:
+    post:
+      description: Should insert defaults into JSON body.
+      operationId: fakeapi.hello.test_defaults_insertion_openapi
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ["data"]
+              properties:
+                data:
+                  type: object
+                  properties:
+                    prop:
+                      type: string
+                      default: prop_default
+      responses:
+        '200':
+          description: Data with defaults filled in by validator
 components:
   responses:
     GeneralList:

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -291,6 +291,27 @@ paths:
         200:
           $ref: '#/responses/GeneralList'
 
+  /defaults_insertion:
+    post:
+      description: Should insert defaults into JSON body.
+      operationId: fakeapi.hello.test_defaults_insertion_swagger
+      parameters:
+        - name: data
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  prop:
+                    type: string
+                    default: prop_default
+      responses:
+        '200':
+          description: Data with defaults filled in by validator
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
Changes proposed in this pull request:

 - JSON bodies' defaults could have been enforced using [this approach](https://github.com/zalando/connexion/tree/96bdcb010a4e5180c2bce18295e7b576c9c1ef0f/examples/swagger2/enforcedefaults). But why won't we make it implicit? Without any external "monkey patching"?