### PR TITLE
Clean up operation classes

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -22,8 +22,8 @@ class OpenAPIOperation(AbstractOperation):
     """
 
     def __init__(self, api, method, path, operation, resolver, path_parameters=None,
-                 app_security=None, components=None, validate_responses=False,
-                 strict_validation=False, randomize_endpoint=None, validator_map=None,
+                 components=None, validate_responses=False, strict_validation=False,
+                 randomize_endpoint=None, validator_map=None,
                  pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
         """
         This class uses the OperationID identify the module and function that will handle the operation
@@ -44,8 +44,6 @@ class OpenAPIOperation(AbstractOperation):
         :param resolver: Callable that maps operationID to a function
         :param path_parameters: Parameters defined in the path level
         :type path_parameters: list
-        :param app_security: list of security rules the application uses by default
-        :type app_security: list
         :param components: `Components Object
             <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject>`_
         :type components: dict
@@ -68,9 +66,6 @@ class OpenAPIOperation(AbstractOperation):
         """
         self.components = components or {}
 
-        def component_get(oas3_name):
-            return self.components.get(oas3_name, {})
-
         uri_parser_class = uri_parser_class or OpenAPIURIParser
 
         self._router_controller = operation.get('x-openapi-router-controller')
@@ -89,18 +84,6 @@ class OpenAPIOperation(AbstractOperation):
             uri_parser_class=uri_parser_class,
             pass_context_arg_name=pass_context_arg_name
         )
-
-        self._definitions_map = {
-            'components': {
-                'schemas': component_get('schemas'),
-                'examples': component_get('examples'),
-                'requestBodies': component_get('requestBodies'),
-                'parameters': component_get('parameters'),
-                'securitySchemes': component_get('securitySchemes'),
-                'responses': component_get('responses'),
-                'headers': component_get('headers'),
-            }
-        }
 
         self._request_body = operation.get('requestBody', {})
 
@@ -133,7 +116,6 @@ class OpenAPIOperation(AbstractOperation):
             spec.get_operation(path, method),
             resolver=resolver,
             path_parameters=spec.get_path_params(path),
-            app_security=spec.security,
             components=spec.components,
             *args,
             **kwargs

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -27,10 +27,9 @@ class Swagger2Operation(AbstractOperation):
     """
 
     def __init__(self, api, method, path, operation, resolver, app_produces, app_consumes,
-                 path_parameters=None, definitions=None, parameter_definitions=None,
-                 response_definitions=None, validate_responses=False, strict_validation=False,
-                 randomize_endpoint=None, validator_map=None, pythonic_params=False,
-                 uri_parser_class=None, pass_context_arg_name=None):
+                 path_parameters=None, definitions=None, validate_responses=False,
+                 strict_validation=False, randomize_endpoint=None, validator_map=None,
+                 pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
         """
         :param api: api that this operation is attached to
         :type api: apis.AbstractAPI
@@ -51,10 +50,6 @@ class Swagger2Operation(AbstractOperation):
         :param definitions: `Definitions Object
             <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject>`_
         :type definitions: dict
-        :param parameter_definitions: Global parameter definitions
-        :type parameter_definitions: dict
-        :param response_definitions: Global response definitions
-        :type response_definitions: dict
         :param validate_responses: True enables validation. Validation errors generate HTTP 500 responses.
         :type validate_responses: bool
         :param strict_validation: True enables validation on invalid request parameters
@@ -96,12 +91,6 @@ class Swagger2Operation(AbstractOperation):
 
         self.definitions = definitions or {}
 
-        self.definitions_map = {
-            'definitions': self.definitions,
-            'parameters': parameter_definitions,
-            'responses': response_definitions
-        }
-
         self._parameters = operation.get('parameters', [])
         if path_parameters:
             self._parameters += path_parameters
@@ -124,8 +113,6 @@ class Swagger2Operation(AbstractOperation):
             app_produces=spec.produces,
             app_consumes=spec.consumes,
             definitions=spec.definitions,
-            parameter_definitions=spec.parameter_definitions,
-            response_definitions=spec.response_definitions,
             *args,
             **kwargs
         )

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -25,7 +25,6 @@ def test_mock_resolver_default():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -56,7 +55,6 @@ def test_mock_resolver_numeric():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -93,7 +91,6 @@ def test_mock_resolver_example():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -128,7 +125,6 @@ def test_mock_resolver_example_nested_in_object():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -161,7 +157,6 @@ def test_mock_resolver_example_nested_in_list():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -197,7 +192,6 @@ def test_mock_resolver_example_nested_in_object_openapi():
                                  operation={
                                      'responses': responses
                                  },
-                                 app_security=[],
                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -231,7 +225,6 @@ def test_mock_resolver_example_nested_in_list_openapi():
                                  operation={
                                      'responses': responses
                                  },
-                                 app_security=[],
                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -265,7 +258,6 @@ def test_mock_resolver_no_example_nested_in_object():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -298,7 +290,6 @@ def test_mock_resolver_no_example_nested_in_list_openapi():
                                  operation={
                                      'responses': responses
                                  },
-                                 app_security=[],
                                  resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -323,7 +314,6 @@ def test_mock_resolver_no_examples():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'mock-1'
 
@@ -350,7 +340,6 @@ def test_mock_resolver_notimplemented():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
     assert operation.operation_id == 'fakeapi.hello.get'
 
@@ -366,7 +355,6 @@ def test_mock_resolver_notimplemented():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions={},
                                   resolver=resolver)
 
     # check if it is using the mock function

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -29,7 +29,6 @@ def test_mock_resolver_default():
         operation={
             'responses': responses
         },
-        app_security=[],
         resolver=resolver
     )
     assert operation.operation_id == 'mock-1'
@@ -66,7 +65,6 @@ def test_mock_resolver_numeric():
         operation={
             'responses': responses
         },
-        app_security=[],
         resolver=resolver
     )
     assert operation.operation_id == 'mock-1'
@@ -109,7 +107,6 @@ def test_mock_resolver_inline_schema_example():
         operation={
             'responses': responses
         },
-        app_security=[],
         resolver=resolver
     )
     assert operation.operation_id == 'mock-1'
@@ -133,7 +130,6 @@ def test_mock_resolver_no_examples():
         operation={
             'responses': responses
         },
-        app_security=[],
         resolver=resolver
     )
     assert operation.operation_id == 'mock-1'
@@ -158,7 +154,6 @@ def test_mock_resolver_notimplemented():
         operation={
             'operationId': 'fakeapi.hello.get'
         },
-        app_security=[],
         resolver=resolver
     )
     assert operation.operation_id == 'fakeapi.hello.get'
@@ -173,7 +168,6 @@ def test_mock_resolver_notimplemented():
             'operationId': 'fakeapi.hello.nonexistent_function',
             'responses': responses
         },
-        app_security=[],
         resolver=resolver
     )
     # check if it is using the mock function

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -290,7 +290,6 @@ def test_operation(api, security_handler_factory):
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions=DEFINITIONS,
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
 
     assert operation.method == 'GET'
@@ -327,7 +326,6 @@ def test_operation_array(api):
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions=DEFINITIONS,
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
 
@@ -353,7 +351,6 @@ def test_operation_composed_definition(api):
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions=DEFINITIONS,
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
     assert isinstance(operation.function, types.FunctionType)
 
@@ -399,7 +396,6 @@ def test_multi_body(api):
                                       app_produces=['application/json'],
                                       app_consumes=['application/json'],
                                       definitions=DEFINITIONS,
-                                      parameter_definitions=PARAMETER_DEFINITIONS,
                                       resolver=Resolver())
         operation.body_schema
 
@@ -464,7 +460,6 @@ def test_parameter_reference(api):
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
     assert operation.parameters == [{'in': 'path', 'type': 'integer'}]
 
@@ -476,7 +471,7 @@ def test_default(api):
         api=api, method='GET', path='endpoint', path_parameters=[],
         operation=op_spec, app_produces=['application/json'],
         app_consumes=['application/json'], definitions=DEFINITIONS,
-        parameter_definitions=PARAMETER_DEFINITIONS, resolver=Resolver()
+        resolver=Resolver()
     )
     op_spec = make_operation(OPERATION6, parameters=False)
     op_spec['parameters'][0]['default'] = {
@@ -489,7 +484,7 @@ def test_default(api):
         api=api, method='POST', path='endpoint', path_parameters=[],
         operation=op_spec, app_produces=['application/json'],
         app_consumes=['application/json'], definitions=DEFINITIONS,
-        parameter_definitions={}, resolver=Resolver()
+        resolver=Resolver()
     )
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,8 +4,6 @@ from connexion.exceptions import ResolverError
 from connexion.operations import Swagger2Operation
 from connexion.resolver import RelativeResolver, Resolver, RestyResolver
 
-PARAMETER_DEFINITIONS = {'myparam': {'in': 'path', 'type': 'integer'}}
-
 
 def test_standard_get_function():
     function = Resolver().resolve_function_from_operation_id('connexion.FlaskApp.common_error_handler')
@@ -56,7 +54,6 @@ def test_standard_resolve_x_router_controller():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=Resolver())
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -73,7 +70,6 @@ def test_relative_resolve_x_router_controller():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RelativeResolver('root_path'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -89,7 +85,6 @@ def test_relative_resolve_operation_id():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RelativeResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -106,7 +101,6 @@ def test_relative_resolve_operation_id_with_module():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RelativeResolver(fakeapi))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -122,7 +116,6 @@ def test_resty_resolve_operation_id():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -139,7 +132,6 @@ def test_resty_resolve_x_router_controller_with_operation_id():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
@@ -153,7 +145,6 @@ def test_resty_resolve_x_router_controller_without_operation_id():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
@@ -167,7 +158,6 @@ def test_resty_resolve_with_default_module_name():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
@@ -181,7 +171,6 @@ def test_resty_resolve_with_default_module_name_nested():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.world.search'
 
@@ -195,7 +184,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
@@ -208,7 +196,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.world.get'
 
@@ -222,7 +209,6 @@ def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resourc
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.foo_bar.search'
 
@@ -236,7 +222,6 @@ def test_resty_resolve_with_default_module_name_can_resolve_api_root():
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.get'
 
@@ -250,7 +235,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.search'
 
@@ -266,7 +250,6 @@ def test_resty_resolve_with_default_module_name_and_x_router_controller_will_res
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.search'
 
@@ -280,7 +263,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_co
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi', 'api_list'))
     assert operation.operation_id == 'fakeapi.hello.api_list'
 
@@ -294,6 +276,5 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_
                                   app_produces=['application/json'],
                                   app_consumes=['application/json'],
                                   definitions={},
-                                  parameter_definitions=PARAMETER_DEFINITIONS,
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.post'

--- a/tests/test_resolver3.py
+++ b/tests/test_resolver3.py
@@ -14,7 +14,6 @@ def test_standard_resolve_x_router_controller():
             'x-openapi-router-controller': 'fakeapi.hello',
             'operationId': 'post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=Resolver()
     )
@@ -31,7 +30,6 @@ def test_relative_resolve_x_router_controller():
             'x-openapi-router-controller': 'fakeapi.hello',
             'operationId': 'post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RelativeResolver('root_path')
     )
@@ -47,7 +45,6 @@ def test_relative_resolve_operation_id():
         operation={
             'operationId': 'hello.post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RelativeResolver('fakeapi')
     )
@@ -64,7 +61,6 @@ def test_relative_resolve_operation_id_with_module():
         operation={
             'operationId': 'hello.post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RelativeResolver(fakeapi)
     )
@@ -80,7 +76,6 @@ def test_resty_resolve_operation_id():
         operation={
             'operationId': 'fakeapi.hello.post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -97,7 +92,6 @@ def test_resty_resolve_x_router_controller_with_operation_id():
             'x-openapi-router-controller': 'fakeapi.hello',
             'operationId': 'post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -111,7 +105,6 @@ def test_resty_resolve_x_router_controller_without_operation_id():
         path='/hello/{id}',
         path_parameters=[],
         operation={'x-openapi-router-controller': 'fakeapi.hello'},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
@@ -124,7 +117,6 @@ def test_resty_resolve_with_default_module_name():
         path='/hello/{id}',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -138,7 +130,6 @@ def test_resty_resolve_with_default_module_name():
         path='/hello/{id}/world',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -152,7 +143,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
         path='/hello/{id}',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -166,7 +156,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
         path='/hello/world/{id}',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -180,7 +169,6 @@ def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resourc
         path='/foo-bar',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -194,7 +182,6 @@ def test_resty_resolve_with_default_module_name_can_resolve_api_root():
         path='/',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -208,7 +195,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
         path='/hello',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -224,7 +210,6 @@ def test_resty_resolve_with_default_module_name_and_x_router_controller_will_res
         operation={
             'x-openapi-router-controller': 'fakeapi.hello',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )
@@ -238,7 +223,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_co
         path='/hello',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi', 'api_list')
     )
@@ -252,7 +236,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_
         path='/hello',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=RestyResolver('fakeapi')
     )

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -14,7 +14,6 @@ def test_standard_resolve_x_router_controller():
             'x-openapi-router-controller': 'fakeapi.hello',
             'operationId': 'post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=Resolver()
     )
@@ -29,7 +28,6 @@ def test_methodview_resolve_operation_id():
         operation={
             'operationId': 'fakeapi.hello.post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -46,7 +44,6 @@ def test_methodview_resolve_x_router_controller_with_operation_id():
             'x-openapi-router-controller': 'fakeapi.ExampleMethodView',
             'operationId': 'post_greeting',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -59,7 +56,6 @@ def test_methodview_resolve_x_router_controller_without_operation_id():
                           path='/hello/{id}',
                           path_parameters=[],
                           operation={'x-openapi-router-controller': 'fakeapi.example_method'},
-                          app_security=[],
                           components=COMPONENTS,
                           resolver=MethodViewResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
@@ -72,7 +68,6 @@ def test_methodview_resolve_with_default_module_name():
         path='/example_method/{id}',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -86,7 +81,6 @@ def test_methodview_resolve_with_default_module_name_lowercase_verb():
         path='/example_method/{id}',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -100,7 +94,6 @@ def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_re
         path='/example-method',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -114,7 +107,6 @@ def test_methodview_resolve_with_default_module_name_can_resolve_api_root():
         path='/',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi.example_method',)
     )
@@ -128,7 +120,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path='/example_method',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -144,7 +135,6 @@ def test_methodview_resolve_with_default_module_name_and_x_router_controller_wil
         operation={
             'x-openapi-router-controller': 'fakeapi.example_method',
         },
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )
@@ -158,7 +148,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path='/example_method',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi', 'api_list')
     )
@@ -172,7 +161,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path='/example_method',
         path_parameters=[],
         operation={},
-        app_security=[],
         components=COMPONENTS,
         resolver=MethodViewResolver('fakeapi')
     )


### PR DESCRIPTION
This PR does some additional cleanup of the operation classes after we migrated the security functionality to middleware in #1514. Cleaned up some additional unused code as well.
