### PR TITLE
Fix fail to parse body for open api schema defining multiple content …

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -14,7 +14,7 @@ import inflection
 
 from ..http_facts import FORM_CONTENT_TYPES
 from ..lifecycle import ConnexionRequest  # NOQA
-from ..utils import all_json
+from ..utils import all_json, is_json_mimetype
 
 logger = logging.getLogger(__name__)
 
@@ -80,10 +80,10 @@ def parameter_to_arg(operation, function, pythonic_params=False,
         # type: (ConnexionRequest) -> Any
         logger.debug('Function Arguments: %s', arguments)
         kwargs = {}
-
-        if all_json(consumes):
+        request_content_type = request.headers.get('CONTENT_TYPE')
+        if all_json(consumes) or is_json_mimetype(request_content_type):
             request_body = request.json
-        elif consumes[0] in FORM_CONTENT_TYPES:
+        elif consumes[0] in FORM_CONTENT_TYPES or request_content_type in FORM_CONTENT_TYPES:
             request_body = {sanitize(k): v for k, v in request.form.items()}
         else:
             request_body = request.body


### PR DESCRIPTION
…types

Fixes
When using an open api schema with multiple content type definition like:
```
requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/DownTimeLogCreate'
          application/x-www-form-urlencoded:
            schema:
              $ref: '#/components/schemas/DownTimeLogCreate'
          multipart/form-data:
            schema:
              $ref: '#/components/schemas/DownTimeLogCreate'
        required: true
```
sending a request with a json body causes the following error:
```
  File "/home/marco/Projects/Synapse/azka_vision_mock_server/venv/lib/python3.6/site-packages/connexion/decorators/parameter.py", line 97, in wrapper
    request.files, arguments, has_kwargs, sanitize)
  File "/home/marco/Projects/Synapse/azka_vision_mock_server/venv/lib/python3.6/site-packages/connexion/operations/abstract.py", line 282, in get_arguments
    has_kwargs, sanitize))
  File "/home/marco/Projects/Synapse/azka_vision_mock_server/venv/lib/python3.6/site-packages/connexion/operations/openapi.py", line 296, in _get_body_argument
    body_arg.update(body or {})
TypeError: cannot convert dictionary update sequence element #0 to a sequence
```



Changes proposed in this pull request:

 - I am proposing that the request body parsing also considers the CONTENT-TYPE header sent with the request not just the open api schema definition
