### PR TITLE
Proof of concept to move connexion functionality into middleware

### DIFF
--- a/connexion/apis/__init__.py
+++ b/connexion/apis/__init__.py
@@ -13,4 +13,5 @@ on the framework app.
 """
 
 
-from .abstract import AbstractAPI, AbstractMinimalAPI, AbstractSwaggerUIAPI  # NOQA
+from .abstract import (AbstractAPI, AbstractMinimalAPI,  # NOQA
+                       AbstractSwaggerUIAPI)

--- a/connexion/apis/__init__.py
+++ b/connexion/apis/__init__.py
@@ -13,4 +13,4 @@ on the framework app.
 """
 
 
-from .abstract import AbstractAPI  # NOQA
+from .abstract import AbstractAPI, AbstractMinimalAPI  # NOQA

--- a/connexion/apis/__init__.py
+++ b/connexion/apis/__init__.py
@@ -13,4 +13,4 @@ on the framework app.
 """
 
 
-from .abstract import AbstractAPI, AbstractMinimalAPI  # NOQA
+from .abstract import AbstractAPI, AbstractMinimalAPI, AbstractSwaggerUIAPI  # NOQA

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -34,40 +34,21 @@ class AbstractAPIMeta(abc.ABCMeta):
         cls._set_jsonifier()
 
 
-class AbstractMinimalAPI:
+class AbstractSpecAPI(metaclass=AbstractAPIMeta):
 
     def __init__(
             self,
             specification: t.Union[pathlib.Path, str, dict],
             base_path: t.Optional[str] = None,
             arguments: t.Optional[dict] = None,
-            resolver: t.Optional[Resolver] = None,
-            auth_all_paths: bool = False,
-            resolver_error_handler: t.Optional[t.Callable] = None,
-            debug: bool = False,
-            pass_context_arg_name: t.Optional[str] = None,
             options: t.Optional[dict] = None,
+            *args,
             **kwargs
-    ) -> None:
-        """Minimal interface of an API, with only functionality related to routing.
-
-        :param specification: OpenAPI specification. Can be provided either as dict, or as path
-        to file.
-        :param base_path: Base path to host the API.
-        :param arguments: Jinja arguments to resolve in specification.
-        :param resolver: Callable that maps operationID to a function
-        :param resolver_error_handler: Callable that generates an Operation used for handling
-        ResolveErrors
-        :param debug: Flag to run in debug mode
-        """
-        self.debug = debug
-        self.resolver_error_handler = resolver_error_handler
-
+    ):
         logger.debug('Loading specification: %s', specification,
                      extra={'swagger_yaml': specification,
                             'base_path': base_path,
-                            'arguments': arguments,
-                            'auth_all_paths': auth_all_paths})
+                            'arguments': arguments})
 
         # Avoid validator having ability to modify specification
         self.specification = Specification.load(specification, arguments=arguments)
@@ -83,6 +64,45 @@ class AbstractMinimalAPI:
 
         self._set_base_path(base_path)
 
+    def _set_base_path(self, base_path: t.Optional[str] = None) -> None:
+        if base_path is not None:
+            # update spec to include user-provided base_path
+            self.specification.base_path = base_path
+            self.base_path = base_path
+        else:
+            self.base_path = self.specification.base_path
+
+    @classmethod
+    def _set_jsonifier(cls):
+        cls.jsonifier = Jsonifier()
+
+
+class AbstractMinimalAPI(AbstractSpecAPI):
+
+    def __init__(
+            self,
+            *args,
+            resolver: t.Optional[Resolver] = None,
+            resolver_error_handler: t.Optional[t.Callable] = None,
+            debug: bool = False,
+            pass_context_arg_name: t.Optional[str] = None,
+            **kwargs
+    ) -> None:
+        """Minimal interface of an API, with only functionality related to routing.
+
+        :param specification: OpenAPI specification. Can be provided either as dict, or as path
+        to file.
+        :param base_path: Base path to host the API.
+        :param arguments: Jinja arguments to resolve in specification.
+        :param resolver: Callable that maps operationID to a function
+        :param resolver_error_handler: Callable that generates an Operation used for handling
+        ResolveErrors
+        :param debug: Flag to run in debug mode
+        """
+        super().__init__(*args, **kwargs)
+        self.debug = debug
+        self.resolver_error_handler = resolver_error_handler
+
         logger.debug('Security Definitions: %s', self.specification.security_definitions)
 
         self.resolver = resolver or Resolver()
@@ -93,14 +113,6 @@ class AbstractMinimalAPI:
         self.security_handler_factory = self.make_security_handler_factory(pass_context_arg_name)
 
         self.add_paths()
-
-    def _set_base_path(self, base_path: t.Optional[str] = None) -> None:
-        if base_path is not None:
-            # update spec to include user-provided base_path
-            self.specification.base_path = base_path
-            self.base_path = base_path
-        else:
-            self.base_path = self.specification.base_path
 
     @staticmethod
     @abc.abstractmethod
@@ -165,7 +177,40 @@ class AbstractMinimalAPI:
             raise value.with_traceback(traceback)
 
 
-class AbstractAPI(AbstractMinimalAPI, metaclass=AbstractAPIMeta):
+class AbstractSwaggerUIAPI(AbstractSpecAPI):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.options.openapi_spec_available:
+            self.add_openapi_json()
+            self.add_openapi_yaml()
+
+        if self.options.openapi_console_ui_available:
+            self.add_swagger_ui()
+
+    @abc.abstractmethod
+    def add_openapi_json(self):
+        """
+        Adds openapi spec to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
+        """
+
+    @abc.abstractmethod
+    def add_openapi_yaml(self):
+        """
+        Adds openapi spec to {base_path}/openapi.yaml
+             (or {base_path}/swagger.yaml for swagger2)
+        """
+
+    @abc.abstractmethod
+    def add_swagger_ui(self):
+        """
+        Adds swagger ui to {base_path}/ui/
+        """
+
+
+class AbstractAPI(AbstractSwaggerUIAPI, AbstractMinimalAPI):
     """
     Defines an abstract interface for a Swagger API
     """
@@ -207,31 +252,11 @@ class AbstractAPI(AbstractMinimalAPI, metaclass=AbstractAPIMeta):
                          resolver_error_handler=resolver_error_handler,
                          debug=debug, pass_context_arg_name=pass_context_arg_name, options=options)
 
-        if self.options.openapi_spec_available:
-            self.add_openapi_json()
-            self.add_openapi_yaml()
-
-        if self.options.openapi_console_ui_available:
-            self.add_swagger_ui()
-
         if auth_all_paths:
             self.add_auth_on_not_found(
                 self.specification.security,
                 self.specification.security_definitions
             )
-
-    @abc.abstractmethod
-    def add_openapi_json(self):
-        """
-        Adds openapi spec to {base_path}/openapi.json
-             (or {base_path}/swagger.json for swagger2)
-        """
-
-    @abc.abstractmethod
-    def add_swagger_ui(self):
-        """
-        Adds swagger ui to {base_path}/ui/
-        """
 
     @abc.abstractmethod
     def add_auth_on_not_found(self, security, security_definitions):
@@ -481,7 +506,3 @@ class AbstractAPI(AbstractMinimalAPI, metaclass=AbstractAPIMeta):
 
     def json_loads(self, data):
         return self.jsonifier.loads(data)
-
-    @classmethod
-    def _set_jsonifier(cls):
-        cls.jsonifier = Jsonifier()

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -15,7 +15,7 @@ from ..exceptions import ResolverError
 from ..http_facts import METHODS
 from ..jsonifier import Jsonifier
 from ..lifecycle import ConnexionResponse
-from ..operations import make_operation, AbstractOperation
+from ..operations import AbstractOperation, make_operation
 from ..options import ConnexionOptions
 from ..resolver import Resolver
 from ..spec import Specification
@@ -91,12 +91,12 @@ class AbstractMinimalAPI(AbstractSpecAPI):
         """Minimal interface of an API, with only functionality related to routing.
 
         :param specification: OpenAPI specification. Can be provided either as dict, or as path
-        to file.
+                              to file.
         :param base_path: Base path to host the API.
         :param arguments: Jinja arguments to resolve in specification.
         :param resolver: Callable that maps operationID to a function
         :param resolver_error_handler: Callable that generates an Operation used for handling
-        ResolveErrors
+                                       ResolveErrors
         :param debug: Flag to run in debug mode
         """
         super().__init__(*args, **kwargs)

--- a/connexion/apis/middleware_api.py
+++ b/connexion/apis/middleware_api.py
@@ -1,12 +1,22 @@
+import logging
 import pathlib
+import re
 import typing as t
 
+from starlette.responses import RedirectResponse, Response as StarletteResponse
 from starlette.routing import Router
+from starlette.staticfiles import StaticFiles
+from starlette.templating import Jinja2Templates
+from starlette.types import ASGIApp
 
-from connexion.apis import AbstractMinimalAPI
+from connexion.apis import AbstractMinimalAPI, AbstractSwaggerUIAPI
 from connexion.operations import make_operation, AbstractOperation
 from connexion.resolver import Resolver
 from connexion.security import MiddlewareSecurityHandlerFactory
+from connexion.utils import yamldumper
+
+
+logger = logging.getLogger('connexion.apis.middleware')
 
 
 class MiddlewareAPI(AbstractMinimalAPI):
@@ -51,3 +61,141 @@ class MiddlewareAPI(AbstractMinimalAPI):
     def make_security_handler_factory(pass_context_arg_name):
         """ Create default SecurityHandlerFactory to create all security check handlers """
         return MiddlewareSecurityHandlerFactory(pass_context_arg_name)
+
+
+class SwaggerUIAPI(AbstractSwaggerUIAPI):
+
+    def __init__(self, *args, default: ASGIApp, **kwargs):
+        self.router = Router(default=default)
+
+        super().__init__(*args, **kwargs)
+
+        self._templates = Jinja2Templates(
+            directory=str(self.options.openapi_console_ui_from_dir)
+        )
+
+    @staticmethod
+    def normalize_string(string):
+        return re.sub(r"[^a-zA-Z0-9]", "_", string.strip("/"))
+
+    def _base_path_for_prefix(self, request):
+        """
+        returns a modified basePath which includes the incoming request's
+        path prefix.
+        """
+        base_path = self.base_path
+        if not request.url.path.startswith(self.base_path):
+            prefix = request.url.path.split(self.base_path)[0]
+            base_path = prefix + base_path
+        return base_path
+
+    def _spec_for_prefix(self, request):
+        """
+        returns a spec with a modified basePath / servers block
+        which corresponds to the incoming request path.
+        This is needed when behind a path-altering reverse proxy.
+        """
+        base_path = self._base_path_for_prefix(request)
+        return self.specification.with_base_path(base_path).raw
+
+    def add_openapi_json(self):
+        """
+        Adds openapi json to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
+        """
+        logger.info(
+            "Adding spec json: %s/%s", self.base_path, self.options.openapi_spec_path
+        )
+        self.router.add_route(
+            methods=["GET"],
+            path=self.options.openapi_spec_path,
+            endpoint=self._get_openapi_json,
+        )
+
+    def add_openapi_yaml(self):
+        """
+        Adds openapi json to {base_path}/openapi.json
+             (or {base_path}/swagger.json for swagger2)
+        """
+        if not self.options.openapi_spec_path.endswith("json"):
+            return
+
+        openapi_spec_path_yaml = self.options.openapi_spec_path[: -len("json")] + "yaml"
+        logger.debug("Adding spec yaml: %s/%s", self.base_path, openapi_spec_path_yaml)
+        self.router.add_route(
+            methods=["GET"],
+            path=openapi_spec_path_yaml,
+            endpoint=self._get_openapi_yaml,
+        )
+
+    async def _get_openapi_json(self, request):
+        return StarletteResponse(
+            content=self.jsonifier.dumps(self._spec_for_prefix(request)),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    async def _get_openapi_yaml(self, request):
+        return StarletteResponse(
+            content=yamldumper(self._spec_for_prefix(request)),
+            status_code=200,
+            media_type="text/yaml",
+        )
+
+    def add_swagger_ui(self):
+        """
+        Adds swagger ui to {base_path}/ui/
+        """
+        console_ui_path = self.options.openapi_console_ui_path.strip().rstrip("/")
+        logger.debug("Adding swagger-ui: %s%s/", self.base_path, console_ui_path)
+
+        for path in (
+            console_ui_path + "/",
+            console_ui_path + "/index.html",
+        ):
+            self.router.add_route(
+                methods=["GET"], path=path, endpoint=self._get_swagger_ui_home
+            )
+
+        if self.options.openapi_console_ui_config is not None:
+            self.router.add_route(
+                methods=["GET"],
+                path=console_ui_path + "/swagger-ui-config.json",
+                endpoint=self._get_swagger_ui_config,
+            )
+
+        # we have to add an explicit redirect instead of relying on the
+        # normalize_path_middleware because we also serve static files
+        # from this dir (below)
+
+        async def redirect(request):
+            return RedirectResponse(url=self.base_path + console_ui_path + "/")
+
+        self.router.add_route(methods=["GET"], path=console_ui_path, endpoint=redirect)
+
+        # this route will match and get a permission error when trying to
+        # serve index.html, so we add the redirect above.
+        self.router.mount(
+            path=console_ui_path,
+            app=StaticFiles(directory=str(self.options.openapi_console_ui_from_dir)),
+            name="swagger_ui_static",
+        )
+
+    async def _get_swagger_ui_home(self, req):
+        base_path = self._base_path_for_prefix(req)
+        template_variables = {
+            "request": req,
+            "openapi_spec_url": (base_path + self.options.openapi_spec_path),
+            **self.options.openapi_console_ui_index_template_variables,
+        }
+        if self.options.openapi_console_ui_config is not None:
+            template_variables["configUrl"] = "swagger-ui-config.json"
+
+        return self._templates.TemplateResponse("index.j2", template_variables)
+
+    async def _get_swagger_ui_config(self, request):
+        return StarletteResponse(
+            status_code=200,
+            media_type="application/json",
+            content=self.jsonifier.dumps(self.options.openapi_console_ui_config),
+        )

--- a/connexion/apis/middleware_api.py
+++ b/connexion/apis/middleware_api.py
@@ -1,0 +1,53 @@
+import pathlib
+import typing as t
+
+from starlette.routing import Router
+
+from connexion.apis import AbstractMinimalAPI
+from connexion.operations import make_operation, AbstractOperation
+from connexion.resolver import Resolver
+from connexion.security import MiddlewareSecurityHandlerFactory
+
+
+class MiddlewareAPI(AbstractMinimalAPI):
+
+    def __init__(
+            self,
+            specification: t.Union[pathlib.Path, str, dict],
+            base_path: t.Optional[str] = None,
+            arguments: t.Optional[dict] = None,
+            resolver: t.Optional[Resolver] = None,
+            resolver_error_handler: t.Optional[t.Callable] = None,
+            debug: bool = False,
+    ) -> None:
+        """API implementation on top of Starlette Router for Connexion middleware."""
+        self.router = Router()
+
+        super().__init__(
+            specification,
+            base_path=base_path,
+            arguments=arguments,
+            resolver=resolver,
+            resolver_error_handler=resolver_error_handler,
+            debug=debug
+        )
+
+    def add_operation(self, path: str, method: str) -> None:
+        operation = make_operation(
+            self.specification,
+            self,
+            path,
+            method,
+            self.resolver
+        )
+        # Don't set decorators in middleware
+        AbstractOperation.function = operation._resolution.function
+        self._add_operation_internal(method, path, operation)
+
+    def _add_operation_internal(self, method: str, path: str, operation: AbstractOperation) -> None:
+        self.router.add_route(path, operation.function, methods=[method])
+
+    @staticmethod
+    def make_security_handler_factory(pass_context_arg_name):
+        """ Create default SecurityHandlerFactory to create all security check handlers """
+        return MiddlewareSecurityHandlerFactory(pass_context_arg_name)

--- a/connexion/apis/middleware_api.py
+++ b/connexion/apis/middleware_api.py
@@ -3,18 +3,18 @@ import pathlib
 import re
 import typing as t
 
-from starlette.responses import RedirectResponse, Response as StarletteResponse
+from starlette.responses import RedirectResponse
+from starlette.responses import Response as StarletteResponse
 from starlette.routing import Router
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.types import ASGIApp
 
 from connexion.apis import AbstractMinimalAPI, AbstractSwaggerUIAPI
-from connexion.operations import make_operation, AbstractOperation
+from connexion.operations import AbstractOperation, make_operation
 from connexion.resolver import Resolver
 from connexion.security import MiddlewareSecurityHandlerFactory
 from connexion.utils import yamldumper
-
 
 logger = logging.getLogger('connexion.apis.middleware')
 

--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseHTTPMiddleware
+from .main import ConnexionMiddleware
+from .routing import RoutingMiddleware
+from .test import TestMiddleware

--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseHTTPMiddleware
 from .main import ConnexionMiddleware
 from .routing import RoutingMiddleware
+from .swagger_ui import SwaggerUIMiddleware
 from .test import TestMiddleware

--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,5 +1,5 @@
-from .base import BaseHTTPMiddleware
-from .main import ConnexionMiddleware
-from .routing import RoutingMiddleware
-from .swagger_ui import SwaggerUIMiddleware
-from .test import TestMiddleware
+from .base import BaseHTTPMiddleware  # NOQA
+from .main import ConnexionMiddleware  # NOQA
+from .routing import RoutingMiddleware  # NOQA
+from .swagger_ui import SwaggerUIMiddleware  # NOQA
+from .test import TestMiddleware  # NOQA

--- a/connexion/middleware/base.py
+++ b/connexion/middleware/base.py
@@ -1,4 +1,6 @@
+import json
 import typing
+from urllib.parse import parse_qs
 
 import anyio
 from starlette.requests import Request as StarletteRequest
@@ -67,6 +69,8 @@ class BaseHTTPMiddleware:
 
         async with anyio.create_task_group() as task_group:
             request = StarletteRequest(scope, receive=receive)
+            # request = await self.starlette_to_connexion_request(request)
+            request = transform_request(request)
             operation = scope["operation"]
             response = await self.dispatch_func(request, operation, call_next)
             await response(scope, receive, send)
@@ -93,3 +97,10 @@ class BaseHTTPMiddleware:
         :return: Manipulated response
         """
         raise NotImplementedError()  # pragma: no cover
+
+
+def transform_request(req: StarletteRequest) -> StarletteRequest:
+    # TODO: cast to connexion request instead
+    req.query = parse_qs(req.url.query)
+    req.context = {}
+    return req

--- a/connexion/middleware/base.py
+++ b/connexion/middleware/base.py
@@ -1,0 +1,95 @@
+import typing
+
+import anyio
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse, StreamingResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.operations import AbstractOperation
+
+
+RequestResponseEndpoint = typing.Callable[[StarletteRequest], typing.Awaitable[StreamingResponse]]
+DispatchFunction = typing.Callable[
+    [StarletteRequest, 'Operation', RequestResponseEndpoint], typing.Awaitable[StarletteResponse]
+]
+
+
+class BaseHTTPMiddleware:
+
+    def __init__(self, app: ASGIApp, dispatch: DispatchFunction = None) -> None:
+        """Base Middleware to subclass. Provides easy access to request and operation."""
+        self.app = app
+        self.dispatch_func = self.dispatch if dispatch is None else dispatch
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def call_next(request: StarletteRequest) -> StarletteResponse:
+            app_exc: typing.Optional[Exception] = None
+            send_stream, recv_stream = anyio.create_memory_object_stream()
+
+            async def coro() -> None:
+                nonlocal app_exc
+
+                async with send_stream:
+                    try:
+                        await self.app(scope, request.receive, send_stream.send)
+                    except Exception as exc:
+                        app_exc = exc
+
+            task_group.start_soon(coro)
+
+            try:
+                message = await recv_stream.receive()
+            except anyio.EndOfStream:
+                if app_exc is not None:
+                    raise app_exc
+                raise RuntimeError("No response returned.")
+
+            assert message["type"] == "http.response.start"
+
+            async def body_stream() -> typing.AsyncGenerator[bytes, None]:
+                async with recv_stream:
+                    async for message in recv_stream:
+                        assert message["type"] == "http.response.body"
+                        yield message.get("body", b"")
+
+                if app_exc is not None:
+                    raise app_exc
+
+            response = StreamingResponse(
+                status_code=message["status"], content=body_stream()
+            )
+            response.raw_headers = message["headers"]
+            return response
+
+        async with anyio.create_task_group() as task_group:
+            request = StarletteRequest(scope, receive=receive)
+            operation = scope["operation"]
+            response = await self.dispatch_func(request, operation, call_next)
+            await response(scope, receive, send)
+            await task_group.cancel_scope.cancel()
+
+    async def dispatch(
+        self,
+            request: StarletteRequest,
+            operation: AbstractOperation,
+            call_next: RequestResponseEndpoint
+    ) -> StarletteResponse:
+        """Function to implement in subclass.
+
+        def dispatch(...):
+            # Manipulate request
+            response = await call_next(request)
+            # Manipulate response
+            return response
+
+        :param request: Incoming request.
+        :param operation: Operation matching the incoming request.
+        :param call_next: Utility function to call then next App.
+
+        :return: Manipulated response
+        """
+        raise NotImplementedError()  # pragma: no cover

--- a/connexion/middleware/base.py
+++ b/connexion/middleware/base.py
@@ -1,18 +1,18 @@
-import json
 import typing
 from urllib.parse import parse_qs
 
 import anyio
 from starlette.requests import Request as StarletteRequest
-from starlette.responses import Response as StarletteResponse, StreamingResponse
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.operations import AbstractOperation
 
-
 RequestResponseEndpoint = typing.Callable[[StarletteRequest], typing.Awaitable[StreamingResponse]]
 DispatchFunction = typing.Callable[
-    [StarletteRequest, 'Operation', RequestResponseEndpoint], typing.Awaitable[StarletteResponse]
+    [StarletteRequest, AbstractOperation, RequestResponseEndpoint],
+    typing.Awaitable[StarletteResponse]
 ]
 
 

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -5,8 +5,8 @@ from starlette.exceptions import ExceptionMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.middleware.routing import RoutingMiddleware
-from connexion.middleware.swagger_ui import SwaggerUIMiddleware
 from connexion.middleware.security import SecurityMiddleware
+from connexion.middleware.swagger_ui import SwaggerUIMiddleware
 
 
 class MissingMiddlewareError(Exception):
@@ -32,7 +32,7 @@ class ConnexionMiddleware:
 
         :param app: App to wrap middleware around.
         :param middlewares: List of middlewares to wrap around app. The list should be ordered
-        from outer to inner middleware.
+                            from outer to inner middleware.
         """
         if middlewares is None:
             middlewares = self.default_middlewares
@@ -48,7 +48,7 @@ class ConnexionMiddleware:
 
         :param app: App to wrap in middlewares.
         :param middlewares: List of middlewares to wrap around app. The list should be ordered
-        from outer to inner middleware.
+                            from outer to inner middleware.
 
         :return: App with all middlewares applied.
         """

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -6,6 +6,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.middleware.routing import RoutingMiddleware
 from connexion.middleware.swagger_ui import SwaggerUIMiddleware
+from connexion.middleware.security import SecurityMiddleware
 
 
 class MissingMiddlewareError(Exception):
@@ -18,6 +19,7 @@ class ConnexionMiddleware:
         ExceptionMiddleware,
         SwaggerUIMiddleware,
         RoutingMiddleware,
+        SecurityMiddleware,
     ]
 
     def __init__(

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -1,0 +1,88 @@
+import pathlib
+import typing as t
+
+from starlette.exceptions import ExceptionMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.middleware.routing import RoutingMiddleware
+
+
+class MissingMiddlewareError(Exception):
+    pass
+
+
+class ConnexionMiddleware:
+
+    default_middlewares = [
+        ExceptionMiddleware,
+        RoutingMiddleware,
+    ]
+
+    def __init__(
+            self,
+            app: ASGIApp,
+            middlewares: t.Optional[t.List[t.Type[ASGIApp]]] = None
+    ):
+        """High level Connexion middleware that manages a list o middlewares wrapped around an
+        application.
+
+        :param app: App to wrap middleware around.
+        :param middlewares: List of middlewares to wrap around app. The list should be ordered
+        from outer to inner middleware.
+        """
+        if middlewares is None:
+            middlewares = self.default_middlewares
+        self.app, self.apps = self._apply_middlewares(app, middlewares)
+
+        self._routing_middleware = None
+
+    @staticmethod
+    def _apply_middlewares(app: ASGIApp, middlewares: t.List[t.Type[ASGIApp]]) \
+            -> t.Tuple[ASGIApp, t.List[ASGIApp]]:
+        """Apply all middlewares to the provided app.
+
+        :param app: App to wrap in middlewares.
+        :param middlewares: List of middlewares to wrap around app. The list should be ordered
+        from outer to inner middleware.
+
+        :return: App with all middlewares applied.
+        """
+        apps = []
+        for middleware in reversed(middlewares):
+            app = middleware(app)
+            apps.append(app)
+        return app, apps
+
+    @property
+    def routing_middleware(self) -> RoutingMiddleware:
+        """Instance of RoutingMiddleware applied to app.
+
+        :raises: MissingMiddlewareError if no routing middleware is applied.
+        """
+        if self._routing_middleware is None:
+            for app in self.apps:
+                if isinstance(app, RoutingMiddleware):
+                    self._routing_middleware = app
+                    break
+            else:
+                raise MissingMiddlewareError(
+                    "No routing middleware is applied"
+                )
+        return self._routing_middleware
+
+    def add_api(
+            self,
+            specification: t.Union[pathlib.Path, str, dict],
+            base_path: t.Optional[str] = None,
+            arguments: t.Optional[dict] = None,
+    ) -> None:
+        """Add an API to the underlying routing middleware based on a OpenAPI spec.
+
+        :param specification: OpenAPI spec as dict or path to file.
+        :param base_path: Base path where to add this API.
+        :param arguments: Jinja arguments to replace in the spec.
+        """
+        self.routing_middleware.add_api(specification, base_path, arguments)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self.app(scope, receive, send)

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -1,18 +1,18 @@
 import pathlib
 import typing as t
-from functools import partial
 from contextvars import ContextVar
+from functools import partial
 
 import anyio
 from starlette.requests import Request as StarletteRequest
-from starlette.responses import Response as StarletteResponse, StreamingResponse
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse
 from starlette.routing import Router
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.apis.middleware_api import MiddlewareAPI
 from connexion.operations import AbstractOperation
 from connexion.resolver import Resolver
-
 
 # Context variable that is set to starlette call_next function with current request
 _call_next_fn: ContextVar[t.Callable] = ContextVar('CALL_NEXT')

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -1,0 +1,137 @@
+import pathlib
+import typing as t
+from functools import partial
+from contextvars import ContextVar
+
+import anyio
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse, StreamingResponse
+from starlette.routing import Router
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.apis.middleware_api import MiddlewareAPI
+from connexion.operations import AbstractOperation
+from connexion.resolver import Resolver
+
+
+# Context variable that is set to starlette call_next function with current request
+_call_next_fn: ContextVar[t.Callable] = ContextVar('CALL_NEXT')
+
+
+async def call_next_callback(operation: AbstractOperation, _request: StarletteRequest) \
+        -> StarletteResponse:
+    """Callback to call next app with current request."""
+    return await _call_next_fn.get()(operation)
+
+
+class MiddlewareResolver(Resolver):
+
+    def __init__(self, call_next: t.Callable) -> None:
+        """Resolver that resolves each operation to the provided call_next function."""
+        super().__init__()
+        self.call_next = call_next
+
+    def resolve_function_from_operation_id(self, operation_id: str) -> t.Callable:
+        return self.call_next
+
+
+class RoutingMiddleware:
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Middleware that resolves the Operation for an incoming request and attaches it to the
+        scope.
+
+        :param app: app to wrap in middleware.
+        """
+        self.app = app
+        self.router = Router()
+
+    def add_api(
+            self,
+            specification: t.Union[pathlib.Path, str, dict],
+            base_path: t.Optional[str] = None,
+            arguments: t.Optional[dict] = None,
+    ) -> None:
+        """Add an API to the router based on a OpenAPI spec.
+
+        :param specification: OpenAPI spec as dict or path to file.
+        :param base_path: Base path where to add this API.
+        :param arguments: Jinja arguments to replace in the spec.
+        """
+        resolver = MiddlewareResolver(call_next_callback)
+        api = MiddlewareAPI(specification, base_path=base_path, arguments=arguments,
+                            resolver=resolver)
+        self.router.mount(api.base_path, app=api.router)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Route request to matching operation, and attach it to the scope before calling the
+        next app."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        call_next = self._create_call_next(scope)
+
+        async with anyio.create_task_group() as task_group:
+            request = StarletteRequest(scope, receive=receive)
+            call_next_ = partial(call_next, request, task_group)
+            _call_next_fn.set(call_next_)
+
+            await self.router(scope, receive, send)
+            await task_group.cancel_scope.cancel()
+
+    def _create_call_next(self, scope: Scope) -> t.Callable:
+        """Create callable to call next app."""
+
+        async def call_next(request: StarletteRequest, task_group: anyio.abc.TaskGroup) \
+                -> StarletteResponse:
+            """Adapted from starlette.middleware.base.BaseHTTPMiddleware"""
+            app_exc: t.Optional[Exception] = None
+            send_stream, recv_stream = anyio.create_memory_object_stream()
+
+            async def coro() -> None:
+                nonlocal app_exc
+
+                async with send_stream:
+                    try:
+                        await self.app(scope, request.receive, send_stream.send)
+                    except Exception as exc:
+                        app_exc = exc
+
+            task_group.start_soon(coro)
+
+            try:
+                message = await recv_stream.receive()
+            except anyio.EndOfStream:
+                if app_exc is not None:
+                    raise app_exc
+                raise RuntimeError("No response returned.")
+
+            assert message["type"] == "http.response.start"
+
+            async def body_stream() -> t.AsyncGenerator[bytes, None]:
+                async with recv_stream:
+                    async for msg in recv_stream:
+                        assert msg["type"] == "http.response.body"
+                        yield msg.get("body", b"")
+
+                if app_exc is not None:
+                    raise app_exc
+
+            response = StreamingResponse(
+                status_code=message["status"], content=body_stream()
+            )
+
+            response.raw_headers = message["headers"]
+            return response
+
+        async def attach_operation_and_call_next(
+                request: StarletteRequest,
+                task_group: anyio.abc.TaskGroup,
+                operation: AbstractOperation
+        ) -> StarletteResponse:
+            """Attach operation to scope and pass it to the next app"""
+            scope["operation"] = operation
+            return await call_next(request, task_group)
+
+        return attach_operation_and_call_next

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -1,0 +1,16 @@
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
+
+from connexion.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from connexion.operations import AbstractOperation
+
+
+class SecurityMiddleware(BaseHTTPMiddleware):
+    """Middleware to check security."""
+
+    async def dispatch(self, request: StarletteRequest, operation: AbstractOperation,
+                       call_next: RequestResponseEndpoint) -> StarletteResponse:
+        # Shortcut for now, should be implemented cleanly
+        await operation.security_decorator(lambda _: None)(request)
+        response = await call_next(request)
+        return response

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -1,7 +1,8 @@
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 
-from connexion.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from connexion.middleware.base import (BaseHTTPMiddleware,
+                                       RequestResponseEndpoint)
 from connexion.operations import AbstractOperation
 
 

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -1,0 +1,38 @@
+import pathlib
+import typing as t
+
+from starlette.routing import Router
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.apis.middleware_api import SwaggerUIAPI
+
+
+class SwaggerUIMiddleware:
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Middleware that hosts a swagger UI.
+
+        :param app: app to wrap in middleware.
+        """
+        self.app = app
+        # Pass unknown routes to next app
+        self.router = Router(default=self.app)
+
+    def add_api(
+            self,
+            specification: t.Union[pathlib.Path, str, dict],
+            base_path: t.Optional[str] = None,
+            arguments: t.Optional[dict] = None,
+    ) -> None:
+        """Add an API to the router based on a OpenAPI spec.
+
+        :param specification: OpenAPI spec as dict or path to file.
+        :param base_path: Base path where to add this API.
+        :param arguments: Jinja arguments to replace in the spec.
+        """
+        api = SwaggerUIAPI(specification, base_path=base_path, arguments=arguments,
+                           default=self.app)
+        self.router.mount(api.base_path, app=api.router)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self.router(scope, receive, send)

--- a/connexion/middleware/test.py
+++ b/connexion/middleware/test.py
@@ -1,0 +1,15 @@
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
+
+from connexion.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from connexion.operations import AbstractOperation
+
+
+class TestMiddleware(BaseHTTPMiddleware):
+    """Middleware to check if operation is accessible on scope."""
+
+    async def dispatch(self, request: StarletteRequest, operation: AbstractOperation,
+                       call_next: RequestResponseEndpoint) -> StarletteResponse:
+        response = await call_next(request)
+        response.headers.update({'operation_id': operation.operation_id})
+        return response

--- a/connexion/middleware/test.py
+++ b/connexion/middleware/test.py
@@ -1,7 +1,8 @@
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 
-from connexion.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from connexion.middleware.base import (BaseHTTPMiddleware,
+                                       RequestResponseEndpoint)
 from connexion.operations import AbstractOperation
 
 

--- a/connexion/security/__init__.py
+++ b/connexion/security/__init__.py
@@ -21,3 +21,8 @@ try:
     from .aiohttp_security_handler_factory import AioHttpSecurityHandlerFactory
 except ImportError as err:  # pragma: no cover
     AioHttpSecurityHandlerFactory = not_installed_error(err)
+
+try:
+    from .middleware_security_handler_factory import MiddlewareSecurityHandlerFactory
+except ImportError as err:  # pragma: no cover
+    MiddlewareSecurityHandlerFactory = not_installed_error(err)

--- a/connexion/security/middleware_security_handler_factory.py
+++ b/connexion/security/middleware_security_handler_factory.py
@@ -1,0 +1,29 @@
+"""
+"""
+
+import logging
+
+from .async_security_handler_factory import AbstractAsyncSecurityHandlerFactory
+
+logger = logging.getLogger('connexion.api.security')
+
+
+class MiddlewareSecurityHandlerFactory(AbstractAsyncSecurityHandlerFactory):
+    def __init__(self, pass_context_arg_name):
+        super().__init__(pass_context_arg_name=pass_context_arg_name)
+        self.client_session = None
+
+    def get_token_info_remote(self, token_info_url):
+        """
+        Return a function which will call `token_info_url` to retrieve token info.
+
+        Returned function must accept oauth token in parameter.
+        It must return a token_info dict in case of success, None otherwise.
+
+        :param token_info_url: Url to get information about the token
+        :type token_info_url: str
+        :rtype: types.FunctionType
+        """
+        async def wrapper(token):
+            return
+        return wrapper

--- a/test_middleware/flask_app.py
+++ b/test_middleware/flask_app.py
@@ -1,0 +1,28 @@
+from asgiref.wsgi import WsgiToAsgi
+from flask import Flask, json, request
+
+
+from connexion.middleware import ConnexionMiddleware, TestMiddleware
+
+
+# Simple Flask app. Can be any WSGI framework if we use WsgiToAsgi adapter.
+
+app = Flask(__name__)
+
+
+@app.route('/test')
+def test():
+    value = request.args.get('int')
+
+    if value == '1':
+        value = int(value)
+
+    return json.dumps({'int': value})
+
+
+# Add connexion middleware.
+
+middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware, WsgiToAsgi]
+
+app = ConnexionMiddleware(app, middlewares=middlewares)
+app.add_api('openapi.yaml')

--- a/test_middleware/openapi.yaml
+++ b/test_middleware/openapi.yaml
@@ -21,7 +21,16 @@ paths:
                 properties:
                   int:
                     type: integer
-
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: key
+      in: query
+      x-apikeyInfoFunc: security.apikey_info
+      
+security:
+  - api_key: []
 
 
 

--- a/test_middleware/openapi.yaml
+++ b/test_middleware/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: 'app'
+  version: '1.0'
+paths:
+  /test:
+    get:
+      operationId: success
+      parameters:
+        - name: int
+          in: query
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  int:
+                    type: integer
+
+
+
+

--- a/test_middleware/quart_app.py
+++ b/test_middleware/quart_app.py
@@ -1,0 +1,27 @@
+from quart import Quart, json, request
+
+
+from connexion.middleware import ConnexionMiddleware, TestMiddleware
+
+
+# Simple Flask app. Can be any WSGI framework if we use WsgiToAsgi adapter.
+
+app = Quart(__name__)
+
+
+@app.route('/test')
+def test():
+    value = request.args.get('int')
+
+    if value == '1':
+        value = int(value)
+
+    return json.dumps({'int': value})
+
+
+# Add connexion middleware.
+
+middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]
+
+app = ConnexionMiddleware(app, middlewares=middlewares)
+app.add_api('openapi.yaml')

--- a/test_middleware/requirements.txt
+++ b/test_middleware/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.0.3
+quart==0.16.3
+sanic==20.12.6  # Bug in newer versions
+starlette==0.18.0

--- a/test_middleware/sanic_app.py
+++ b/test_middleware/sanic_app.py
@@ -1,0 +1,28 @@
+from sanic import Sanic
+from sanic.response import json
+
+
+from connexion.middleware import ConnexionMiddleware, SwaggerUIMiddleware, TestMiddleware
+
+
+# Simple Sanic app. Can be any ASGI framework.
+
+app = Sanic('test')
+
+
+@app.route('/test')
+async def test(request):
+    value = request.args.get('int')
+
+    if value == '1':
+        value = int(value)
+
+    return json({'int': value})
+
+
+# Add connexion middleware.
+
+middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]
+
+app = ConnexionMiddleware(app, middlewares=middlewares)
+app.add_api('openapi.yaml')

--- a/test_middleware/sanic_app_issue.py
+++ b/test_middleware/sanic_app_issue.py
@@ -1,0 +1,30 @@
+from sanic import Sanic
+from sanic.response import json
+
+
+from starlette.exceptions import ExceptionMiddleware
+
+
+app = Sanic('test')
+
+
+@app.route('/test')
+async def test(request):
+    value = request.args.get('int')
+
+    if value == '1':
+        value = int(value)
+
+    return json({'int': value})
+
+
+class SimpleMiddleware:
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        await self.app(scope, receive, send)
+
+
+wrapped_app = SimpleMiddleware(app)

--- a/test_middleware/security.py
+++ b/test_middleware/security.py
@@ -1,0 +1,3 @@
+
+async def apikey_info(token, required_scopes):
+    return {'uid': 100}

--- a/test_middleware/starlette_app.py
+++ b/test_middleware/starlette_app.py
@@ -1,0 +1,29 @@
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from connexion.middleware import ConnexionMiddleware, TestMiddleware
+
+
+# Simple Starlette app. Can be any ASGI framework.
+
+async def test(request):
+    value = request.query_params.get('int')
+
+    if value == '1':
+        value = int(value)
+
+    return JSONResponse({'int': value})
+
+
+app = Starlette(debug=True, routes=[
+    Route('/test', test),
+])
+
+
+# Add connexion middleware.
+
+middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]
+
+app = ConnexionMiddleware(app, middlewares=middlewares)
+app.add_api('openapi.yaml')

--- a/test_middleware/test.py
+++ b/test_middleware/test.py
@@ -1,0 +1,48 @@
+import contextlib
+import time
+import threading
+
+import requests
+import uvicorn
+
+
+class Server(uvicorn.Server):
+    def install_signal_handlers(self):
+        pass
+
+    @contextlib.contextmanager
+    def run_in_thread(self):
+        thread = threading.Thread(target=self.run)
+        thread.start()
+        try:
+            while not self.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = True
+            thread.join()
+
+
+apps = [
+    'flask_app',
+    'quart_app',
+    'sanic_app',
+    'starlette_app'
+]
+
+
+def test_app(app):
+    print(f'Testing {app}')
+    config = uvicorn.Config(f'{app}:app', host="127.0.0.1", port=8000, log_level="info")
+    server = Server(config=config)
+
+    with server.run_in_thread():
+        response = requests.get('http://localhost:8000/test', params={'int': 1})
+
+    assert response.headers.get('operation_id') == 'success'
+    print(response.headers.get('operation_id'))
+    print()
+
+
+for app in apps:
+    test_app(app)

--- a/test_middleware/test.py
+++ b/test_middleware/test.py
@@ -37,7 +37,8 @@ def test_app(app):
     server = Server(config=config)
 
     with server.run_in_thread():
-        response = requests.get('http://localhost:8000/test', params={'int': 1})
+        response = requests.get('http://localhost:8000/test', params={'int': 1,
+                                                                      'key': 'abc'})
 
     assert response.headers.get('operation_id') == 'success'
     print(response.headers.get('operation_id'))


### PR DESCRIPTION
This PR implements a proof of concept to move most of the Connexion functionality to ASGI middleware. This middleware can be wrapped around any ASGI (and WSGI by using an adapter) compliant framework, greatly increasing the compatibility of connexion.

There is one `ConnexionMiddleware` component, which manages a pluggable list of ASGI middlewares. Similar to the [middlewares mechanism of Django](https://docs.djangoproject.com/en/4.0/topics/http/middleware/).

![image](https://user-images.githubusercontent.com/20990866/156630433-b9652b63-7d9a-4583-aa48-ee391f4f7703.png)

Note that I used Starlette for the implementation, but as an ASGI toolkit, not as a web framework. The result is not limited to Starlette, but framework-agnostic.

You can find some example apps in the [`test_middleware`](https://github.com/spec-first/connexion/tree/feature/middleware/test_middleware) directory, showing compatibility with Flask, Quart, Sanic, and Starlette.

Eg. `starlette_app.py`:
```python
from starlette.applications import Starlette
from starlette.responses import JSONResponse
from starlette.routing import Route

from connexion.middleware import ConnexionMiddleware, TestMiddleware


# Simple Starlette app. Can be any ASGI framework.

async def test(request):
    value = request.query_params.get('int')

    if value == '1':
        value = int(value)

    return JSONResponse({'int': value})


app = Starlette(debug=True, routes=[
    Route('/test', test),
])


# Add connexion middleware.

middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]

app = ConnexionMiddleware(app, middlewares=middlewares)
app.add_api('openapi.yaml')
```

This PR is quite big, but I split the work into logical commits. Once we want to start actually reviewing this, I'll submit them as separate PRs with more info.