### PR TITLE
Use resolver in security middleware

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -39,7 +39,6 @@ class AbstractSpecAPI(metaclass=AbstractAPIMeta):
             specification: t.Union[pathlib.Path, str, dict],
             base_path: t.Optional[str] = None,
             resolver: t.Optional[Resolver] = None,
-            resolver_error_handler: t.Optional[t.Callable] = None,
             arguments: t.Optional[dict] = None,
             options: t.Optional[dict] = None,
             *args,
@@ -75,7 +74,6 @@ class AbstractSpecAPI(metaclass=AbstractAPIMeta):
 
         self._set_base_path(base_path)
 
-        self.resolver_error_handler = resolver_error_handler
         self.resolver = resolver or Resolver()
 
     def _set_base_path(self, base_path: t.Optional[str] = None) -> None:
@@ -129,6 +127,7 @@ class AbstractRoutingAPI(AbstractSpecAPI):
     def __init__(
             self,
             *args,
+            resolver_error_handler: t.Optional[t.Callable] = None,
             debug: bool = False,
             pass_context_arg_name: t.Optional[str] = None,
             **kwargs
@@ -141,6 +140,7 @@ class AbstractRoutingAPI(AbstractSpecAPI):
         """
         super().__init__(*args, **kwargs)
         self.debug = debug
+        self.resolver_error_handler = resolver_error_handler
 
         logger.debug('pass_context_arg_name: %s', pass_context_arg_name)
         self.pass_context_arg_name = pass_context_arg_name

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -43,6 +43,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
                 serious_business(stuff)
     """
     def __init__(self, api, method, path, operation, resolver,
+                 app_security=None, security_schemes=None,
                  validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None,
                  pythonic_params=False, uri_parser_class=None,
@@ -57,7 +58,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :param operation: swagger operation object
         :type operation: dict
         :param resolver: Callable that maps operationID to a function
-        :param app_produces: list of content types the application can return by default
         :param app_security: list of security rules the application uses by default
         :type app_security: list
         :param security_schemes: `Security Definitions Object
@@ -85,6 +85,8 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         self._path = path
         self._operation = operation
         self._resolver = resolver
+        self._security = operation.get('security', app_security)
+        self._security_schemes = security_schemes
         self._validate_responses = validate_responses
         self._strict_validation = strict_validation
         self._pythonic_params = pythonic_params
@@ -118,6 +120,14 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         The path of the operation, relative to the API base path
         """
         return self._path
+
+    @property
+    def security(self):
+        return self._security
+
+    @property
+    def security_schemes(self):
+        return self._security_schemes
 
     @property
     def responses(self):

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -22,6 +22,7 @@ class OpenAPIOperation(AbstractOperation):
     """
 
     def __init__(self, api, method, path, operation, resolver, path_parameters=None,
+                 app_security=None, security_schemes=None,
                  components=None, validate_responses=False, strict_validation=False,
                  randomize_endpoint=None, validator_map=None,
                  pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
@@ -44,6 +45,11 @@ class OpenAPIOperation(AbstractOperation):
         :param resolver: Callable that maps operationID to a function
         :param path_parameters: Parameters defined in the path level
         :type path_parameters: list
+        :param app_security: list of security rules the application uses by default
+        :type app_security: list
+        :param security_schemes: `Security Definitions Object
+            <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#security-definitions-object>`_
+        :type security_schemes: dict
         :param components: `Components Object
             <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject>`_
         :type components: dict
@@ -76,6 +82,8 @@ class OpenAPIOperation(AbstractOperation):
             path=path,
             operation=operation,
             resolver=resolver,
+            app_security=app_security,
+            security_schemes=security_schemes,
             validate_responses=validate_responses,
             strict_validation=strict_validation,
             randomize_endpoint=randomize_endpoint,
@@ -116,6 +124,8 @@ class OpenAPIOperation(AbstractOperation):
             spec.get_operation(path, method),
             resolver=resolver,
             path_parameters=spec.get_path_params(path),
+            app_security=spec.security,
+            security_schemes=spec.security_schemes,
             components=spec.components,
             *args,
             **kwargs

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -27,7 +27,8 @@ class Swagger2Operation(AbstractOperation):
     """
 
     def __init__(self, api, method, path, operation, resolver, app_produces, app_consumes,
-                 path_parameters=None, definitions=None, validate_responses=False,
+                 path_parameters=None, app_security=None, security_schemes=None,
+                 definitions=None, validate_responses=False,
                  strict_validation=False, randomize_endpoint=None, validator_map=None,
                  pythonic_params=False, uri_parser_class=None, pass_context_arg_name=None):
         """
@@ -47,6 +48,11 @@ class Swagger2Operation(AbstractOperation):
         :type app_consumes: list
         :param path_parameters: Parameters defined in the path level
         :type path_parameters: list
+        :param app_security: list of security rules the application uses by default
+        :type app_security: list
+        :param security_schemes: `Security Definitions Object
+            <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#security-definitions-object>`_
+        :type security_schemes: dict
         :param definitions: `Definitions Object
             <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject>`_
         :type definitions: dict
@@ -77,6 +83,8 @@ class Swagger2Operation(AbstractOperation):
             path=path,
             operation=operation,
             resolver=resolver,
+            app_security=app_security,
+            security_schemes=security_schemes,
             validate_responses=validate_responses,
             strict_validation=strict_validation,
             randomize_endpoint=randomize_endpoint,
@@ -112,6 +120,8 @@ class Swagger2Operation(AbstractOperation):
             path_parameters=spec.get_path_params(path),
             app_produces=spec.produces,
             app_consumes=spec.consumes,
+            app_security=spec.security,
+            security_schemes=spec.security_schemes,
             definitions=spec.definitions,
             *args,
             **kwargs

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -239,7 +239,7 @@ class Swagger2Specification(Specification):
         return self._spec['responses']
 
     @property
-    def security_definitions(self):
+    def security_schemes(self):
         return self._spec.get('securityDefinitions', {})
 
     @property
@@ -268,7 +268,7 @@ class OpenAPISpecification(Specification):
         spec.setdefault('components', {})
 
     @property
-    def security_definitions(self):
+    def security_schemes(self):
         return self._spec['components'].get('securitySchemes', {})
 
     @property


### PR DESCRIPTION
Continues on https://github.com/spec-first/connexion/pull/1514.

This PR continues the implementation of the security middleware, which was started in https://github.com/spec-first/connexion/pull/1514. I took some shortcuts in the original PR, one of them the naive 'resolution' of the `operation_id` by fetching it from the spec instead of relying on a resolver.

https://github.com/spec-first/connexion/blob/b561ecfdaacd7606d1398512762b946e2d778c74/connexion/middleware/security.py#L93

This PR replaces this with resolution via resolver.

You'll see that I rely on the original Connexion `Operation` classes for this, instead of on the `Resolver` directly. I propose to further hollow out the `Operation` classes during the refactoring into a middleware stack, until it becomes a 'data class' providing an interface for the specification of the operation across openapi versions. This is similar to the `Specification` class, but on an operation level.

Specific middleware operations such as `SecurityOperation` and `RoutingOperation` can then use this `Operation` object to initialize themselves. I added this for the `RoutingOperation` as a separate commit.