### PR TITLE
Change test release trigger to tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types:
       - published
@@ -19,7 +19,6 @@ jobs:
         python-version: 3.9
 
     - name: Update version
-      if: github.event_name == 'release'
       run: sed -i "s/__version__ = .*/__version__ = '${{github.ref_name}}'/" */__init__.py
 
     - name: Build a binary wheel and a source tarball


### PR DESCRIPTION
[The test release pipeline failed](https://github.com/spec-first/connexion/actions/runs/1809057983) after merging #1454 because you can only upload a package on PyPi with the same version once.

This PR changes the trigger for the test release pipeline to tags, so it only runs when there's a new version.

This way, releasing works as follows:
1. Push tag
2. Test release pipeline
3. Publish release
4. Release pipeline