### PR TITLE
[FIX] MethodViewResolver CamelCase Methods

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -5,8 +5,9 @@ from the operations defined in the OpenAPI spec.
 
 import inspect
 import logging
-import re
 import sys
+
+from inflection import camelize
 
 import connexion.utils as utils
 from connexion.exceptions import ResolverError
@@ -210,7 +211,7 @@ class MethodViewResolver(RestyResolver):
         # Use RestyResolver to get operation_id for us (follow their naming conventions/structure)
         operation_id = self.resolve_operation_id_using_rest_semantics(operation)
         module_name, view_base, meth_name = operation_id.rsplit('.', 2)
-        view_name = ''.join(w.title() for w in re.split('_|-', view_base)) + 'View'
+        view_name = camelize(view_base) + 'View'
 
         return f"{module_name}.{view_name}.{meth_name}"
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -5,6 +5,7 @@ from the operations defined in the OpenAPI spec.
 
 import inspect
 import logging
+import re
 import sys
 
 import connexion.utils as utils
@@ -209,7 +210,7 @@ class MethodViewResolver(RestyResolver):
         # Use RestyResolver to get operation_id for us (follow their naming conventions/structure)
         operation_id = self.resolve_operation_id_using_rest_semantics(operation)
         module_name, view_base, meth_name = operation_id.rsplit('.', 2)
-        view_name = view_base[0].upper() + view_base[1:] + 'View'
+        view_name = ''.join(w.title() for w in re.split('_|-', view_base)) + 'View'
 
         return f"{module_name}.{view_name}.{meth_name}"
 

--- a/tests/fakeapi/__init__.py
+++ b/tests/fakeapi/__init__.py
@@ -1,4 +1,4 @@
-from .example_method_view import Example_methodView
+from .example_method_view import ExampleMethodView
 
 
 def get():

--- a/tests/fakeapi/example_method_view.py
+++ b/tests/fakeapi/example_method_view.py
@@ -1,7 +1,7 @@
 from flask.views import MethodView
 
 
-class Example_methodView(MethodView):
+class ExampleMethodView(MethodView):
     mycontent="demonstrate return from MethodView class"
     def get(self):
       return self.mycontent

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -43,14 +43,14 @@ def test_methodview_resolve_x_router_controller_with_operation_id():
         path='endpoint',
         path_parameters=[],
         operation={
-            'x-openapi-router-controller': 'fakeapi.Example_methodView',
+            'x-openapi-router-controller': 'fakeapi.ExampleMethodView',
             'operationId': 'post_greeting',
         },
         app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.post_greeting'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.post_greeting'
 
 
 def test_methodview_resolve_x_router_controller_without_operation_id():
@@ -58,11 +58,11 @@ def test_methodview_resolve_x_router_controller_without_operation_id():
                           method='GET',
                           path='/hello/{id}',
                           path_parameters=[],
-                          operation={'x-openapi-router-controller': 'fakeapi.Example_method'},
+                          operation={'x-openapi-router-controller': 'fakeapi.example_method'},
                           app_security=[],
                           components=COMPONENTS,
                           resolver=MethodViewResolver('fakeapi'))
-    assert operation.operation_id == 'fakeapi.Example_methodView.get'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
 def test_methodview_resolve_with_default_module_name():
@@ -76,7 +76,7 @@ def test_methodview_resolve_with_default_module_name():
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.get'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
 def test_methodview_resolve_with_default_module_name_lowercase_verb():
@@ -90,7 +90,7 @@ def test_methodview_resolve_with_default_module_name_lowercase_verb():
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.get'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
 def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
@@ -104,7 +104,7 @@ def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_re
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.search'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
 def test_methodview_resolve_with_default_module_name_can_resolve_api_root():
@@ -116,9 +116,9 @@ def test_methodview_resolve_with_default_module_name_can_resolve_api_root():
         operation={},
         app_security=[],
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi.Example_method',)
+        resolver=MethodViewResolver('fakeapi.example_method',)
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.get'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
@@ -132,7 +132,7 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.search'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
 def test_methodview_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
@@ -148,7 +148,7 @@ def test_methodview_resolve_with_default_module_name_and_x_router_controller_wil
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.search'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
@@ -162,7 +162,7 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi', 'api_list')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.api_list'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.api_list'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
@@ -176,4 +176,4 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.Example_methodView.post'
+    assert operation.operation_id == 'fakeapi.ExampleMethodView.post'


### PR DESCRIPTION
Fixes #1466 .

dependent on #1465 

Changes proposed in this pull request:

 - change `view_name` to be `CamelCase` instead of a mix of CamelCase and snake_case.
 - update tests to output CamelCase for MethodViewResolver
