### PR TITLE
Only warn about the schema's x-body-name being deprecated if it's used.

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -277,17 +277,16 @@ class OpenAPIOperation(AbstractOperation):
         if len(arguments) <= 0 and not has_kwargs:
             return {}
 
-        # prefer the x-body-name as an extension of requestBody
-        x_body_name = sanitize(self.request_body.get('x-body-name', None))
+        # get the deprecated name from the body-schema for legacy connexion compat
+        x_body_name = sanitize(self.body_schema.get('x-body-name'))
 
-        if not x_body_name:
-            # x-body-name also accepted in the schema field for legacy connexion compat
-            x_body_name = sanitize(self.body_schema.get('x-body-name', 'body'))
+        if x_body_name:
+            warnings.warn('x-body-name within the requestBody schema will be deprecated in the '
+                          'next major version. It should be provided directly under '
+                          'the requestBody instead.', DeprecationWarning)
 
-            if x_body_name:
-                warnings.warn('x-body-name within the requestBody schema will be deprecated in the '
-                              'next major version. It should be provided directly under '
-                              'the requestBody instead.', DeprecationWarning)
+        # prefer the x-body-name as an extension of requestBody, fallback to deprecated schema name, default 'body'
+        x_body_name = sanitize(self.request_body.get('x-body-name', x_body_name or 'body'))
 
         if self.consumes[0] in FORM_CONTENT_TYPES:
             result = self._get_body_argument_form(body)


### PR DESCRIPTION
Fixes #1520 

Resubmitting PR #1550 which got bogged down in git issues


Changes proposed in this pull request:
- Code behaviour is unchanged, if body name is set use it, otherwise fallback to the schema's (deprecated) name or "body" if nothing is set
- If x-body-name is set in the schema, warn about deprecation and use (unless overridden by the request body).
