### PR TITLE
debug mode interaction for non-flask server

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -140,6 +140,7 @@ class FlaskApp(AbstractApp):
                          extra_files=self.extra_files, **options)
         elif self.server == 'tornado':
             try:
+                import tornado.autoreload
                 import tornado.httpserver
                 import tornado.ioloop
                 import tornado.wsgi
@@ -148,6 +149,8 @@ class FlaskApp(AbstractApp):
             wsgi_container = tornado.wsgi.WSGIContainer(self.app)
             http_server = tornado.httpserver.HTTPServer(wsgi_container, **options)
             http_server.listen(self.port, address=self.host)
+            if self.debug:
+                tornado.autoreload.start()
             logger.info('Listening on %s:%s..', self.host, self.port)
             tornado.ioloop.IOLoop.instance().start()
         elif self.server == 'gevent':
@@ -155,6 +158,8 @@ class FlaskApp(AbstractApp):
                 import gevent.pywsgi
             except ImportError:
                 raise Exception('gevent library not installed')
+            if self.debug:
+                logger.warning("gevent server doesn't support debug mode. Please switch to flask/tornado server.")
             http_server = gevent.pywsgi.WSGIServer((self.host, self.port), self.app, **options)
             logger.info('Listening on %s:%s..', self.host, self.port)
             http_server.serve_forever()


### PR DESCRIPTION
Fixes the interaction of the debug mode with available server options.

When having `debug=True` and specify `server` argument, the application currently has the interaction as below:
- `server='flask'`: this works correctly and the application is updated when users edit a file
- `server='tornado'`: no update when users edit a file
- `server='gevent'`: no update when users edit a file

Changes proposed in this pull request:

 - for tornado, `tornado.autoreload` is enabled if debug is true
 - for gevent, because it doesn't support automatic detection for code changes, the application'll display a log message suggesting users to try other options
