### PR TITLE
Don't validate streamed responses

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -163,6 +163,7 @@ class FlaskApi(AbstractAPI):
             content_type=response.content_type,
             headers=response.headers,
             body=response.get_data(),
+            is_streamed=response.is_streamed
         )
 
     @classmethod

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -162,7 +162,7 @@ class FlaskApi(AbstractAPI):
             mimetype=response.mimetype,
             content_type=response.content_type,
             headers=response.headers,
-            body=response.get_data(),
+            body=response.get_data() if not response.direct_passthrough else None,
             is_streamed=response.is_streamed
         )
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -86,9 +86,9 @@ class ResponseValidator(BaseDecorator):
         """
 
         def _wrapper(request, response):
-            if not getattr(response, 'is_streamed', False):
-                connexion_response = \
-                    self.operation.api.get_connexion_response(response, self.mimetype)
+            connexion_response = \
+                self.operation.api.get_connexion_response(response, self.mimetype)
+            if not connexion_response.is_streamed:
                 self.validate_response(
                     connexion_response.body, connexion_response.status_code,
                     connexion_response.headers, request.url)

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -86,11 +86,12 @@ class ResponseValidator(BaseDecorator):
         """
 
         def _wrapper(request, response):
-            connexion_response = \
-                self.operation.api.get_connexion_response(response, self.mimetype)
-            self.validate_response(
-                connexion_response.body, connexion_response.status_code,
-                connexion_response.headers, request.url)
+            if not getattr(response, 'is_streamed', False):
+                connexion_response = \
+                    self.operation.api.get_connexion_response(response, self.mimetype)
+                self.validate_response(
+                    connexion_response.body, connexion_response.status_code,
+                    connexion_response.headers, request.url)
 
             return response
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -89,6 +89,7 @@ class ResponseValidator(BaseDecorator):
             connexion_response = \
                 self.operation.api.get_connexion_response(response, self.mimetype)
             if not connexion_response.is_streamed:
+                logger.warning("Skipping response validation for streamed response.")
                 self.validate_response(
                     connexion_response.body, connexion_response.status_code,
                     connexion_response.headers, request.url)

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -40,9 +40,11 @@ class ConnexionResponse:
                  mimetype=None,
                  content_type=None,
                  body=None,
-                 headers=None):
+                 headers=None,
+                 is_streamed=False):
         self.status_code = status_code
         self.mimetype = mimetype
         self.content_type = content_type
         self.body = body
         self.headers = headers or {}
+        self.is_streamed = is_streamed

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -382,3 +382,9 @@ def test_get_bad_default_response(simple_app):
 
     resp = app_client.get('/v1.0/get_bad_default_response/202')
     assert resp.status_code == 500
+
+
+def test_streaming_response(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get('/v1.0/get_streaming_response')
+    assert resp.status_code == 200

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -3,7 +3,7 @@ import datetime
 import uuid
 
 from connexion import NoContent, ProblemException, context, request
-from flask import jsonify, redirect
+from flask import jsonify, redirect, send_file
 
 
 class DummyClass:
@@ -615,3 +615,7 @@ def test_optional_headers():
 
 def nullable_default(test):
     return
+
+
+def get_streaming_response():
+    return send_file(__file__)

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1196,6 +1196,17 @@ paths:
               schema:
                 type: string
               required: false
+  /get_streaming_response:
+    get:
+      operationId: fakeapi.hello.get_streaming_response
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
 
 servers:
   - url: http://localhost:{port}/{basePath}

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -1026,6 +1026,15 @@ paths:
           schema:
             type: object
 
+  /get_streaming_response:
+    get:
+      operationId: fakeapi.hello.get_streaming_response
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: file
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
prior to validation get_connexion_response ultimately calls response.get_data()

I haven't found a workaround for this and the old PR was closed due to inactivity.

I changed it to use getattr as the object may not be a response (could be tuple).

Fixes #904 .

there are also a few other issues raised.

Changes proposed in this pull request:

 - bypass for response.is_streamed, otherwise no change in behaviour
 -
 -
