### PR TITLE
Fix: #878. Support OAS3 requestBody.required.

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -424,9 +424,14 @@ class AbstractOperation(SecureOperation):
                                      self.api,
                                      strict_validation=self.strict_validation)
         if self.body_schema:
+            try:
+                body_required = self.request_body['required']
+            except (AttributeError, KeyError):
+                body_required = False
             yield RequestBodyValidator(self.body_schema, self.consumes, self.api,
                                        is_nullable(self.body_definition),
-                                       strict_validation=self.strict_validation)
+                                       strict_validation=self.strict_validation,
+                                       body_required=body_required)
 
     @property
     def __response_validation_decorator(self):

--- a/tests/fixtures/json_validation/openapi.yaml
+++ b/tests/fixtures/json_validation/openapi.yaml
@@ -54,6 +54,7 @@ paths:
     post:
       operationId: fakeapi.hello.post_user
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -64,6 +64,10 @@ def test_writeonly(json_validation_spec_dir, spec):
     app = build_app_from_fixture(json_validation_spec_dir, spec, validate_responses=True)
     app_client = app.app.test_client()
 
+
+    res = app_client.post('/v1.0/user', data='', content_type='application/json') # type: flask.Response
+    assert res.status_code == 400
+
     res = app_client.post('/v1.0/user', data=json.dumps({'name': 'max', 'password': '1234'}), content_type='application/json') # type: flask.Response
     assert res.status_code == 200
     assert 'password' not in json.loads(res.data.decode())


### PR DESCRIPTION
Fixes #878 



Changes proposed in this pull request:

 - pass `requestBody.required` to connexion
 - check if requestBody is not None when required
 
