### PR TITLE
Drop pkg_resources

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -8,9 +8,14 @@ import functools
 import logging
 from typing import AnyStr, Union
 
-import pkg_resources
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
 from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
 from jsonschema.validators import extend
+from packaging.version import Version
 from werkzeug.datastructures import FileStorage
 
 from ..exceptions import (BadRequestProblem, ExtraParameterProblem,
@@ -20,9 +25,7 @@ from ..json_schema import Draft4RequestValidator, Draft4ResponseValidator
 from ..lifecycle import ConnexionResponse
 from ..utils import all_json, boolean, is_json_mimetype, is_null, is_nullable
 
-_jsonschema_3_or_newer = pkg_resources.parse_version(
-        pkg_resources.get_distribution("jsonschema").version) >= \
-    pkg_resources.parse_version("3.0.0")
+_jsonschema_3_or_newer = Version(version("jsonschema")) >= Version("3.0.0")
 
 logger = logging.getLogger('connexion.decorators.validation')
 

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -6,12 +6,12 @@ import abc
 import copy
 import json
 import pathlib
+import pkgutil
 from collections.abc import Mapping
 from urllib.parse import urlsplit
 
 import jinja2
 import jsonschema
-import pkg_resources
 import yaml
 from jsonschema import Draft4Validator
 from jsonschema.validators import extend as extend_validator
@@ -206,9 +206,9 @@ class Swagger2Specification(Specification):
     yaml_name = 'swagger.yaml'
     operation_cls = Swagger2Operation
 
-    schema_string = pkg_resources.resource_string('connexion', 'resources/schemas/v2.0/schema.json')
-    openapi_schema = json.loads(schema_string.decode('utf-8'))
-    del schema_string
+    openapi_schema = json.loads(
+        pkgutil.get_data('connexion', 'resources/schemas/v2.0/schema.json')
+    )
 
     @classmethod
     def _set_defaults(cls, spec):
@@ -259,9 +259,9 @@ class OpenAPISpecification(Specification):
     yaml_name = 'openapi.yaml'
     operation_cls = OpenAPIOperation
 
-    schema_string = pkg_resources.resource_string('connexion', 'resources/schemas/v3.0/schema.json')
-    openapi_schema = json.loads(schema_string.decode('utf-8'))
-    del schema_string
+    openapi_schema = json.loads(
+        pkgutil.get_data('connexion', 'resources/schemas/v3.0/schema.json')
+    )
 
     @classmethod
     def _set_defaults(cls, spec):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ install_requires = [
     'requests>=2.9.1,<3',
     'inflection>=0.3.1,<0.6',
     'werkzeug>=1.0,<3',
+    'importlib-metadata>=1 ; python_version<"3.8"',
+    'packaging>=20',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'


### PR DESCRIPTION
Fixes #1479 

Changes proposed in this pull request:

 - Use `importlib.resources` to retrieve schemas
   - `read_text()` doesn't support files in directories, so we have to use the package name, but the package name was invalid due to the `.` in the directories, and also needed to add `__init__.py` files for it to work. 
   We can also use the `files()` function, which does support subdirectories, but this would require the external package until Python 3.9
 - Use `importlib.metadata` and `packaging` to retrieve, parse and compare versions
   - This can be dropped once we bump the minimum version of `jsonschema` to `3`
 
