### PR TITLE
Fix uri parsing for query parameter with empty brackets

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -48,6 +48,17 @@ def snake_and_shadow(name):
     return snake
 
 
+def sanitized(name):
+    return name and re.sub('^[^a-zA-Z_]+', '',
+                           re.sub('[^0-9a-zA-Z_]', '',
+                                  re.sub(r'\[(?!])', '_', name)))
+
+
+def pythonic(name):
+    name = name and snake_and_shadow(name)
+    return sanitized(name)
+
+
 def parameter_to_arg(operation, function, pythonic_params=False,
                      pass_context_arg_name=None):
     """
@@ -64,13 +75,6 @@ def parameter_to_arg(operation, function, pythonic_params=False,
     :type pass_context_arg_name: str|None
     """
     consumes = operation.consumes
-
-    def sanitized(name):
-        return name and re.sub('^[^a-zA-Z_]+', '', re.sub('[^0-9a-zA-Z[_]', '', re.sub(r'[\[]', '_', name)))
-
-    def pythonic(name):
-        name = name and snake_and_shadow(name)
-        return sanitized(name)
 
     sanitize = pythonic if pythonic_params else sanitized
     arguments, has_kwargs = inspect_function_arguments(function)

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from connexion.decorators.parameter import parameter_to_arg
+from connexion.decorators.parameter import parameter_to_arg, pythonic
 
 
 def test_injection():
@@ -25,3 +25,8 @@ def test_injection():
 
     parameter_to_arg(Op(), handler, pass_context_arg_name='framework_request_ctx')(request)
     func.assert_called_with(p1='123', framework_request_ctx=request.context)
+
+
+def test_pythonic_params():
+    assert pythonic('orderBy[eq]') == 'order_by_eq'
+    assert pythonic('ids[]') == 'ids'


### PR DESCRIPTION
Fixes an issue where query parameters with empty brackets are not sanitized correctly.

In the example below, the `ids[]` parameter was sanitized to `ids_` since [this change](https://github.com/spec-first/connexion/pull/1408/files#diff-fdef5b8ce70b2c603bff264825d3b8baad76326f32a4e94455224f680f65b780L68-R68).
```yaml
parameters:
  - name: ids[]
    in: query
    type: array
      items: string
    collectionFormat: multi
```
```Python
?ids[]=a&ids[]=b
```

This PR fixes the sanitization so it's `ids[]` becomes `ids`.