### PR TITLE
Fix async tests

### DIFF
--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -279,10 +279,12 @@ class SecurityHandlerFactory:
         :rtype: types.FunctionType
         """
 
-        def wrapper(request):
+        async def wrapper(request):
             token_info = {}
             for scheme_name, func in schemes.items():
                 result = func(request)
+                while asyncio.iscoroutine(result):
+                    result = await result
                 if result is self.no_value:
                     return self.no_value
                 token_info[scheme_name] = result

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ flask_require = [
 
 tests_require = [
     'pytest>=6,<7',
+    'pytest-asyncio>=0.18,<0.19',
     'pre-commit>=2,<3',
     'pytest-cov>=2,<3',
     *flask_require,
@@ -57,7 +58,7 @@ class PyTest(TestCommand):
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.cov = None
-        self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing', '-v']
+        self.pytest_args = ['--cov', 'connexion', '--cov-report', 'term-missing', '-v', "--asyncio-mode", "auto"]
         self.cov_html = False
 
     def finalize_options(self):


### PR DESCRIPTION
The async tests were getting skipped because we didn't have an appropriate pytest setup for it. This PR aims to fix this and adjusts the tests accordingly.
