### PR TITLE
adds pass_operation_arg_name to `parameter_to_arg`

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -37,7 +37,8 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
     def __init__(self, specification, base_path=None, arguments=None,
                  validate_responses=False, strict_validation=False, resolver=None,
                  auth_all_paths=False, debug=False, resolver_error_handler=None,
-                 validator_map=None, pythonic_params=False, pass_context_arg_name=None, options=None,
+                 validator_map=None, pythonic_params=False, pass_context_arg_name=None,
+                 pass_operation_arg_name=None, options=None,
                  ):
         """
         :type specification: pathlib.Path | dict
@@ -61,6 +62,9 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
         :param pass_context_arg_name: If not None URL request handling functions with an argument matching this name
         will be passed the framework's request context.
         :type pass_context_arg_name: str | None
+        :param pass_operation_arg_name: If not None URL request handling functions with an argument matching this name
+        will be passed the current operation.
+        :type pass_operation_arg_name: str | None
         """
         self.debug = debug
         self.validator_map = validator_map
@@ -101,6 +105,9 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
 
         logger.debug('pass_context_arg_name: %s', pass_context_arg_name)
         self.pass_context_arg_name = pass_context_arg_name
+
+        logger.debug('pass_operation_arg_name: %s', pass_operation_arg_name)
+        self.pass_operation_arg_name = pass_operation_arg_name
 
         self.security_handler_factory = self.make_security_handler_factory(pass_context_arg_name)
 
@@ -178,7 +185,8 @@ class AbstractAPI(metaclass=AbstractAPIMeta):
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,
-            pass_context_arg_name=self.pass_context_arg_name
+            pass_context_arg_name=self.pass_context_arg_name,
+            pass_operation_arg_name=self.pass_operation_arg_name,
         )
         self._add_operation_internal(method, path, operation)
 

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -88,8 +88,8 @@ class AbstractApp(metaclass=abc.ABCMeta):
     def add_api(self, specification, base_path=None, arguments=None,
                 auth_all_paths=None, validate_responses=False,
                 strict_validation=False, resolver=None, resolver_error=None,
-                pythonic_params=False, pass_context_arg_name=None, options=None,
-                validator_map=None):
+                pythonic_params=False, pass_context_arg_name=None,
+                pass_operation_arg_name=None, options=None, validator_map=None):
         """
         Adds an API to the application based on a swagger file or API dict
 
@@ -116,6 +116,9 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type options: dict | None
         :param pass_context_arg_name: Name of argument in handler functions to pass request context to.
         :type pass_context_arg_name: str | None
+        :param pass_operation_arg_name: If not None URL request handling functions with an argument matching this name
+        will be passed the current operation.
+        :type pass_operation_arg_name: str | None
         :param validator_map: map of validators
         :type validator_map: dict
         :rtype: AbstractAPI
@@ -153,6 +156,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
                            validator_map=validator_map,
                            pythonic_params=pythonic_params,
                            pass_context_arg_name=pass_context_arg_name,
+                           pass_operation_arg_name=pass_operation_arg_name,
                            options=api_options.as_dict())
         return api
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -54,7 +54,7 @@ def snake_and_shadow(name):
 
 
 def parameter_to_arg(operation, function, pythonic_params=False,
-                     pass_context_arg_name=None):
+                     pass_context_arg_name=None, pass_operation_arg_name=None):
     """
     Pass query and body parameters as keyword arguments to handler function.
 
@@ -117,6 +117,10 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         # attempt to provide the request context to the function
         if pass_context_arg_name and (has_kwargs or pass_context_arg_name in arguments):
             kwargs[pass_context_arg_name] = request.context
+
+        # attempt to provide the current operation to the function
+        if pass_operation_arg_name and (has_kwargs or pass_operation_arg_name in arguments):
+            kwargs[pass_operation_arg_name] = operation
 
         return function(**kwargs)
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -44,7 +44,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
                  validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None,
                  pythonic_params=False, uri_parser_class=None,
-                 pass_context_arg_name=None):
+                 pass_context_arg_name=None, pass_operation_arg_name=None):
         """
         :param api: api that this operation is attached to
         :type api: apis.AbstractAPI
@@ -77,6 +77,9 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.
         :type pass_context_arg_name: str|None
+        :param pass_operation_arg_name: If not None will try to inject self to the function using this
+        name.
+        :type pass_operation_arg_name: str|None
         """
         self._api = api
         self._method = method
@@ -90,6 +93,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         self._pythonic_params = pythonic_params
         self._uri_parser_class = uri_parser_class
         self._pass_context_arg_name = pass_context_arg_name
+        self._pass_operation_arg_name = pass_operation_arg_name
         self._randomize_endpoint = randomize_endpoint
 
         self._operation_id = self._operation.get("operationId")
@@ -345,7 +349,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         """
         function = parameter_to_arg(
             self, self._resolution.function, self.pythonic_params,
-            self._pass_context_arg_name
+            self._pass_context_arg_name, self._pass_operation_arg_name
         )
 
         if self.validate_responses:

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -18,7 +18,8 @@ class OpenAPIOperation(AbstractOperation):
     def __init__(self, api, method, path, operation, resolver, path_parameters=None,
                  app_security=None, components=None, validate_responses=False,
                  strict_validation=False, randomize_endpoint=None, validator_map=None,
-                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
+                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None,
+                 pass_operation_arg_name=None):
         """
         This class uses the OperationID identify the module and function that will handle the operation
 
@@ -59,6 +60,9 @@ class OpenAPIOperation(AbstractOperation):
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.
         :type pass_context_arg_name: str|None
+        :param pass_operation_arg_name: If not None will try to inject self to the function using this
+        name.
+        :type pass_operation_arg_name: str|None
         """
         self.components = components or {}
 
@@ -86,7 +90,8 @@ class OpenAPIOperation(AbstractOperation):
             validator_map=validator_map,
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
-            pass_context_arg_name=pass_context_arg_name
+            pass_context_arg_name=pass_context_arg_name,
+            pass_operation_arg_name=pass_operation_arg_name
         )
 
         self._definitions_map = {

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -27,7 +27,7 @@ class Swagger2Operation(AbstractOperation):
                  definitions=None, parameter_definitions=None,
                  response_definitions=None, validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None, pythonic_params=False,
-                 uri_parser_class=None, pass_context_arg_name=None):
+                 uri_parser_class=None, pass_context_arg_name=None, pass_operation_arg_name=None):
         """
         :param api: api that this operation is attached to
         :type api: apis.AbstractAPI
@@ -73,6 +73,9 @@ class Swagger2Operation(AbstractOperation):
         :param pass_context_arg_name: If not None will try to inject the request context to the function using this
         name.
         :type pass_context_arg_name: str|None
+        :param pass_operation_arg_name: If not None will try to inject self to the function using this
+        name.
+        :type pass_operation_arg_name: str|None
         """
         app_security = operation.get('security', app_security)
         uri_parser_class = uri_parser_class or Swagger2URIParser
@@ -93,7 +96,8 @@ class Swagger2Operation(AbstractOperation):
             validator_map=validator_map,
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
-            pass_context_arg_name=pass_context_arg_name
+            pass_context_arg_name=pass_context_arg_name,
+            pass_operation_arg_name=pass_operation_arg_name,
         )
 
         self._produces = operation.get('produces', app_produces)

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -25,3 +25,7 @@ def test_injection():
 
     parameter_to_arg(Op(), handler, pass_context_arg_name='framework_request_ctx')(request)
     func.assert_called_with(p1='123', framework_request_ctx=request.context)
+
+    operation = Op()
+    parameter_to_arg(operation, handler, pass_operation_arg_name='current_operation')(request)
+    func.assert_called_with(p1='123', current_operation=operation)


### PR DESCRIPTION
Fixes https://github.com/zalando/connexion/issues/937



Changes proposed in this pull request:

 - adds `pass_operation_arg_name` to allow passing the current operation to the related handler (similar approach to pass_context_arg_name)
