### PR TITLE
Drop openapi-spec-validator for custom ref handler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     'PyYAML>=5.1,<6',
     'requests>=2.9.1,<3',
     'inflection>=0.3.1,<0.6',
-    'openapi-spec-validator>=0.2.4,<0.4',
     'werkzeug>=1.0,<3',
 ]
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -7,7 +7,7 @@ import yaml
 from connexion import App
 from connexion.exceptions import InvalidSpecification
 from connexion.http_facts import METHODS
-from openapi_spec_validator.loaders import ExtendedSafeLoader
+from connexion.json_schema import ExtendedSafeLoader
 
 from conftest import TEST_FOLDER, build_app_from_fixture
 


### PR DESCRIPTION
Fixes #930 
Continues on #936 

This PR completely removes the dependency on `openapi-spec-validator`. There's multiple reasons to do this:
- One dependency less
- We don't use `openapi-spec-validator` for it's main purpose, but for utility functionality
- It's not production ready (https://github.com/p1c2u/openapi-schema-validator/issues/31#issuecomment-1014141023)
- We recently had some issues with dependency conflicts (https://github.com/spec-first/connexion/issues/1430#issuecomment-1007737974)