### PR TITLE
Add test for MethodViewResolver

### DIFF
--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -194,6 +194,11 @@ class MethodViewResolver(RestyResolver):
 
     def __init__(self, *args,  class_arguments=None, **kwargs):
         self.class_arguments = class_arguments or {}
+        if "collection_endpoint_name" in kwargs:
+            del kwargs["collection_endpoint_name"]
+            # Dispatch of request is done by Flask
+            logger.warning("collection_endpoint_name is ignored by the MethodViewResolver. "
+                           "Requests to a collection endpoint will be routed to .get()")
         super(MethodViewResolver, self).__init__(*args, **kwargs)
         self.initialized_views = []
 

--- a/connexion/resolver.py
+++ b/connexion/resolver.py
@@ -6,6 +6,7 @@ from the operations defined in the OpenAPI spec.
 import inspect
 import logging
 import sys
+import typing as t
 
 from inflection import camelize
 
@@ -192,7 +193,20 @@ class MethodViewResolver(RestyResolver):
                     return ...
     """
 
-    def __init__(self, *args,  class_arguments=None, **kwargs):
+    _class_arguments_type = t.Dict[str, t.Dict[str, t.Union[t.Iterable, t.Dict[str, t.Any]]]]
+
+    def __init__(self, *args,  class_arguments: _class_arguments_type = None, **kwargs):
+        """
+        :param class_arguments: Arguments to instantiate the View Class in the format  # noqa
+                                {
+                                  "ViewName": {
+                                    "args": (positional arguments,)
+                                    "kwargs": {
+                                      "keyword": "argument"
+                                    }
+                                  }
+                                }
+        """
         self.class_arguments = class_arguments or {}
         if "collection_endpoint_name" in kwargs:
             del kwargs["collection_endpoint_name"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,6 +262,12 @@ def bad_operations_app(request):
                                   resolver_error=501)
 
 
+@pytest.fixture(scope="session", params=SPECS)
+def method_view_app(request):
+    return build_app_from_fixture('method_view', request.param,
+                                  resolver=MethodViewResolver('fakeapi.example_method_view'))
+
+
 @pytest.fixture(scope="session", params=METHOD_VIEW_RESOLVERS)
 def method_view_resolver(request):
     return request.param

--- a/tests/fakeapi/__init__.py
+++ b/tests/fakeapi/__init__.py
@@ -1,4 +1,4 @@
-from .example_method_view import ExampleMethodView
+from .example_method_view import PetsView
 
 
 def get():

--- a/tests/fakeapi/example_method_view.py
+++ b/tests/fakeapi/example_method_view.py
@@ -1,15 +1,35 @@
 from flask.views import MethodView
 
 
-class ExampleMethodView(MethodView):
+class PetsView(MethodView):
+
     mycontent="demonstrate return from MethodView class"
-    def get(self):
-      return self.mycontent
+
+    def get(self, **kwargs):
+        kwargs.update({
+            "method": "get"
+        })
+        return kwargs
+
     def search(self):
-      return self.mycontent
+        return "search"
+
+    def post(self, **kwargs):
+        kwargs.update({
+            "method": "post"
+        })
+        return kwargs
+
+    def put(self, *args, **kwargs):
+        kwargs.update({
+            "method": "put"
+        })
+        return kwargs
+
+    # Test that operation_id can still override resolver
+
     def api_list(self):
-      return self.mycontent
+        return "api_list"
+
     def post_greeting(self):
-      return self.mycontent
-    def post(self):
-      return self.mycontent
+        return "post_greeting"

--- a/tests/fixtures/method_view/openapi.yaml
+++ b/tests/fixtures/method_view/openapi.yaml
@@ -1,0 +1,174 @@
+openapi: "3.0.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+servers:
+  - url: /v1.0
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      tags:
+        - pets
+      requestBody:
+        description: Pet to add to the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Pet record interpreted by backend
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  '/pets/{petId}':
+    get:
+      summary: Info for a specific pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    put:
+      summary: Update a pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to update
+          schema:
+            type: integer
+      requestBody:
+        description: Pet data to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Pet record interpreted by backend
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Update a pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to update
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Pet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: fluffy
+        tag:
+          type: string
+          example: red
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+          example: 1
+        last_updated:
+          type: string
+          readOnly: true
+          example: 2019-01-16T23:52:54.309102Z
+
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/fixtures/method_view/swagger.yaml
+++ b/tests/fixtures/method_view/swagger.yaml
@@ -1,0 +1,152 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          schema:
+            $ref: "#/definitions/Pets"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+    post:
+      summary: Create a pet
+      tags:
+        - pets
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: Pet to add to the system
+          schema:
+            $ref: "#/definitions/Pet"
+      responses:
+        '201':
+          description: Pet record interpreted by backend
+          schema:
+            $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+
+  '/pets/{petId}':
+    get:
+      summary: Info for a specific pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: integer
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+
+    put:
+      summary: Update a pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to update
+          type: integer
+        - name: body
+          in: body
+          required: true
+          description: Pet to add to the system
+          schema:
+            $ref: "#/definitions/Pet"
+      responses:
+        '201':
+          description: Pet record interpreted by backend
+          schema:
+            $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+    delete:
+      summary: Update a pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to update
+          type: integer
+      responses:
+        '204':
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+
+
+definitions:
+  Pet:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: fluffy
+      tag:
+        type: string
+        example: red
+      id:
+        type: integer
+        format: int64
+        readOnly: true
+        example: 1
+      last_updated:
+        type: string
+        readOnly: true
+        example: 2019-01-16T23:52:54.309102Z
+
+  Pets:
+    type: array
+    items:
+      $ref: "#/definitions/Pet"
+
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -187,6 +187,7 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
                                   resolver=RestyResolver('fakeapi'))
     assert operation.operation_id == 'fakeapi.hello.get'
 
+
 def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
     operation = Swagger2Operation(api=None,
                                   method='get',

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -39,13 +39,13 @@ def test_methodview_resolve_x_router_controller_with_operation_id(method_view_re
         path='endpoint',
         path_parameters=[],
         operation={
-            'x-openapi-router-controller': 'fakeapi.ExampleMethodView',
+            'x-openapi-router-controller': 'fakeapi.PetsView',
             'operationId': 'post_greeting',
         },
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.post_greeting'
+    assert operation.operation_id == 'fakeapi.PetsView.post_greeting'
 
 
 def test_methodview_resolve_x_router_controller_without_operation_id(method_view_resolver):
@@ -53,49 +53,49 @@ def test_methodview_resolve_x_router_controller_without_operation_id(method_view
                           method='GET',
                           path='/hello/{id}',
                           path_parameters=[],
-                          operation={'x-openapi-router-controller': 'fakeapi.example_method'},
+                          operation={'x-openapi-router-controller': 'fakeapi.pets'},
                           components=COMPONENTS,
                           resolver=method_view_resolver('fakeapi'))
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
+    assert operation.operation_id == 'fakeapi.PetsView.get'
 
 
 def test_methodview_resolve_with_default_module_name(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
-        path='/example_method/{id}',
+        path='/pets/{id}',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
+    assert operation.operation_id == 'fakeapi.PetsView.get'
 
 
 def test_methodview_resolve_with_default_module_name_lowercase_verb(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='get',
-        path='/example_method/{id}',
+        path='/pets/{id}',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
+    assert operation.operation_id == 'fakeapi.PetsView.get'
 
 
 def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_resource_name(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
-        path='/example-method',
+        path='/pets',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
+    assert operation.operation_id == 'fakeapi.PetsView.search'
 
 
 def test_methodview_resolve_with_default_module_name_can_resolve_api_root(method_view_resolver):
@@ -106,22 +106,22 @@ def test_methodview_resolve_with_default_module_name_can_resolve_api_root(method
         path_parameters=[],
         operation={},
         components=COMPONENTS,
-        resolver=method_view_resolver('fakeapi.example_method',)
+        resolver=method_view_resolver('fakeapi.pets',)
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.get'
+    assert operation.operation_id == 'fakeapi.PetsView.get'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_get_as_search(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
-        path='/example_method',
+        path='/pets',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
+    assert operation.operation_id == 'fakeapi.PetsView.search'
 
 
 def test_methodview_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search(method_view_resolver):
@@ -131,35 +131,67 @@ def test_methodview_resolve_with_default_module_name_and_x_router_controller_wil
         path='/hello',
         path_parameters=[],
         operation={
-            'x-openapi-router-controller': 'fakeapi.example_method',
+            'x-openapi-router-controller': 'fakeapi.pets',
         },
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.search'
+    assert operation.operation_id == 'fakeapi.PetsView.search'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_as_configured(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='GET',
-        path='/example_method',
+        path='/pets',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi', 'api_list')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.api_list'
+    assert operation.operation_id == 'fakeapi.PetsView.api_list'
 
 
 def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_post_as_post(method_view_resolver):
     operation = OpenAPIOperation(
         api=None,
         method='POST',
-        path='/example_method',
+        path='/pets',
         path_parameters=[],
         operation={},
         components=COMPONENTS,
         resolver=method_view_resolver('fakeapi')
     )
-    assert operation.operation_id == 'fakeapi.ExampleMethodView.post'
+    assert operation.operation_id == 'fakeapi.PetsView.post'
+
+
+def test_method_view_resolver_integration(method_view_app):
+    client = method_view_app.app.test_client()
+
+    r = client.get('/v1.0/pets')
+    assert r.json == {
+        "method": "get"
+    }
+
+    r = client.get('/v1.0/pets/1')
+    assert r.json == {
+        "method": "get",
+        "petId": 1
+    }
+
+    r = client.post('/v1.0/pets', json={"name": "Musti"})
+    assert r.json == {
+        "method": "post",
+        "body": {
+            "name": "Musti"
+        }
+    }
+
+    r = client.put('/v1.0/pets/1', json={"name": "Igor"})
+    assert r.json == {
+        "method": "put",
+        "petId": 1,
+        "body": {
+            "name": "Igor"
+        }
+    }


### PR DESCRIPTION
Follow up on #1552 

Changes proposed in this pull request:

 - Add test for `MethodViewResolver`. I had to rename some stuff to clean this up a bit.
 - Add warning about ignoring `collection_endpoint_name` in `MethodViewResolver`
 - Add format of `class_arguments` in docstring

CC: @bluebrown 
