### PR TITLE
 issue 1452 - placement of x-body-name isnt valid OAS3 location for an extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmlcov/
 .vscode/
 venv/
 src/
+*.un~

--- a/README.rst
+++ b/README.rst
@@ -266,9 +266,21 @@ of the endpoint parameter ``message`` to your view function.
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody schema
+          provide the x-body-name parameter in your requestBody media-type
+          (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
+
+.. code-block:: yaml
+
+    requestBody:
+      content:
+        application/json:
+          x-body-name: stack
+          schema:
+            # legacy location here should be ignored because the preferred location is at the media-type level above
+            x-body-name: this_should_be_ignored
+            $ref: '#/components/schemas/someComponent'
 
 .. warning:: When you define a parameter at your endpoint as *not* required, and
     this argument does not have default value in your Python view, you will get

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ of the endpoint parameter ``message`` to your view function.
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody media-type
+          provide the x-body-name parameter in your requestBody 
           (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
@@ -274,11 +274,11 @@ of the endpoint parameter ``message`` to your view function.
 .. code-block:: yaml
 
     requestBody:
+      x-body-name: stack
       content:
         application/json:
-          x-body-name: stack
           schema:
-            # legacy location here should be ignored because the preferred location is at the media-type level above
+            # legacy location here should be ignored because the preferred location is at the requestBody level above
             x-body-name: this_should_be_ignored
             $ref: '#/components/schemas/someComponent'
 

--- a/README.rst
+++ b/README.rst
@@ -266,21 +266,24 @@ of the endpoint parameter ``message`` to your view function.
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody 
+          provide the x-body-name parameter in your operation 
           (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
 
 .. code-block:: yaml
 
-    requestBody:
-      x-body-name: stack
-      content:
-        application/json:
-          schema:
-            # legacy location here should be ignored because the preferred location is at the requestBody level above
-            x-body-name: this_should_be_ignored
-            $ref: '#/components/schemas/someComponent'
+
+    /path
+      post:
+        x-body-name: body
+        requestBody:
+          content:
+            application/json:
+              schema:
+                # legacy location here should be ignored because the preferred location for x-body-name is at the operation level above
+                x-body-name: this_should_be_ignored
+                $ref: '#/components/schemas/someComponent'
 
 .. warning:: When you define a parameter at your endpoint as *not* required, and
     this argument does not have default value in your Python view, you will get

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -272,8 +272,10 @@ class OpenAPIOperation(AbstractOperation):
         return {}
 
     def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
+        # prefer the x-body-name as an extension of the media-type
         x_body_name = sanitize(self.body_definition.get('x-body-name', None))
         if not x_body_name:
+            # x-body-name also accepted in the schema field of the media-type for legacy compat
             x_body_name = sanitize(self.body_schema.get('x-body-name', 'body'))
 
         if is_nullable(self.body_schema) and is_null(body):

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -3,7 +3,6 @@ This module defines an OpenAPIOperation class, a Connexion operation specific fo
 """
 
 import logging
-import io
 from copy import copy, deepcopy
 
 from connexion.operations.abstract import AbstractOperation

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -272,7 +272,10 @@ class OpenAPIOperation(AbstractOperation):
         return {}
 
     def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
-        x_body_name = sanitize(self.body_schema.get('x-body-name', 'body'))
+        x_body_name = sanitize(self.body_definition.get('x-body-name', None))
+        if not x_body_name:
+            x_body_name = sanitize(self.body_schema.get('x-body-name', 'body'))
+
         if is_nullable(self.body_schema) and is_null(body):
             return {x_body_name: None}
 

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -273,10 +273,8 @@ class OpenAPIOperation(AbstractOperation):
         return {}
 
     def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
-        # prefer the x-body-name as an extension of the request body
-        x_body_name = None
-        if self._request_body:
-            x_body_name = sanitize(self._request_body.get('x-body-name', None))
+        # prefer the x-body-name as an extension of operation
+        x_body_name = sanitize(self._operation.get('x-body-name', None))
 
         if not x_body_name:
             # x-body-name also accepted in the schema field for legacy connexion compat

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -3,6 +3,7 @@ This module defines an OpenAPIOperation class, a Connexion operation specific fo
 """
 
 import logging
+import io
 from copy import copy, deepcopy
 
 from connexion.operations.abstract import AbstractOperation
@@ -272,10 +273,13 @@ class OpenAPIOperation(AbstractOperation):
         return {}
 
     def _get_body_argument(self, body, arguments, has_kwargs, sanitize):
-        # prefer the x-body-name as an extension of the media-type
-        x_body_name = sanitize(self.body_definition.get('x-body-name', None))
+        # prefer the x-body-name as an extension of the request body
+        x_body_name = None
+        if self._request_body:
+            x_body_name = sanitize(self._request_body.get('x-body-name', None))
+
         if not x_body_name:
-            # x-body-name also accepted in the schema field of the media-type for legacy compat
+            # x-body-name also accepted in the schema field for legacy connexion compat
             x_body_name = sanitize(self.body_schema.get('x-body-name', 'body'))
 
         if is_nullable(self.body_schema) and is_null(body):

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -92,7 +92,7 @@ And the view function:
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody media-type
+          provide the x-body-name parameter in your requestBody 
           (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
@@ -100,11 +100,11 @@ And the view function:
 .. code-block:: yaml
 
     requestBody:
+      x-body-name: stack
       content:
         application/json:
-          x-body-name: stack
           schema:
-            # legacy location here should be ignored because the preferred location is at the media-type level above
+            # legacy location here should be ignored because the preferred location is at the requestBody level above
             x-body-name: this_should_be_ignored
             $ref: '#/components/schemas/someComponent'
 

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -92,21 +92,22 @@ And the view function:
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody 
+          provide the x-body-name parameter in your operation 
           (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
 
 .. code-block:: yaml
 
-    requestBody:
-      x-body-name: stack
-      content:
-        application/json:
-          schema:
-            # legacy location here should be ignored because the preferred location is at the requestBody level above
-            x-body-name: this_should_be_ignored
-            $ref: '#/components/schemas/someComponent'
+    /path
+      post:
+        x-body-name: body
+        requestBody:
+          content:
+            application/json:
+              schema:
+                # legacy location here should be ignored because the preferred location for x-body-name is at the operation level above
+                x-body-name: this_should_be_ignored
 
 .. warning:: Please note that when you have a parameter defined as
              *not* required at your endpoint and your Python view have

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -92,9 +92,21 @@ And the view function:
 
 .. note:: In the OpenAPI 3.x.x spec, the requestBody does not have a name.
           By default it will be passed in as 'body'. You can optionally
-          provide the x-body-name parameter in your requestBody schema
+          provide the x-body-name parameter in your requestBody media-type
+          (or non-OAS compliant legacy position within the requestBody schema)
           to override the name of the parameter that will be passed to your
           handler function.
+
+.. code-block:: yaml
+
+    requestBody:
+      content:
+        application/json:
+          x-body-name: stack
+          schema:
+            # legacy location here should be ignored because the preferred location is at the media-type level above
+            x-body-name: this_should_be_ignored
+            $ref: '#/components/schemas/someComponent'
 
 .. warning:: Please note that when you have a parameter defined as
              *not* required at your endpoint and your Python view have

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -270,8 +270,8 @@ paths:
       responses:
         '200':
           description: OK
+      x-body-name: stack
       requestBody:
-        x-body-name: stack
         content:
           application/json:
             schema:

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -271,9 +271,9 @@ paths:
         '200':
           description: OK
       requestBody:
+        x-body-name: stack
         content:
           application/json:
-            x-body-name: stack
             schema:
               # should be ignored because the preferred location is at the media-type level above
               x-body-name: this_should_be_ignored

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -273,8 +273,10 @@ paths:
       requestBody:
         content:
           application/json:
+            x-body-name: stack
             schema:
-              x-body-name: stack
+              # should be ignored because the preferred location is at the media-type level above
+              x-body-name: this_should_be_ignored
               $ref: '#/components/schemas/new_stack'
               default:
                 image_version: default_image

--- a/tests/fixtures/snake_case/openapi.yaml
+++ b/tests/fixtures/snake_case/openapi.yaml
@@ -149,8 +149,10 @@ paths:
       requestBody:
         content:
           application/json:
+            x-body-name: round_
             schema:
-              x-body-name: round_
+              # should be ignored because the preferred location is at the media-type level above
+              x-body-name: this_should_be_ignored
               type: object
         description: round parameter
         required: true

--- a/tests/fixtures/snake_case/openapi.yaml
+++ b/tests/fixtures/snake_case/openapi.yaml
@@ -149,10 +149,8 @@ paths:
       requestBody:
         content:
           application/json:
-            x-body-name: round_
             schema:
-              # should be ignored because the preferred location is at the media-type level above
-              x-body-name: this_should_be_ignored
+              x-body-name: round_
               type: object
         description: round parameter
         required: true


### PR DESCRIPTION
Fixes # [1452 ](https://github.com/zalando/connexion/issues/1452) - placement of x-body-name isnt valid OAS3 location for an extension

Changes proposed in this pull request:

 - permit use of x-body-name at a location that does not violate the OAS spec
