### PR TITLE
Rework required_scopes checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ htmlcov/
 .idea/
 .vscode/
 venv/
+.venv/
 src/

--- a/connexion/security/async_security_handler_factory.py
+++ b/connexion/security/async_security_handler_factory.py
@@ -62,12 +62,12 @@ class AbstractAsyncSecurityHandlerFactory(AbstractSecurityHandlerFactory):
         return wrapper
 
     @classmethod
-    def verify_security(cls, auth_funcs, required_scopes, function):
+    def verify_security(cls, auth_funcs, function):
         @functools.wraps(function)
         async def wrapper(request):
             token_info = cls.no_value
             for func in auth_funcs:
-                token_info = func(request, required_scopes)
+                token_info = func(request)
                 while asyncio.iscoroutine(token_info):
                     token_info = await token_info
                 if token_info is not cls.no_value:

--- a/connexion/security/async_security_handler_factory.py
+++ b/connexion/security/async_security_handler_factory.py
@@ -75,7 +75,7 @@ class AbstractAsyncSecurityHandlerFactory(AbstractSecurityHandlerFactory):
                     if token_info is not cls.no_value:
                         break
                 except Exception as err:
-                    errors += err
+                    errors.append(err)
 
             if token_info is cls.no_value:
                 if errors != []:

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -373,7 +373,7 @@ class AbstractSecurityHandlerFactory(abc.ABC):
                     if token_info is not cls.no_value:
                         break
                 except Exception as err:
-                    errors += err
+                    errors.append(err)
 
             if token_info is cls.no_value:
                 if errors != []:

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -320,9 +320,6 @@ class AbstractSecurityHandlerFactory(abc.ABC):
             if need_to_add_required_scopes:
                 kwargs[self.required_scopes_kw] = required_scopes
             token_info = func(*args, **kwargs)
-            # TODO: Multiple OAuth schemes defined in OR fashion
-            # This currently doesn't work because if the first one doesn't apply, it will raise an error
-            # and the second OAuth security func is never checked
             if token_info is self.no_value:
                 return self.no_value
             if token_info is None:
@@ -375,7 +372,6 @@ class AbstractSecurityHandlerFactory(abc.ABC):
                     token_info = func(request)
                     if token_info is not cls.no_value:
                         break
-                # TODO: Catch any error that might be raised instead of specific ones?
                 except (OAuthProblem, OAuthResponseProblem, OAuthScopeProblem) as err:
                     problem = err
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -57,11 +57,7 @@ Basic Authentication
 With Connexion, the API security definition **must** include a
 ``x-basicInfoFunc`` or set ``BASICINFO_FUNC`` env var. It uses the same
 semantics as for ``x-tokenInfoFunc``, but the function accepts three
-parameters: username, password and required_scopes. If the security declaration
-of the operation also has an oauth security requirement, required_scopes is
-taken from there, otherwise it's None. This allows authorizing individual
-operations with `oauth scope`_ while using basic authentication for
-authentication.
+parameters: username, password and required_scopes.
 
 You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
 

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -96,7 +96,8 @@ def test_security(oauth_requests, secure_endpoint_app):
     assert response.data == b'"Authenticated"\n'
     headers = {"X-AUTH": "wrong-key"}
     response = app_client.get('/v1.0/optional-auth', headers=headers)  # type: flask.Response
-    assert response.status_code == 401
+    assert response.data == b'"Unauthenticated"\n'
+    assert response.status_code == 200
 
 
 def test_checking_that_client_token_has_all_necessary_scopes(

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -34,12 +34,12 @@ def test_verify_oauth_missing_auth_header(security_handler_factory):
     def somefunc(token):
         return None
 
-    wrapped_func = security_handler_factory.verify_oauth(somefunc, security_handler_factory.validate_scope)
+    wrapped_func = security_handler_factory.verify_oauth(somefunc, security_handler_factory.validate_scope, ['admin'])
 
     request = MagicMock()
     request.headers = {}
 
-    assert wrapped_func(request, ['admin']) is security_handler_factory.no_value
+    assert wrapped_func(request) is security_handler_factory.no_value
 
 
 def test_verify_oauth_scopes_remote(monkeypatch, security_handler_factory):
@@ -52,7 +52,7 @@ def test_verify_oauth_scopes_remote(monkeypatch, security_handler_factory):
         return tokeninfo_response
 
     token_info_func = security_handler_factory.get_tokeninfo_func({'x-tokenInfoUrl': 'https://example.org/tokeninfo'})
-    wrapped_func = security_handler_factory.verify_oauth(token_info_func, security_handler_factory.validate_scope)
+    wrapped_func = security_handler_factory.verify_oauth(token_info_func, security_handler_factory.validate_scope, ['admin'])
 
     request = MagicMock()
     request.headers = {"Authorization": "Bearer 123"}
@@ -62,30 +62,30 @@ def test_verify_oauth_scopes_remote(monkeypatch, security_handler_factory):
     monkeypatch.setattr('connexion.security.flask_security_handler_factory.session', session)
 
     with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
-        wrapped_func(request, ['admin'])
+        wrapped_func(request)
 
     tokeninfo["scope"] += " admin"
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
     tokeninfo["scope"] = ["foo", "bar"]
     with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
-        wrapped_func(request, ['admin'])
+        wrapped_func(request)
 
     tokeninfo["scope"].append("admin")
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
 
 def test_verify_oauth_invalid_local_token_response_none(security_handler_factory):
     def somefunc(token):
         return None
 
-    wrapped_func = security_handler_factory.verify_oauth(somefunc, security_handler_factory.validate_scope)
+    wrapped_func = security_handler_factory.verify_oauth(somefunc, security_handler_factory.validate_scope, ['admin'])
 
     request = MagicMock()
     request.headers = {"Authorization": "Bearer 123"}
 
     with pytest.raises(OAuthResponseProblem):
-        wrapped_func(request, ['admin'])
+        wrapped_func(request)
 
 
 def test_verify_oauth_scopes_local(security_handler_factory):
@@ -94,23 +94,23 @@ def test_verify_oauth_scopes_local(security_handler_factory):
     def token_info(token):
         return tokeninfo
 
-    wrapped_func = security_handler_factory.verify_oauth(token_info, security_handler_factory.validate_scope)
+    wrapped_func = security_handler_factory.verify_oauth(token_info, security_handler_factory.validate_scope, ['admin'])
 
     request = MagicMock()
     request.headers = {"Authorization": "Bearer 123"}
 
     with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
-        wrapped_func(request, ['admin'])
+        wrapped_func(request)
 
     tokeninfo["scope"] += " admin"
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
     tokeninfo["scope"] = ["foo", "bar"]
     with pytest.raises(OAuthScopeProblem, match="Provided token doesn't have the required scope"):
-        wrapped_func(request, ['admin'])
+        wrapped_func(request)
 
     tokeninfo["scope"].append("admin")
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
 
 def test_verify_basic_missing_auth_header(security_handler_factory):
@@ -122,7 +122,7 @@ def test_verify_basic_missing_auth_header(security_handler_factory):
     request = MagicMock()
     request.headers = {"Authorization": "Bearer 123"}
 
-    assert wrapped_func(request, ['admin']) is security_handler_factory.no_value
+    assert wrapped_func(request) is security_handler_factory.no_value
 
 
 def test_verify_basic(security_handler_factory):
@@ -136,7 +136,7 @@ def test_verify_basic(security_handler_factory):
     request = MagicMock()
     request.headers = {"Authorization": 'Basic Zm9vOmJhcg=='}
 
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
 
 def test_verify_apikey_query(security_handler_factory):
@@ -150,7 +150,7 @@ def test_verify_apikey_query(security_handler_factory):
     request = MagicMock()
     request.query = {"auth": 'foobar'}
 
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
 
 def test_verify_apikey_header(security_handler_factory):
@@ -164,7 +164,7 @@ def test_verify_apikey_header(security_handler_factory):
     request = MagicMock()
     request.headers = {"X-Auth": 'foobar'}
 
-    assert wrapped_func(request, ['admin']) is not None
+    assert wrapped_func(request) is not None
 
 
 def test_multiple_schemes(security_handler_factory):
@@ -189,12 +189,12 @@ def test_multiple_schemes(security_handler_factory):
     request = MagicMock()
     request.headers = {"X-Auth-1": 'foobar'}
 
-    assert wrapped_func(request, ['admin']) is security_handler_factory.no_value
+    assert wrapped_func(request) is security_handler_factory.no_value
 
     request = MagicMock()
     request.headers = {"X-Auth-2": 'bar'}
 
-    assert wrapped_func(request, ['admin']) is security_handler_factory.no_value
+    assert wrapped_func(request) is security_handler_factory.no_value
 
     # Supplying both keys does succeed
     request = MagicMock()
@@ -207,13 +207,13 @@ def test_multiple_schemes(security_handler_factory):
         'key1': {'sub': 'foo'},
         'key2': {'sub': 'bar'},
     }
-    assert wrapped_func(request, ['admin']) == expected_token_info
+    assert wrapped_func(request) == expected_token_info
 
 
 def test_verify_security_oauthproblem(security_handler_factory):
     """Tests whether verify_security raises an OAuthProblem if there are no auth_funcs."""
     func_to_secure = MagicMock(return_value='func')
-    secured_func = security_handler_factory.verify_security([], [], func_to_secure)
+    secured_func = security_handler_factory.verify_security([], func_to_secure)
 
     request = MagicMock()
     with pytest.raises(OAuthProblem) as exc_info:

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock
 
 import pytest
 import requests
-from connexion.exceptions import (OAuthProblem, OAuthResponseProblem,
-                                  OAuthScopeProblem, BadRequestProblem,
-                                  ConnexionException)
+from connexion.exceptions import (BadRequestProblem, ConnexionException,
+                                  OAuthProblem, OAuthResponseProblem,
+                                  OAuthScopeProblem)
 
 
 def test_get_tokeninfo_url(monkeypatch, security_handler_factory):

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -296,8 +296,7 @@ def test_operation(api, security_handler_factory):
     security_decorator = operation.security_decorator
     assert len(security_decorator.args[0]) == 1
     assert security_decorator.args[0][0] == 'verify_oauth_result'
-    assert security_decorator.args[1] == ['uid']
-    verify_oauth.assert_called_with('get_token_info_remote_result',security_handler_factory.validate_scope)
+    verify_oauth.assert_called_with('get_token_info_remote_result', security_handler_factory.validate_scope, ['uid'])
     security_handler_factory.get_token_info_remote.assert_called_with('https://oauth.example/token_info')
 
     assert operation.method == 'GET'
@@ -384,8 +383,7 @@ def test_operation_local_security_oauth2(api):
     security_decorator = operation.security_decorator
     assert len(security_decorator.args[0]) == 1
     assert security_decorator.args[0][0] == 'verify_oauth_result'
-    assert security_decorator.args[1] == ['uid']
-    verify_oauth.assert_called_with(math.ceil, api.security_handler_factory.validate_scope)
+    verify_oauth.assert_called_with(math.ceil, api.security_handler_factory.validate_scope, ['uid'])
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -418,8 +416,7 @@ def test_operation_local_security_duplicate_token_info(api):
     security_decorator = operation.security_decorator
     assert len(security_decorator.args[0]) == 1
     assert security_decorator.args[0][0] == 'verify_oauth_result'
-    assert security_decorator.args[1] == ['uid']
-    verify_oauth.call_args.assert_called_with(math.ceil, api.security_handler_factory.validate_scope)
+    verify_oauth.call_args.assert_called_with(math.ceil, api.security_handler_factory.validate_scope, ['uid'])
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -514,7 +511,6 @@ def test_multiple_security_schemes_and(api):
     security_decorator = operation.security_decorator
     assert len(security_decorator.args[0]) == 1
     assert security_decorator.args[0][0] == 'verify_multiple_result'
-    assert security_decorator.args[1] is None
 
     assert operation.method == 'GET'
     assert operation.produces == ['application/json']
@@ -548,7 +544,6 @@ def test_multiple_oauth_in_and(api, caplog):
     security_decorator = operation.security_decorator
     assert len(security_decorator.args[0]) == 0
     assert security_decorator.args[0] == []
-    assert security_decorator.args[1] == ['uid']
 
     assert '... multiple OAuth2 security schemes in AND fashion not supported' in caplog.text
 


### PR DESCRIPTION
Fixes #1423  .

Moves the required_scopes argument as current approach assumes there is one possible set of scopes per operation/security object.

I have changed the tested behaviour for [this test](https://github.com/spec-first/connexion/blob/main/tests/api/test_secure_api.py#L99).
If there is optional auth, if an incorrect API key is provided, the `verify_none` still passes and given that the security schemes are specified in OR fashion, the security check should pass.
(For example, changing the security schemes around in the spec ([link](https://github.com/spec-first/connexion/blob/main/tests/fixtures/secure_endpoint/swagger.yaml#L169-L170)) also causes the test to fail, which shouldn't happen as the order shouldn't matter)