### PR TITLE
Allow template variables for swagger-ui to be passed via options to app

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -286,6 +286,11 @@ class InternalHandlers(object):
         template_variables = {
             'openapi_spec_url': flask.url_for(openapi_json_route_name)
         }
+        if "swagger_ui_template_variables" in self.options.as_dict():
+            logger.info("Swagger UI template variables: %s",
+                self.options.as_dict()["swagger_ui_template_variables"]
+            )
+            template_variables.update(self.options.as_dict()["swagger_ui_template_variables"])
         if self.options.openapi_console_ui_config is not None:
             template_variables['configUrl'] = 'swagger-ui-config.json'
         return flask.render_template('index.j2', **template_variables)


### PR DESCRIPTION

Allow the template variables for swagger-ui index.j2 to be set via app options.
This allow for setting e.g. the clientId and other oauth config like so:

```
options = {
    "swagger_ui_template_variables": {
        "initOAuth": {
            "clientId": "00000000-1111-2222-3333-444444444444",
            "usePkceWithAuthorizationCodeGrant": True,
        }
    },
}
app = connexion.FlaskApp(options=options)
```

This was necessary specifically for me to be able to pass `"usePkceWithAuthorizationCodeGrant": True` to swagger-ui to enable oauth autorization code flow with PKCE.
