### PR TITLE
Change deprecated aiohttp req.has_body to req.can_read_body

### DIFF
--- a/connexion/apis/aiohttp_api.py
+++ b/connexion/apis/aiohttp_api.py
@@ -306,7 +306,7 @@ class AioHttpApi(AbstractAPI):
         """
         url = str(req.url)
         logger.debug('Getting data and status code',
-                     extra={'has_body': req.has_body, 'url': url})
+                     extra={'can_read_body': req.can_read_body, 'url': url})
 
         query = parse_qs(req.rel_url.query_string)
         headers = req.headers


### PR DESCRIPTION
Change `aiohttp` `req.has_body` to `req.can_read_body`. Fixes #1136.
Changes proposed in this pull request:
 - Support for `aiohttp 4.x` (which is the default installation version), where `req.has_body` is no longer supported ([ref](https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.BaseRequest.has_body)).