### PR TITLE
Only push to TestPyPi on tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish distribution 📦 to Test PyPI
+      if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@v1.5.0
       with:
         user: __token__


### PR DESCRIPTION
Last time hopefully :)

The release pipeline fails because we're uploading the same version to TestPyPi both in the test pipeline (on push of tag) and on the release pipeline (when publishing the github release). This PR skips publishing to TestPyPi in the actual release pipeline.

After this is merged, I'll move the 2.11.0 tag to the merge commit. The triggered test pipeline will fail (because it will try to upload 2.11.0 again), but the release pipeline should succeed.
