### PR TITLE
Add Python 3.9 to supported versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',


### PR DESCRIPTION
This PR updates our `setup.py` to correctly indicate support for Python 3.9 which we're already using as target version in our test pipeline.