### PR TITLE
call as_view in methodresolver

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -192,15 +192,8 @@ class MethodViewResolver(RestyResolver):
                     return ...
     """
 
-    def __init__(self, *args,  class_arguments={}, **kwargs):
-        """
-        :param class_arguments: args and kwargs to pass to the class constructor
-        :type class_arguments: dict[str, dict[str, tuple[Any] | dict[str, Any]]]
-        example:
-        >>> class_arguments = {'MyView': 'args': ('foo',), 'kwargs': {'bar': 'baz'}}
-        """
-
-        self.class_arguments = class_arguments
+    def __init__(self, *args,  class_arguments=None, **kwargs):
+        self.class_arguments = class_arguments or {}
         super(MethodViewResolver, self).__init__(*args, **kwargs)
         self.initialized_views = []
 
@@ -263,7 +256,7 @@ class MethodViewResolver(RestyResolver):
             # get the args and kwargs for this view
             cls_arguments = self.class_arguments.get(view_name, {})
             cls_args = cls_arguments.get('args', ())
-            cls_kwargs= cls_arguments.get('kwargs', {})
+            cls_kwargs = cls_arguments.get('kwargs', {})
             # call as_view to get a view function
             # that is decorated with the classes
             # decorator list, if any

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -129,10 +129,10 @@ collected and all passed to the endpoint handlers.
 Automatic Routing with MethodViewResolver
 -------------------------------------------
 
-Note: 
-If you migrate from connextion v2 you may want to use the `DeprecatedMethodViewResolver`
-in order to maintain the old behavior. The behavior described here is the new behavior,
-introduced in connextion v3.
+.. note::
+   If you migrate from connextion v2 you may want to use the `DeprecatedMethodViewResolver`
+   in order to maintain the old behavior. The behavior described here is the new behavior,
+   introduced in connextion v3.
 
 ``MethodViewResolver`` is an customised Resolver based on ``RestyResolver``
 to take advantage of MethodView structure of building Flask APIs.
@@ -227,11 +227,11 @@ and a __init__.py file to make the Class visible in the api directory.
 
 .. code-block:: python
 
-  from .petsview import PetsView
+    from .petsview import PetsView
 
 
-the `as_view` method of the class is called. Its `dispatch_request` method is 
-used to route requests based on the HTTP method. 
+The `as_view` method of the class is called to create the view function.
+Its `dispatch_request` method is used to route requests based on the HTTP method. 
 Therefore it is required to use the same `get` method for both, collection and 
 single resources. I.E. `/pets` and `/pets/{id}`.
 
@@ -241,10 +241,6 @@ decorator attribute of the class:
 .. code-block:: python
 
     def example_decorator(f):
-        """
-        the returned view from <class>.as_view can be decorated
-        the decorator is initialized exactly once per class
-        """
 
         def decorator(*args, **kwargs):
             return f(*args, **kwargs)

--- a/examples/openapi3/methodresolver/api/__init__.py
+++ b/examples/openapi3/methodresolver/api/__init__.py
@@ -1,1 +1,1 @@
-from .petsview import PetsView
+from .petsview import PetsView as PetsView

--- a/examples/openapi3/methodresolver/api/petsview.py
+++ b/examples/openapi3/methodresolver/api/petsview.py
@@ -1,60 +1,67 @@
 import datetime
 
 from connexion import NoContent
-from flask import request
 from flask.views import MethodView
 
 
 def example_decorator(f):
-    """the returned view from <class>.as_view can be decorated"""
+    """
+    the returned view from <class>.as_view can be decorated
+    the decorator is initialized exactly once per class
+    """
+
     def decorator(*args, **kwargs):
         return f(*args, **kwargs)
+
     return decorator
 
 
 class PetsView(MethodView):
-    """ Create Pets service
-    """
+    """Create Pets service"""
+
     decorators = [example_decorator]
     pets = {}
 
-    def post(self):
-      body= request.json
-      name = body.get("name")
-      tag = body.get("tag")
-      count = len(self.pets)
-      pet = {}
-      pet['id'] = count + 1
-      pet["tag"] = tag
-      pet["name"] = name
-      pet['last_updated'] = datetime.datetime.now()
-      self.pets[pet['id']] = pet
-      return pet, 201
+    def __init__(self, pets=None):
+        # the args and kwargs can be provided
+        # via the MethodViewResolver's class_params dict
+        if pets is not None:
+            self.pets = pets
 
-    def put(self, petId):
-      body = request.json
-      name = body["name"]
-      tag = body.get("tag")
-      id_ = int(petId)
-      pet = self.pets.get(petId, {"id": id_})
-      pet["name"] = name
-      pet["tag"] = tag
-      pet['last_updated'] = datetime.datetime.now()
-      self.pets[id_] = pet
-      return self.pets[id_], 201
+    def post(self, body: dict):
+        name = body.get("name")
+        tag = body.get("tag")
+        count = len(self.pets)
+        pet = {}
+        pet["id"] = count + 1
+        pet["tag"] = tag
+        pet["name"] = name
+        pet["last_updated"] = datetime.datetime.now()
+        self.pets[pet["id"]] = pet
+        return pet, 201
+
+    def put(self, petId, body: dict):
+        name = body["name"]
+        tag = body.get("tag")
+        pet = self.pets.get(petId, {"id": petId})
+        pet["name"] = name
+        pet["tag"] = tag
+        pet["last_updated"] = datetime.datetime.now()
+        self.pets[petId] = pet
+        return self.pets[petId], 201
 
     def delete(self, petId):
-      id_ = int(petId)
-      if self.pets.get(id_) is None:
-          return NoContent, 404
-      del self.pets[id_]
-      return NoContent, 204
+        id_ = int(petId)
+        if self.pets.get(id_) is None:
+            return NoContent, 404
+        del self.pets[id_]
+        return NoContent, 204
 
-    def get(self, petId = None, limit=100):
-      if petId is None:
-        # NOTE: we need to wrap it with list for Python 3 as dict_values is not JSON serializable
-        return list(self.pets.values())[0:limit]
-      id_ = int(petId)
-      if self.pets.get(id_) is None:
-          return NoContent, 404
-      return self.pets[id_]
+    def get(self, petId=None, limit=100):
+        if petId is None:
+            # NOTE: we need to wrap it with list for Python 3 as 
+            # dict_values is not JSON serializable
+            return list(self.pets.values())[0:limit]
+        if self.pets.get(petId) is None:
+            return NoContent, 404
+        return self.pets[petId]

--- a/examples/openapi3/methodresolver/api/petsview.py
+++ b/examples/openapi3/methodresolver/api/petsview.py
@@ -5,10 +5,17 @@ from flask import request
 from flask.views import MethodView
 
 
+def example_decorator(f):
+    """the returned view from <class>.as_view can be decorated"""
+    def decorator(*args, **kwargs):
+        return f(*args, **kwargs)
+    return decorator
+
+
 class PetsView(MethodView):
     """ Create Pets service
     """
-    method_decorators = []
+    decorators = [example_decorator]
     pets = {}
 
     def post(self):
@@ -43,12 +50,11 @@ class PetsView(MethodView):
       del self.pets[id_]
       return NoContent, 204
 
-    def get(self, petId):
+    def get(self, petId = None, limit=100):
+      if petId is None:
+        # NOTE: we need to wrap it with list for Python 3 as dict_values is not JSON serializable
+        return list(self.pets.values())[0:limit]
       id_ = int(petId)
       if self.pets.get(id_) is None:
           return NoContent, 404
       return self.pets[id_]
-
-    def search(self, limit=100):
-      # NOTE: we need to wrap it with list for Python 3 as dict_values is not JSON serializable
-      return list(self.pets.values())[0:limit]

--- a/examples/openapi3/methodresolver/app.py
+++ b/examples/openapi3/methodresolver/app.py
@@ -6,12 +6,36 @@ from connexion.resolver import MethodViewResolver
 
 logging.basicConfig(level=logging.INFO)
 
-if __name__ == '__main__':
-    app = connexion.FlaskApp(__name__, specification_dir='openapi/', debug=True)
+zoo = {
+    1: {
+        "id": 1,
+        "name": "giraffe",
+        "tags": ["africa", "yellow", "hoofs", "herbivore", "long neck"],
+    },
+    2: {
+        "id": 2,
+        "name": "lion",
+        "tags": ["africa", "yellow", "paws", "carnivore", "mane"],
+    },
+}
+
+if __name__ == "__main__":
+    app = connexion.FlaskApp(__name__, specification_dir="openapi/", debug=True)
 
     options = {"swagger_ui": True}
-    app.add_api('pets-api.yaml',
-                options=options,
-                arguments={'title': 'MethodViewResolver Example'},
-                resolver=MethodViewResolver('api'), strict_validation=True, validate_responses=True )
-    app.run(port=9090)
+    app.add_api(
+        "pets-api.yaml",
+        options=options,
+        arguments={"title": "MethodViewResolver Example"},
+
+        resolver=MethodViewResolver(
+            "api", 
+            # class params are entirely optional
+            # they allow to inject dependencies top down
+            # so that the app can be wired, in the entrypoint
+            class_arguments={"PetsView": {"kwargs": {"pets": zoo}}},
+        ),
+        strict_validation=True,
+        validate_responses=True,
+    )
+    app.run(port=9090, debug=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 from connexion import App
+from connexion.resolver import DeprecatedMethodViewResolver, MethodViewResolver
 from connexion.security import SecurityHandlerFactory
 from werkzeug.test import Client, EnvironBuilder
 
@@ -15,6 +16,7 @@ SPEC_FOLDER = TEST_FOLDER / "fakeapi"
 OPENAPI2_SPEC = ["swagger.yaml"]
 OPENAPI3_SPEC = ["openapi.yaml"]
 SPECS = OPENAPI2_SPEC + OPENAPI3_SPEC
+METHOD_VIEW_RESOLVERS = [MethodViewResolver, DeprecatedMethodViewResolver]
 
 
 class FakeResponse:
@@ -258,3 +260,8 @@ def unordered_definition_app(request):
 def bad_operations_app(request):
     return build_app_from_fixture('bad_operations', request.param,
                                   resolver_error=501)
+
+
+@pytest.fixture(scope="session", params=METHOD_VIEW_RESOLVERS)
+def method_view_resolver(request):
+    return request.param

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -1,8 +1,7 @@
 from connexion.operations import OpenAPIOperation
-from connexion.resolver import MethodViewResolver, Resolver
+from connexion.resolver import Resolver
 
 COMPONENTS = {'parameters': {'myparam': {'in': 'path', 'schema': {'type': 'integer'}}}}
-
 
 def test_standard_resolve_x_router_controller():
     operation = OpenAPIOperation(
@@ -19,7 +18,7 @@ def test_standard_resolve_x_router_controller():
     )
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
-def test_methodview_resolve_operation_id():
+def test_methodview_resolve_operation_id(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -29,12 +28,11 @@ def test_methodview_resolve_operation_id():
             'operationId': 'fakeapi.hello.post_greeting',
         },
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.hello.post_greeting'
 
-
-def test_methodview_resolve_x_router_controller_with_operation_id():
+def test_methodview_resolve_x_router_controller_with_operation_id(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -45,23 +43,23 @@ def test_methodview_resolve_x_router_controller_with_operation_id():
             'operationId': 'post_greeting',
         },
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.post_greeting'
 
 
-def test_methodview_resolve_x_router_controller_without_operation_id():
+def test_methodview_resolve_x_router_controller_without_operation_id(method_view_resolver):
     operation = OpenAPIOperation(api=None,
                           method='GET',
                           path='/hello/{id}',
                           path_parameters=[],
                           operation={'x-openapi-router-controller': 'fakeapi.example_method'},
                           components=COMPONENTS,
-                          resolver=MethodViewResolver('fakeapi'))
+                          resolver=method_view_resolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
-def test_methodview_resolve_with_default_module_name():
+def test_methodview_resolve_with_default_module_name(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -69,12 +67,12 @@ def test_methodview_resolve_with_default_module_name():
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
-def test_methodview_resolve_with_default_module_name_lowercase_verb():
+def test_methodview_resolve_with_default_module_name_lowercase_verb(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='get',
@@ -82,12 +80,12 @@ def test_methodview_resolve_with_default_module_name_lowercase_verb():
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
-def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
+def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_resource_name(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -95,12 +93,12 @@ def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_re
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
-def test_methodview_resolve_with_default_module_name_can_resolve_api_root():
+def test_methodview_resolve_with_default_module_name_can_resolve_api_root(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -108,12 +106,12 @@ def test_methodview_resolve_with_default_module_name_can_resolve_api_root():
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi.example_method',)
+        resolver=method_view_resolver('fakeapi.example_method',)
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
 
 
-def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
+def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_get_as_search(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -121,12 +119,12 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
-def test_methodview_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
+def test_methodview_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -136,12 +134,12 @@ def test_methodview_resolve_with_default_module_name_and_x_router_controller_wil
             'x-openapi-router-controller': 'fakeapi.example_method',
         },
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
 
 
-def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
+def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_as_configured(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
@@ -149,12 +147,12 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi', 'api_list')
+        resolver=method_view_resolver('fakeapi', 'api_list')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.api_list'
 
 
-def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
+def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_post_as_post(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='POST',
@@ -162,6 +160,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=MethodViewResolver('fakeapi')
+        resolver=method_view_resolver('fakeapi')
     )
     assert operation.operation_id == 'fakeapi.ExampleMethodView.post'


### PR DESCRIPTION
Signed-off-by: Nico Braun <rainbowstack@gmail.com>

Fixes #1549 

>**Warning** 
>this is a breaking change
> users will be required to change any search method to a get method, merging _get by id_ and _get collection_ into a single handler

The primary reason for this change is to be able to use method decorators as described here: https://flask.palletsprojects.com/en/2.1.x/views/#decorating-views


Changes proposed in this pull request:

 - change the `MethodResolver` to call `as_view` on the classes
