### PR TITLE
pass correct content_type to is_json_schema_compatible

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -46,7 +46,7 @@ class ResponseValidator(BaseDecorator):
         response_definition = self.operation.response_definition(str(status_code), content_type)
         response_schema = self.operation.response_schema(str(status_code), content_type)
 
-        if self.is_json_schema_compatible(response_schema):
+        if self.is_json_schema_compatible(response_schema,content_type):
             v = ResponseBodyValidator(response_schema, validator=self.validator)
             try:
                 data = self.operation.json_loads(data)
@@ -66,7 +66,7 @@ class ResponseValidator(BaseDecorator):
                 raise NonConformingResponseHeaders(message=msg)
         return True
 
-    def is_json_schema_compatible(self, response_schema: dict) -> bool:
+    def is_json_schema_compatible(self, response_schema: dict, content_type: str) -> bool:
         """
         Verify if the specified operation responses are JSON schema
         compatible.
@@ -77,7 +77,7 @@ class ResponseValidator(BaseDecorator):
         """
         if not response_schema:
             return False
-        return all_json([self.mimetype]) or self.mimetype == 'text/plain'
+        return all_json([content_type]) or content_type == 'text/plain'
 
     def __call__(self, function):
         """


### PR DESCRIPTION
Fixes #655 
Fixes #860 
Related to pull request #760

Changes proposed in this pull request:
 - Use correct content_type instead of self.mimetype in [is_json_schema_compatible](https://github.com/zalando/connexion/blob/96bdcb010a4e5180c2bce18295e7b576c9c1ef0f/connexion/decorators/response.py#L65) function in decorators/reponse.py

Problem Statement:
   - In the case of multiple content_types in spec, response validation assumes incorrect content_type and tries to json_load.

Expected Scenario:
- In the case of multiple content_types in spec, the content_type will be set in the response by the user; else the default application/json will be used. 

Solution:
-  In [is_json_schema_compatible](https://github.com/zalando/connexion/blob/96bdcb010a4e5180c2bce18295e7b576c9c1ef0f/connexion/decorators/response.py#L65) function, the logic rely on self.mimetype which defaults to application/json always. 
-  The above causes the function to always return True. 
- The is_json_schema_compatible must depend on the [content_type](https://github.com/zalando/connexion/blob/96bdcb010a4e5180c2bce18295e7b576c9c1ef0f/connexion/decorators/response.py#L39) set by the user. 
-  The changes made pass content_type to the function and operates the logic on content_type instead of self.mimetype, so returns the correct boolean.

 

 
