### PR TITLE
Fix to get all files value for multipart

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -200,7 +200,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
 
     @staticmethod
     def _get_file_arguments(files, arguments, has_kwargs=False):
-        return {k: v for k, v in files.items() if k in arguments or has_kwargs}
+        return {k: v for k, v in files.lists() if k in arguments or has_kwargs}
 
     @abc.abstractmethod
     def _get_val_from_param(self, value, query_defn):


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

 - get all values from files by using `files.lists()`