### PR TITLE
Pass header parameters to the handler functions as parameters

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -99,7 +99,7 @@ def parameter_to_arg(operation, function, pythonic_params=False,
             query = dict(request.query.items())
 
         kwargs.update(
-            operation.get_arguments(request.path_params, query, request_body,
+            operation.get_arguments(request.path_params, query, request.headers, request_body,
                                     request.files, arguments, has_kwargs, sanitize)
         )
 


### PR DESCRIPTION
Changes proposed in this pull request:

Currently, header parameters are not passed to the handler functions as parameters.
This PR allows connexion to pass header parameters to the handler functions as parameters without breaking existing behaviour.