### PR TITLE
Remove obsolete code from basicauth example

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -19,8 +19,8 @@ field that is either a space-separated list or an array of scopes belonging to
 the supplied token. This list of scopes will be validated against the scopes
 required by the API security definition to determine if the user is authorized.
 You can supply a custom scope validation func with ``x-scopeValidateFunc``
-or set ``SCOPEVALIDATE_FUNC`` env var, otherwise
-``connexion.decorators.security.validate_scope`` will be used as default.
+or set ``SCOPEVALIDATE_FUNC`` env var, otherwise default scope validation function
+``connexion.security.security_handler_factory.validate_scope`` will be used automatically.
 
 
 The recommended approach is to return a dict which complies with

--- a/examples/openapi3/basicauth/README.rst
+++ b/examples/openapi3/basicauth/README.rst
@@ -11,10 +11,4 @@ Running:
 
 Now open your browser and go to http://localhost:8080/ui/ to see the Swagger UI.
 
-The hardcoded credentials are ``admin`` and ``secret``. For an example with
-correct authentication but missing access rights, use ``foo`` and ``bar``.
-
-For a more simple example which doesn't use oauth scope for authorization see
-the `Swagger2 Basic Auth example`_.
-
-.. _Swagger2 Basic Auth example: https://github.com/zalando/connexion/tree/master/examples/swagger2/basicauth
+The hardcoded credentials are ``admin:secret`` and ``foo:bar``.

--- a/examples/openapi3/basicauth/app.py
+++ b/examples/openapi3/basicauth/app.py
@@ -10,7 +10,7 @@ PASSWD={
     'foo': 'bar'
 }
 
-def basic_auth(username, password, required_scopes=None) -> dict:
+def basic_auth(username, password, required_scopes=None):
     if PASSWD.get(username) == password:
         return {'sub': username}
     return None

--- a/examples/openapi3/basicauth/app.py
+++ b/examples/openapi3/basicauth/app.py
@@ -5,14 +5,15 @@ Basic example of a resource server
 
 import connexion
 
-PASSWD={
+PASSWD = {
     'admin': 'secret',
     'foo': 'bar'
 }
 
-def basic_auth(username, password, required_scopes=None):
+def basic_auth(username, password):
     if PASSWD.get(username) == password:
         return {'sub': username}
+    # optional: raise exception for custom error response
     return None
 
 def get_secret(user) -> str:

--- a/examples/openapi3/basicauth/app.py
+++ b/examples/openapi3/basicauth/app.py
@@ -4,8 +4,6 @@ Basic example of a resource server
 '''
 
 import connexion
-from connexion.decorators.security import validate_scope
-from connexion.exceptions import OAuthScopeProblem
 
 
 def basic_auth(username, password, required_scopes=None):
@@ -16,14 +14,6 @@ def basic_auth(username, password, required_scopes=None):
     else:
         # optional: raise exception for custom error response
         return None
-
-    # optional
-    if required_scopes is not None and not validate_scope(required_scopes, info['scope']):
-        raise OAuthScopeProblem(
-                description='Provided user doesn\'t have the required access rights',
-                required_scopes=required_scopes,
-                token_scopes=info['scope']
-            )
 
     return info
 

--- a/examples/openapi3/basicauth/app.py
+++ b/examples/openapi3/basicauth/app.py
@@ -10,7 +10,7 @@ PASSWD={
     'foo': 'bar'
 }
 
-def basic_auth(username, password, required_scopes=None):
+def basic_auth(username, password, required_scopes=None) -> dict:
     if PASSWD.get(username) == password:
         return {'sub': username}
     return None

--- a/examples/openapi3/basicauth/app.py
+++ b/examples/openapi3/basicauth/app.py
@@ -5,18 +5,15 @@ Basic example of a resource server
 
 import connexion
 
+PASSWD={
+    'admin': 'secret',
+    'foo': 'bar'
+}
 
 def basic_auth(username, password, required_scopes=None):
-    if username == 'admin' and password == 'secret':
-        info = {'sub': 'admin', 'scope': 'secret'}
-    elif username == 'foo' and password == 'bar':
-        info = {'sub': 'user1', 'scope': ''}
-    else:
-        # optional: raise exception for custom error response
-        return None
-
-    return info
-
+    if PASSWD.get(username) == password:
+        return {'sub': username}
+    return None
 
 def get_secret(user) -> str:
     return f"You are {user} and the secret is 'wbevuec'"

--- a/examples/swagger2/basicauth/README.rst
+++ b/examples/swagger2/basicauth/README.rst
@@ -11,9 +11,4 @@ Running:
 
 Now open your browser and go to http://localhost:8080/ui/ to see the Swagger UI.
 
-The hardcoded credentials are ``admin`` and ``secret``.
-
-For a more advanced example which reuses oauth scope for authorization see
-the `OpenAPI3 Basic Auth example`_.
-
-.. _OpenAPI3 Basic Auth example: https://github.com/zalando/connexion/tree/master/examples/openapi3/basicauth
+The hardcoded credentials are ``admin:secret`` and ``foo:bar``.

--- a/examples/swagger2/basicauth/app.py
+++ b/examples/swagger2/basicauth/app.py
@@ -5,14 +5,16 @@ Basic example of a resource server
 
 import connexion
 
+PASSWD = {
+    'admin': 'secret',
+    'foo': 'bar'
+}
 
-def basic_auth(username, password, required_scopes=None):
-    if username == 'admin' and password == 'secret':
-        return {'sub': 'admin'}
-
+def basic_auth(username, password):
+    if PASSWD.get(username) == password:
+        return {'sub': username}
     # optional: raise exception for custom error response
     return None
-
 
 def get_secret(user) -> str:
     return f"You are {user} and the secret is 'wbevuec'"


### PR DESCRIPTION
Fixes #1471 / #1485

Changes proposed in this pull request:

 - Remove obsolete code (see the beginning of #1485 for concrete reasoning)
 - Remove scopes completely except necessary arg in `x-basicInfoFunc` implementation