### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+ci:
+  autoupdate_branch: "main"
+  autoupdate_schedule: monthly
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        files: "^connexion/"
+        additional_dependencies:
+          - flake8-rst-docstrings==0.2.3
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort
+        files: "^connexion/"
+        args: ["--project", "connexion", "--check-only", "--diff"]
+      - id: isort
+        name: isort examples
+        files: "^examples/"
+        args: ["--thirdparty", "connexion", "--check-only", "--diff"]
+      - id: isort
+        name: isort tests
+        files: "^tests/"
+        args: ["--project", "conftest", "--thirdparty", "connexion", "--check-only", "--diff"]

--- a/README.rst
+++ b/README.rst
@@ -583,6 +583,14 @@ Contributing to Connexion/TODOs
 We welcome your ideas, issues, and pull requests. Just follow the
 usual/standard GitHub practices.
 
+For easy development, please install connexion in editable mode with the :code:`tests` extra, and
+install the pre-commit hooks.
+
+.. code-block:: bash
+
+    pip install -e .[tests]
+    pre-commit install
+
 You can find out more about how Connexion works and where to apply your changes by having a look
 at our `ARCHITECTURE.rst <ARCHITECTURE.rst>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,9 @@ flask_require = [
 ]
 
 tests_require = [
-    'decorator>=5,<6',
     'pytest>=6,<7',
+    'pre-commit>=2,<3',
     'pytest-cov>=2,<3',
-    'testfixtures>=6,<7',
     *flask_require,
     swagger_ui_require
 ]
@@ -92,7 +91,6 @@ setup(
     url='https://github.com/zalando/connexion',
     keywords='openapi oai swagger rest api oauth flask microservice framework',
     license='Apache License Version 2.0',
-    setup_requires=['flake8'],
     python_requires=">=3.6",
     install_requires=install_requires + flask_require,
     tests_require=tests_require,

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,7 @@ envlist =
     {py38}-{min,pypi,dev}
     {py39}-{min,pypi,dev}
     {py310}-{min,pypi,dev}
-    isort-check
-    isort-check-examples
-    isort-check-tests
-    flake8
+    pre-commit
     mypy
 
 [gh-actions]
@@ -20,7 +17,7 @@ python =
     3.7: py37-min,py37-pypi
     3.8: py38-min,py38-pypi
     3.9: py39-min,py39-pypi
-    3.10: py310-min,py310-pypi,flake8,isort-check,isort-check-examples,isort-check-tests,mypy
+    3.10: py310-min,py310-pypi,pre-commit,mypy
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
@@ -35,29 +32,9 @@ commands=
     dev: pip install --upgrade -r {toxworkdir}/requirements-dev.txt
     python setup.py test
 
-[testenv:flake8]
-deps=
-    flake8==3.9.2
-    flake8-rst-docstrings==0.2.3
-commands=python setup.py flake8
-
-[testenv:isort-check]
-basepython=python3
-deps=isort==5.9.1
-changedir={toxinidir}/connexion
-commands=isort --project connexion --check-only --diff .
-
-[testenv:isort-check-examples]
-basepython=python3
-deps=isort==5.9.1
-changedir={toxinidir}/examples
-commands=isort --thirdparty connexion --check-only --diff .
-
-[testenv:isort-check-tests]
-basepython=python3
-deps=isort==5.9.1
-changedir={toxinidir}/tests
-commands=isort --thirdparty connexion --check-only --diff .
+[testenv:pre-commit]
+deps=pre-commit
+commands=pre-commit run --all-files --show-diff-on-failure
 
 [testenv:mypy]
 deps=


### PR DESCRIPTION
This PR adds a pre-commit hook which runs the static analysis checks on the changed code before committing. The hook is reused by tox so the steps only need to be defined once.

This is a prerequisite for https://github.com/spec-first/connexion/issues/1498.