### PR TITLE
fix-square bracket : V1

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -65,7 +65,7 @@ def parameter_to_arg(operation, function, pythonic_params=False,
     consumes = operation.consumes
 
     def sanitized(name):
-        return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z[_]', '', re.sub('[\[]', '_', name)))
+        return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z[_]', '', re.sub(r'[\[]', '_', name)))
 
     def pythonic(name):
         name = name and snake_and_shadow(name)

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -65,7 +65,7 @@ def parameter_to_arg(operation, function, pythonic_params=False,
     consumes = operation.consumes
 
     def sanitized(name):
-        return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z_]', '', name))
+        return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z[_]', '', re.sub('[\[]', '_', name)))
 
     def pythonic(name):
         name = name and snake_and_shadow(name)

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -113,7 +113,7 @@ class AbstractURIParser(BaseDecorator, metaclass=abc.ABCMeta):
                 # multiple values in a path is impossible
                 values = [values]
 
-            if (param_schema is not None and param_schema['type'] == 'array'):
+            if param_schema and param_schema['type'] == 'array':
                 # resolve variable re-assignment, handle explode
                 values = self._resolve_param_duplicates(values, param_defn, _in)
                 # handle array styles

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -211,7 +211,6 @@ class OpenAPIURIParser(AbstractURIParser):
         prev[k] = v[0]
         return root_key, [root], True
 
-
     def _preprocess_deep_objects(self, query_data):
         """ deep objects provide a way of rendering nested objects using query
             parameters.

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -20,7 +20,6 @@ PATH2 = {"letters": "d|e|f"}
 CSV = "csv"
 PIPES = "pipes"
 MULTI = "multi"
-DICT = {}
 
 
 @pytest.mark.parametrize("parser_class, expected, query_in, collection_format", [
@@ -111,7 +110,7 @@ def test_uri_parser_path_params(parser_class, expected, query_in, collection_for
 
 
 @pytest.mark.parametrize("parser_class, expected, query_in, collection_format", [
-        (OpenAPIURIParser, ['d', 'e', 'f'], QUERY3, DICT),
+        (OpenAPIURIParser, ['d', 'e', 'f'], QUERY3, None),
         (Swagger2URIParser, ['d', 'e', 'f'], QUERY5, CSV),
         (FirstValueURIParser, ['a'], QUERY5, CSV),
         (AlwaysMultiURIParser, ['a', 'b', 'c', 'd', 'e', 'f'], QUERY5, CSV),

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -1,13 +1,16 @@
 import pytest
 from connexion.decorators.uri_parsing import (AlwaysMultiURIParser,
                                               FirstValueURIParser,
-                                              Swagger2URIParser)
+                                              Swagger2URIParser,
+                                              OpenAPIURIParser)
 from werkzeug.datastructures import MultiDict
 
 QUERY1 = MultiDict([("letters", "a"), ("letters", "b,c"),
                     ("letters", "d,e,f")])
 QUERY2 = MultiDict([("letters", "a"), ("letters", "b|c"),
                     ("letters", "d|e|f")])
+QUERY3 = MultiDict([("letters[eq]", "a"), ("letters[eq]", "b,c"),
+                    ("letters[eq]", ["d", "e", "f"])])
 PATH1 = {"letters": "d,e,f"}
 PATH2 = {"letters": "d|e|f"}
 CSV = "csv"
@@ -100,3 +103,25 @@ def test_uri_parser_path_params(parser_class, expected, query_in, collection_for
     p = parser_class(parameters, body_defn)
     res = p(lambda x: x)(request)
     assert res.path_params["letters"] == expected
+
+
+@pytest.mark.parametrize("parser_class, expected, query_in, collection_format", [
+        (OpenAPIURIParser, ['d', 'e', 'f'], QUERY3, {})])
+def test_uri_parser_query_params_with_square_brackets(parser_class, expected, query_in, collection_format):
+    class Request:
+        query = query_in
+        path_params = {}
+        form = {}
+
+    request = Request()
+    parameters = [
+        {"name": "letters[eq]",
+         "in": "query",
+         "type": "array",
+         "items": {"type": "string"},
+         "collectionFormat": collection_format}
+    ]
+    body_defn = {}
+    p = parser_class(parameters, body_defn)
+    res = p(lambda x: x)(request)
+    assert res.query["letters[eq]"] == expected


### PR DESCRIPTION
Fixes # . 

Fix square bracket in query params. Example : `orderBy[eq]`.

Its a quick fix to permit square bracket in query params, if they are define in the schema.

For query params who are not in the schema. Do default computation for deep object.

Changes proposed in this pull request:

 - Modify `sanitized` function to replace `[` by `_`. Example : `orderBy[eq] -> order_by_eq`
 - Modify `_make_deep_object` function to use key with square bracket in the name as a dict key if its define in the schema
