### PR TITLE
lifecycle: add cookies attribute to ConnexionRequest (#1168)

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -322,7 +322,8 @@ class AioHttpApi(AbstractAPI):
                                 body=body,
                                 json_getter=lambda: cls.jsonifier.loads(body),
                                 files={},
-                                context=req)
+                                context=req,
+                                cookies=req.cookies)
 
     @classmethod
     async def get_response(cls, response, mimetype=None, request=None):

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -244,7 +244,8 @@ class FlaskApi(AbstractAPI):
             json_getter=lambda: flask_request.get_json(silent=True),
             files=flask_request.files,
             path_params=params,
-            context=context_dict
+            context=context_dict,
+            cookies=flask_request.cookies,
         )
         logger.debug('Getting data and status code',
                      extra={

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -16,7 +16,8 @@ class ConnexionRequest:
                  body=None,
                  json_getter=None,
                  files=None,
-                 context=None):
+                 context=None,
+                 cookies=None):
         self.url = url
         self.method = method
         self.path_params = path_params or {}
@@ -27,6 +28,7 @@ class ConnexionRequest:
         self.json_getter = json_getter
         self.files = files
         self.context = context if context is not None else {}
+        self.cookies = cookies or {}
 
     @property
     def json(self):

--- a/tests/aiohttp/test_aiohttp_simple_api.py
+++ b/tests/aiohttp/test_aiohttp_simple_api.py
@@ -189,6 +189,19 @@ async def test_pythonic_path_param(aiohttp_api_spec_dir, aiohttp_client):
     assert j['id_'] == 100
 
 
+async def test_cookie_param(aiohttp_api_spec_dir, aiohttp_client):
+    app = AioHttpApp(__name__, port=5001,
+                     specification_dir=aiohttp_api_spec_dir,
+                     debug=True)
+    app.add_api('openapi_simple.yaml', pass_context_arg_name="request")
+
+    app_client = await aiohttp_client(app.app)
+    response = await app_client.get('/v1.0/test-cookie-param', headers={"Cookie": "test_cookie=hello"})
+    assert response.status == 200
+    j = await response.json()
+    assert j['cookie_value'] == "hello"
+
+
 async def test_swagger_ui_static(aiohttp_api_spec_dir, aiohttp_client):
     app = AioHttpApp(__name__, port=5001,
                      specification_dir=aiohttp_api_spec_dir,

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -496,3 +496,11 @@ def test_get_unicode_request(simple_app):
     resp = app_client.get('/v1.0/get_unicode_request?price=%C2%A319.99')  # £19.99
     assert resp.status_code == 200
     assert json.loads(resp.data.decode('utf-8'))['price'] == '£19.99'
+
+
+def test_cookie_param(simple_app):
+    app_client = simple_app.app.test_client()
+    app_client.set_cookie("localhost", "test_cookie", "hello")
+    response = app_client.get("/v1.0/test-cookie-param")
+    assert response.status_code == 200
+    assert response.json == {"cookie_value": "hello"}

--- a/tests/fakeapi/aiohttp_handlers.py
+++ b/tests/fakeapi/aiohttp_handlers.py
@@ -105,3 +105,7 @@ async def get_date():
 
 async def get_uuid():
     return ConnexionResponse(body={'value': uuid.UUID(hex='e7ff66d0-3ec2-4c4e-bed0-6e4723c24c51')})
+
+
+async def test_cookie_param(request):
+    return {"cookie_value": request.cookies["test_cookie"]}

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -330,6 +330,10 @@ def test_required_param(simple):
     return simple
 
 
+def test_cookie_param():
+    return {"cookie_value": request.cookies["test_cookie"]}
+
+
 def test_exploded_deep_object_param(id):
     return id
 

--- a/tests/fixtures/aiohttp/openapi_simple.yaml
+++ b/tests/fixtures/aiohttp/openapi_simple.yaml
@@ -20,3 +20,16 @@ paths:
         '200':
           description: ok
       security: []
+  /test-cookie-param:
+    get:
+      summary: Test cookie parameter support.
+      operationId: fakeapi.aiohttp_handlers.test_cookie_param
+      parameters:
+        - name: test_cookie
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -663,6 +663,19 @@ paths:
       responses:
         '200':
           description: OK
+  /test-cookie-param:
+    get:
+      summary: Test cookie parameter support.
+      operationId: fakeapi.hello.test_cookie_param
+      parameters:
+        - name: test_cookie
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
   /parameters-in-root-path:
     parameters:
       - in: query

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -518,6 +518,15 @@ paths:
         200:
           description: OK
 
+  /test-cookie-param:
+    get:
+      summary: Test cookie parameter support.
+      operationId: fakeapi.hello.test_cookie_param
+      # No parameters because swagger / openapi 2.0 does not support describing cookie parameters.
+      responses:
+        200:
+          description: OK
+
   /parameters-in-root-path:
     parameters:
       - in: query


### PR DESCRIPTION
Fixes #1168.



Changes proposed in this pull request:

 - Add a `cookies` attribute to `lifecycle.ConnexionRequest`
 - Use `flask.Request.cookies` and `aiohttp.web.Request.cookies`
