### PR TITLE
pass request context to authentication functions

### DIFF
--- a/connexion/decorators/security.py
+++ b/connexion/decorators/security.py
@@ -1,6 +1,7 @@
 # Authentication and authorization related decorators
 import base64
 import functools
+import inspect
 import logging
 import os
 import textwrap
@@ -223,7 +224,12 @@ def verify_basic(basic_info_func):
         except Exception:
             raise OAuthProblem(description='Invalid authorization header')
 
-        token_info = basic_info_func(username, password, required_scopes=required_scopes)
+        if 'context' in inspect.signature(basic_info_func).parameters:
+            token_info = basic_info_func(
+                username, password, required_scopes=required_scopes, context=request.context)
+        else:
+            token_info = basic_info_func(username, password, required_scopes=required_scopes)
+
         if token_info is None:
             raise OAuthResponseProblem(
                 description='Provided authorization is not valid',

--- a/examples/openapi3/basicauth_aiohttp/README.rst
+++ b/examples/openapi3/basicauth_aiohttp/README.rst
@@ -1,0 +1,20 @@
+=======================
+HTTP Basic Auth Example
+=======================
+
+Running:
+
+.. code-block:: bash
+
+    $ sudo pip3 install --upgrade connexion[swagger-ui]  # install Connexion from PyPI
+    $ ./app.py
+
+Now open your browser and go to http://localhost:8080/ui/ to see the Swagger UI.
+
+The hardcoded credentials are ``admin`` and ``secret``. For an example with
+correct authentication but missing access rights, use ``foo`` and ``bar``.
+
+For a more simple example which doesn't use oauth scope for authorization see
+the `Swagger2 Basic Auth example`_.
+
+.. _Swagger2 Basic Auth example: https://github.com/zalando/connexion/tree/master/examples/swagger2/basicauth

--- a/examples/openapi3/basicauth_aiohttp/app.py
+++ b/examples/openapi3/basicauth_aiohttp/app.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+'''
+Basic example of a resource server
+'''
+
+import uuid
+
+import connexion
+from aiohttp.web import middleware
+
+
+def basic_auth(username, password, *, context, required_scopes=None):
+    if username == 'admin' and password == 'secret':
+        info = {'sub': 'admin', 'scope': 'secret'}
+    elif username == 'foo' and password == 'bar':
+        info = {'sub': 'user1', 'scope': ''}
+    else:
+        # optional: raise exception for custom error response
+        return None
+
+    print('authenticated', username, context["uuid"], flush=True)
+
+    return info
+
+
+async def get_secret(user) -> str:
+    return "You are {user} and the secret is 'wbevuec'".format(user=user)
+
+
+@middleware
+async def add_uuid(request, handler):
+    request["uuid"] = uuid.uuid4()
+    return await handler(request)
+
+
+if __name__ == '__main__':
+    app = connexion.AioHttpApp(
+        __name__,
+        port=8080,
+        specification_dir='.',
+        server_args={"middlewares": [add_uuid]},
+    )
+    app.add_api('openapi.yaml')
+    app.run()

--- a/examples/openapi3/basicauth_aiohttp/openapi.yaml
+++ b/examples/openapi3/basicauth_aiohttp/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Basic Auth Example
+  version: '1.0'
+servers:
+  - url: http://localhost:8080/api
+paths:
+  /secret:
+    get:
+      summary: Return secret string
+      operationId: app.get_secret
+      responses:
+        '200':
+          description: secret response
+          content:
+            '*/*':
+              schema:
+                type: string
+      security:
+        - basic: []
+components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
+      x-basicInfoFunc: app.basic_auth

--- a/tests/fakeapi/auth.py
+++ b/tests/fakeapi/auth.py
@@ -1,4 +1,4 @@
-def fake_basic_auth(username, password, required_scopes=None):
+def fake_basic_auth(username, password, context, required_scopes=None):
     if username == password:
         return {'uid': username}
     return None


### PR DESCRIPTION
Changes proposed in this pull request:

 - authentication functions might need request context for logging, database access, etc. this pull-request backward-compatibly passes the context to basic auth functions.