### PR TITLE
Add empty connexion middleware

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -55,6 +55,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
         self.server = server
         self.server_args = dict() if server_args is None else server_args
         self.app = self.create_app()
+        self.apply_middleware()
 
         # we get our application root path to avoid duplicating logic
         self.root_path = self.get_root_path()
@@ -76,6 +77,12 @@ class AbstractApp(metaclass=abc.ABCMeta):
     def create_app(self):
         """
         Creates the user framework application
+        """
+
+    @abc.abstractmethod
+    def apply_middleware(self):
+        """
+        Apply middleware to application
         """
 
     @abc.abstractmethod
@@ -243,12 +250,3 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type debug: bool
         :param options: options to be forwarded to the underlying server
         """
-
-    def __call__(self, environ, start_response):  # pragma: no cover
-        """
-        Makes the class callable to be WSGI-compliant. As Flask is used to handle requests,
-        this is a passthrough-call to the Flask callable class.
-        This is an abstraction to avoid directly referencing the app attribute from outside the
-        class and protect it from unwanted modification.
-        """
-        return self.app(environ, start_response)

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -55,7 +55,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
         self.server = server
         self.server_args = dict() if server_args is None else server_args
         self.app = self.create_app()
-        self.apply_middleware()
+        self._apply_middleware()
 
         # we get our application root path to avoid duplicating logic
         self.root_path = self.get_root_path()
@@ -80,7 +80,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def apply_middleware(self):
+    def _apply_middleware(self):
         """
         Apply middleware to application
         """

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -42,7 +42,7 @@ class FlaskApp(AbstractApp):
         app.url_map.converters['int'] = IntegerConverter
         return app
 
-    def apply_middleware(self):
+    def _apply_middleware(self):
         middlewares = [*ConnexionMiddleware.default_middlewares,
                        a2wsgi.WSGIMiddleware]
         self.middleware = ConnexionMiddleware(self.app.wsgi_app, middlewares=middlewares)

--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -8,12 +8,14 @@ import pathlib
 from decimal import Decimal
 from types import FunctionType  # NOQA
 
+import a2wsgi
 import flask
 import werkzeug.exceptions
 from flask import json, signals
 
 from ..apis.flask_api import FlaskApi
 from ..exceptions import ProblemException
+from ..middleware import ConnexionMiddleware
 from ..problem import problem
 from .abstract import AbstractApp
 
@@ -28,8 +30,10 @@ class FlaskApp(AbstractApp):
 
         See :class:`~connexion.AbstractApp` for additional parameters.
         """
-        super().__init__(import_name, FlaskApi, server=server, **kwargs)
         self.extra_files = extra_files or []
+        self.middleware = None
+
+        super().__init__(import_name, FlaskApi, server=server, **kwargs)
 
     def create_app(self):
         app = flask.Flask(self.import_name, **self.server_args)
@@ -37,6 +41,14 @@ class FlaskApp(AbstractApp):
         app.url_map.converters['float'] = NumberConverter
         app.url_map.converters['int'] = IntegerConverter
         return app
+
+    def apply_middleware(self):
+        middlewares = [*ConnexionMiddleware.default_middlewares,
+                       a2wsgi.WSGIMiddleware]
+        self.middleware = ConnexionMiddleware(self.app.wsgi_app, middlewares=middlewares)
+
+        # Wrap with ASGI to WSGI middleware for usage with development server and test client
+        self.app.wsgi_app = a2wsgi.ASGIMiddleware(self.middleware)
 
     def get_root_path(self):
         return pathlib.Path(self.app.root_path)
@@ -146,6 +158,12 @@ class FlaskApp(AbstractApp):
             http_server.serve_forever()
         else:
             raise Exception(f'Server {self.server} not recognized')
+
+    def __call__(self, scope, receive, send):  # pragma: no cover
+        """
+        ASGI interface. Calls the middleware wrapped around the wsgi app.
+        """
+        return self.middleware(scope, receive, send)
 
 
 class FlaskJSONEncoder(json.JSONEncoder):

--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,0 +1,1 @@
+from .main import ConnexionMiddleware  # NOQA

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -1,0 +1,65 @@
+import pathlib
+import typing as t
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class MissingMiddlewareError(Exception):
+    pass
+
+
+class ConnexionMiddleware:
+
+    default_middlewares = [
+    ]
+
+    def __init__(
+            self,
+            app: ASGIApp,
+            middlewares: t.Optional[t.List[t.Type[ASGIApp]]] = None
+    ):
+        """High level Connexion middleware that manages a list o middlewares wrapped around an
+        application.
+
+        :param app: App to wrap middleware around.
+        :param middlewares: List of middlewares to wrap around app. The list should be ordered
+                            from outer to inner middleware.
+        """
+        if middlewares is None:
+            middlewares = self.default_middlewares
+        self.app, self.apps = self._apply_middlewares(app, middlewares)
+
+        self._routing_middleware = None
+
+    @staticmethod
+    def _apply_middlewares(app: ASGIApp, middlewares: t.List[t.Type[ASGIApp]]) \
+            -> t.Tuple[ASGIApp, t.List[ASGIApp]]:
+        """Apply all middlewares to the provided app.
+
+        :param app: App to wrap in middlewares.
+        :param middlewares: List of middlewares to wrap around app. The list should be ordered
+                            from outer to inner middleware.
+
+        :return: App with all middlewares applied.
+        """
+        apps = []
+        for middleware in reversed(middlewares):
+            app = middleware(app)
+            apps.append(app)
+        return app, apps
+
+    def add_api(
+            self,
+            specification: t.Union[pathlib.Path, str, dict],
+            base_path: t.Optional[str] = None,
+            arguments: t.Optional[dict] = None,
+    ) -> None:
+        """Add an API to the underlying routing middleware based on a OpenAPI spec.
+
+        :param specification: OpenAPI spec as dict or path to file.
+        :param base_path: Base path where to add this API.
+        :param arguments: Jinja arguments to replace in the spec.
+        """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self.app(scope, receive, send)

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -4,10 +4,6 @@ import typing as t
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
-class MissingMiddlewareError(Exception):
-    pass
-
-
 class ConnexionMiddleware:
 
     default_middlewares = [
@@ -33,7 +29,7 @@ class ConnexionMiddleware:
 
     @staticmethod
     def _apply_middlewares(app: ASGIApp, middlewares: t.List[t.Type[ASGIApp]]) \
-            -> t.Tuple[ASGIApp, t.List[ASGIApp]]:
+            -> t.Tuple[ASGIApp, t.Iterable[ASGIApp]]:
         """Apply all middlewares to the provided app.
 
         :param app: App to wrap in middlewares.
@@ -46,7 +42,7 @@ class ConnexionMiddleware:
         for middleware in reversed(middlewares):
             app = middleware(app)
             apps.append(app)
-        return app, apps
+        return app, reversed(apps)
 
     def add_api(
             self,

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,14 @@ install_requires = [
     'PyYAML>=5.1,<7',
     'requests>=2.27,<3',
     'inflection>=0.3.1,<0.6',
-    'werkzeug>=1.0,<3',
+    'werkzeug>=2,<3',
     'starlette>=0.15,<1',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
 
 flask_require = [
-    'flask>=1.0.4,<3',
-    'itsdangerous>=0.24',
+    'flask>=2,<3',
     'a2wsgi>=1.1,<2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ install_requires = [
     'clickclick>=1.2,<21',
     'jsonschema>=2.5.1,<5',
     'PyYAML>=5.1,<7',
-    'requests>=2.19.1,<3',
+    'requests>=2.27,<3',
     'inflection>=0.3.1,<0.6',
     'werkzeug>=1.0,<3',
+    'starlette>=0.15,<1',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
@@ -33,6 +34,7 @@ swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
 flask_require = [
     'flask>=1.0.4,<3',
     'itsdangerous>=0.24',
+    'a2wsgi>=1.1,<2',
 ]
 
 tests_require = [

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -44,23 +44,23 @@ def test_errors(problem_app):
 
     get_problem = app_client.get('/v1.0/problem')  # type: flask.Response
     assert get_problem.content_type == 'application/problem+json'
-    assert get_problem.status_code == 418
+    assert get_problem.status_code == 402
     assert get_problem.headers['x-Test-Header'] == 'In Test'
     error_problem = json.loads(get_problem.data.decode('utf-8', 'replace'))
     assert error_problem['type'] == 'http://www.example.com/error'
     assert error_problem['title'] == 'Some Error'
     assert error_problem['detail'] == 'Something went wrong somewhere'
-    assert error_problem['status'] == 418
+    assert error_problem['status'] == 402
     assert error_problem['instance'] == 'instance1'
 
     get_problem2 = app_client.get('/v1.0/other_problem')  # type: flask.Response
     assert get_problem2.content_type == 'application/problem+json'
-    assert get_problem2.status_code == 418
+    assert get_problem2.status_code == 402
     error_problem2 = json.loads(get_problem2.data.decode('utf-8', 'replace'))
     assert error_problem2['type'] == 'about:blank'
     assert error_problem2['title'] == 'Some Error'
     assert error_problem2['detail'] == 'Something went wrong somewhere'
-    assert error_problem2['status'] == 418
+    assert error_problem2['status'] == 402
     assert error_problem2['instance'] == 'instance1'
 
     problematic_json = app_client.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 from connexion import App
 from connexion.security import FlaskSecurityHandlerFactory
+from werkzeug.test import Client, EnvironBuilder
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -29,6 +30,38 @@ class FakeResponse:
 
     def json(self):
         return json.loads(self.text)
+
+
+def fixed_get_environ():
+    """See https://github.com/pallets/werkzeug/issues/2347"""
+
+    original_get_environ = EnvironBuilder.get_environ
+
+    def f(self):
+        result = original_get_environ(self)
+        result.pop("HTTP_CONTENT_TYPE", None)
+        result.pop("HTTP_CONTENT_LENGTH", None)
+        return result
+
+    return f
+
+
+EnvironBuilder.get_environ = fixed_get_environ()
+
+
+def buffered_open():
+    """For use with ASGI middleware"""
+
+    original_open = Client.open
+
+    def f(*args, **kwargs):
+        kwargs["buffered"] = True
+        return original_open(*args, **kwargs)
+
+    return f
+
+
+Client.open = buffered_open()
 
 
 # Helper fixtures functions

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -96,7 +96,7 @@ def with_problem():
     raise ProblemException(type='http://www.example.com/error',
                            title='Some Error',
                            detail='Something went wrong somewhere',
-                           status=418,
+                           status=402,
                            instance='instance1',
                            headers={'x-Test-Header': 'In Test'})
 
@@ -104,7 +104,7 @@ def with_problem():
 def with_problem_txt():
     raise ProblemException(title='Some Error',
                            detail='Something went wrong somewhere',
-                           status=418,
+                           status=402,
                            instance='instance1')
 
 


### PR DESCRIPTION
Part of #1489 

This PR adds the empty ConnexionMiddleware and wraps it around the FlaskApp using the `a2wsgi.WSGIMiddleware` adapter.

The ConnexionMiddleware and FlaskApp both implement the ASGI interface, and an ASGI server is the recommended way to run it. 

The `a2wsgi.ASGIMiddleware` adapter is wrapped around the ASGI middleware to make it WSGI compliant so it can be used by the development server and test client.