### PR TITLE
Fix deprecation warning for Validator.iter_errors

### DIFF
--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -47,7 +47,7 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
         if not valid:
             return
         if isinstance(instance, dict) and 'default' in instance:
-            for error in instance_validator.iter_errors(instance['default'], instance):
+            for error in instance_validator.evolve(instance).iter_errors(instance['default']):
                 yield error
 
     SpecValidator = extend_validator(Draft4Validator, {"properties": validate_defaults})

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -47,8 +47,7 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
         if not valid:
             return
         if isinstance(instance, dict) and 'default' in instance:
-            instance_validator.evolve(schema=instance)
-            for error in instance_validator.iter_errors(instance['default']):
+            for error in instance_validator.evolve(schema=instance).iter_errors(instance['default']):
                 yield error
 
     SpecValidator = extend_validator(Draft4Validator, {"properties": validate_defaults})

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -47,7 +47,8 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
         if not valid:
             return
         if isinstance(instance, dict) and 'default' in instance:
-            for error in instance_validator.evolve(instance).iter_errors(instance['default']):
+            instance_validator.evolve(schema=instance)
+            for error in instance_validator.iter_errors(instance['default']):
                 yield error
 
     SpecValidator = extend_validator(Draft4Validator, {"properties": validate_defaults})

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ version = read_version('connexion')
 
 install_requires = [
     'clickclick>=1.2,<21',
-    'jsonschema>=4,<5',
+    'jsonschema>=4.0.1,<5',
     'PyYAML>=5.1,<7',
     'requests>=2.27,<3',
     'inflection>=0.3.1,<0.6',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ version = read_version('connexion')
 
 install_requires = [
     'clickclick>=1.2,<21',
-    'jsonschema>=2.5.1,<5',
+    'jsonschema>=4,<5',
     'PyYAML>=5.1,<7',
     'requests>=2.27,<3',
     'inflection>=0.3.1,<0.6',


### PR DESCRIPTION
Fixes #1510 

Changes proposed in this pull request:

 - Move from .iter_errors to .evolve().iter_errors to fix the deprecation warning
 - Bump the earliest possible used version of jsonschema to v4.0.1 (v4.0.0 got yanked)
