### PR TITLE
Removed internal variable pass_context_arg_name

### DIFF
--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -134,22 +134,15 @@ class AbstractRoutingAPI(AbstractSpecAPI):
         *args,
         resolver_error_handler: t.Optional[t.Callable] = None,
         debug: bool = False,
-        pass_context_arg: bool = False,
         **kwargs,
     ) -> None:
         """Minimal interface of an API, with only functionality related to routing.
 
         :param debug: Flag to run in debug mode
-        :param pass_context_arg: If true request handling functions with
-            an argument
-            with `context_` name will be passed the framework's request context.
         """
         super().__init__(*args, **kwargs)
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
-
-        logger.debug("pass_context_arg: %s", pass_context_arg)
-        self.pass_context_arg = pass_context_arg
 
         self.add_paths()
 
@@ -227,7 +220,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
         resolver_error_handler=None,
         validator_map=None,
         pythonic_params=False,
-        pass_context_arg=False,
         options=None,
         **kwargs,
     ):
@@ -259,7 +251,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             resolver=resolver,
             resolver_error_handler=resolver_error_handler,
             debug=debug,
-            pass_context_arg=pass_context_arg,
             options=options,
         )
 
@@ -290,7 +281,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,
-            pass_context_arg=self.pass_context_arg,
         )
         self._add_operation_internal(method, path, operation)
 

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -134,15 +134,22 @@ class AbstractRoutingAPI(AbstractSpecAPI):
         *args,
         resolver_error_handler: t.Optional[t.Callable] = None,
         debug: bool = False,
+        pass_context_arg: bool = False,
         **kwargs,
     ) -> None:
         """Minimal interface of an API, with only functionality related to routing.
 
         :param debug: Flag to run in debug mode
+        :param pass_context_arg: If true request handling functions with
+            an argument
+            with `context_` name will be passed the framework's request context.
         """
         super().__init__(*args, **kwargs)
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
+
+        logger.debug("pass_context_arg: %s", pass_context_arg)
+        self.pass_context_arg = pass_context_arg
 
         self.add_paths()
 
@@ -220,6 +227,7 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
         resolver_error_handler=None,
         validator_map=None,
         pythonic_params=False,
+        pass_context_arg=False,
         options=None,
         **kwargs,
     ):
@@ -251,6 +259,7 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             resolver=resolver,
             resolver_error_handler=resolver_error_handler,
             debug=debug,
+            pass_context_arg=pass_context_arg,
             options=options,
         )
 
@@ -281,6 +290,7 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,
+            pass_context_arg=self.pass_context_arg,
         )
         self._add_operation_internal(method, path, operation)
 

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -134,21 +134,15 @@ class AbstractRoutingAPI(AbstractSpecAPI):
         *args,
         resolver_error_handler: t.Optional[t.Callable] = None,
         debug: bool = False,
-        pass_context_arg_name: t.Optional[str] = None,
         **kwargs,
     ) -> None:
         """Minimal interface of an API, with only functionality related to routing.
 
         :param debug: Flag to run in debug mode
-        :param pass_context_arg_name: If not None URL request handling functions with an argument
-            matching this name will be passed the framework's request context.
         """
         super().__init__(*args, **kwargs)
         self.debug = debug
         self.resolver_error_handler = resolver_error_handler
-
-        logger.debug("pass_context_arg_name: %s", pass_context_arg_name)
-        self.pass_context_arg_name = pass_context_arg_name
 
         self.add_paths()
 
@@ -227,7 +221,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
         resolver_error_handler=None,
         validator_map=None,
         pythonic_params=False,
-        pass_context_arg_name=None,
         options=None,
         **kwargs,
     ):
@@ -259,7 +252,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             resolver=resolver,
             resolver_error_handler=resolver_error_handler,
             debug=debug,
-            pass_context_arg_name=pass_context_arg_name,
             options=options,
         )
 
@@ -290,7 +282,6 @@ class AbstractAPI(AbstractRoutingAPI, metaclass=AbstractAPIMeta):
             strict_validation=self.strict_validation,
             pythonic_params=self.pythonic_params,
             uri_parser_class=self.options.uri_parser_class,
-            pass_context_arg_name=self.pass_context_arg_name,
         )
         self._add_operation_internal(method, path, operation)
 

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -131,7 +131,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
         resolver=None,
         resolver_error=None,
         pythonic_params=False,
-        pass_context_arg_name=None,
         options=None,
         validator_map=None,
     ):
@@ -159,8 +158,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type pythonic_params: bool
         :param options: New style options dictionary.
         :type options: dict | None
-        :param pass_context_arg_name: Name of argument in handler functions to pass request context to.
-        :type pass_context_arg_name: str | None
         :param validator_map: map of validators
         :type validator_map: dict
         :rtype: AbstractAPI
@@ -202,7 +199,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg_name=pass_context_arg_name,
             options=api_options.as_dict(),
         )
 
@@ -218,7 +214,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg_name=pass_context_arg_name,
             options=api_options.as_dict(),
         )
         return api

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -131,6 +131,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
         resolver=None,
         resolver_error=None,
         pythonic_params=False,
+        pass_context_arg=False,
         options=None,
         validator_map=None,
     ):
@@ -156,6 +157,9 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type resolver_error: int | None
         :param pythonic_params: When True CamelCase parameters are converted to snake_case
         :type pythonic_params: bool
+        :param pass_context_arg: When True `context_` in handler functions to pass request context to.
+        :type pass_context_arg: bool
+
         :param options: New style options dictionary.
         :type options: dict | None
         :param validator_map: map of validators
@@ -199,6 +203,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            pass_context_arg=pass_context_arg,
             options=api_options.as_dict(),
         )
 
@@ -214,6 +219,7 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            pass_context_arg=pass_context_arg,
             options=api_options.as_dict(),
         )
         return api

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -131,7 +131,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
         resolver=None,
         resolver_error=None,
         pythonic_params=False,
-        pass_context_arg=False,
         options=None,
         validator_map=None,
     ):
@@ -157,8 +156,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
         :type resolver_error: int | None
         :param pythonic_params: When True CamelCase parameters are converted to snake_case
         :type pythonic_params: bool
-        :param pass_context_arg: When True `context_` in handler functions to pass request context to.
-        :type pass_context_arg: bool
 
         :param options: New style options dictionary.
         :type options: dict | None
@@ -203,7 +200,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg=pass_context_arg,
             options=api_options.as_dict(),
         )
 
@@ -219,7 +215,6 @@ class AbstractApp(metaclass=abc.ABCMeta):
             debug=self.debug,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg=pass_context_arg,
             options=api_options.as_dict(),
         )
         return api

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -62,9 +62,7 @@ def pythonic(name):
     return sanitized(name)
 
 
-def parameter_to_arg(
-    operation, function, pythonic_params=False, pass_context_arg_name=None
-):
+def parameter_to_arg(operation, function, pythonic_params=False):
     """
     Pass query and body parameters as keyword arguments to handler function.
 
@@ -74,9 +72,6 @@ def parameter_to_arg(
     :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended to
     any shadowed built-ins
     :type pythonic_params: bool
-    :param pass_context_arg_name: If not None URL and function has an argument matching this name, the framework's
-    request context will be passed as that argument.
-    :type pass_context_arg_name: str|None
     """
     consumes = operation.consumes
 
@@ -123,10 +118,6 @@ def parameter_to_arg(
                 kwargs[key] = value
             else:
                 logger.debug("Context parameter '%s' not in function arguments", key)
-
-        # attempt to provide the request context to the function
-        if pass_context_arg_name and (has_kwargs or pass_context_arg_name in arguments):
-            kwargs[pass_context_arg_name] = request.context
 
         return function(**kwargs)
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -62,7 +62,9 @@ def pythonic(name):
     return sanitized(name)
 
 
-def parameter_to_arg(operation, function, pythonic_params=False):
+def parameter_to_arg(
+    operation, function, pythonic_params=False, pass_context_arg_name=None
+):
     """
     Pass query and body parameters as keyword arguments to handler function.
 
@@ -118,6 +120,9 @@ def parameter_to_arg(operation, function, pythonic_params=False):
                 kwargs[key] = value
             else:
                 logger.debug("Context parameter '%s' not in function arguments", key)
+        # attempt to provide the request context to the function
+        if pass_context_arg_name and (has_kwargs or pass_context_arg_name in arguments):
+            kwargs[pass_context_arg_name] = request.context
 
         return function(**kwargs)
 

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -64,9 +64,7 @@ def pythonic(name):
     return sanitized(name)
 
 
-def parameter_to_arg(
-    operation, function, pythonic_params=False, pass_context_arg=False
-):
+def parameter_to_arg(operation, function, pythonic_params=False):
     """
     Pass query and body parameters as keyword arguments to handler function.
 
@@ -76,9 +74,6 @@ def parameter_to_arg(
     :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended to
     any shadowed built-ins
     :type pythonic_params: bool
-    :param pass_context_arg: If True URL and function has an argument `context_`, the framework's
-    request context will be passed as that argument.
-    :type pass_context_arg: bool
     """
     consumes = operation.consumes
 
@@ -126,7 +121,7 @@ def parameter_to_arg(
             else:
                 logger.debug("Context parameter '%s' not in function arguments", key)
         # attempt to provide the request context to the function
-        if pass_context_arg and (has_kwargs or CONTEXT_NAME in arguments):
+        if CONTEXT_NAME in arguments:
             kwargs[CONTEXT_NAME] = request.context
 
         return function(**kwargs)

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -18,6 +18,8 @@ from ..utils import all_json
 
 logger = logging.getLogger(__name__)
 
+CONTEXT_NAME = "context_"
+
 
 def inspect_function_arguments(function):  # pragma: no cover
     """
@@ -63,7 +65,7 @@ def pythonic(name):
 
 
 def parameter_to_arg(
-    operation, function, pythonic_params=False, pass_context_arg_name=None
+    operation, function, pythonic_params=False, pass_context_arg=False
 ):
     """
     Pass query and body parameters as keyword arguments to handler function.
@@ -74,6 +76,9 @@ def parameter_to_arg(
     :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended to
     any shadowed built-ins
     :type pythonic_params: bool
+    :param pass_context_arg: If True URL and function has an argument `context_`, the framework's
+    request context will be passed as that argument.
+    :type pass_context_arg: bool
     """
     consumes = operation.consumes
 
@@ -121,8 +126,8 @@ def parameter_to_arg(
             else:
                 logger.debug("Context parameter '%s' not in function arguments", key)
         # attempt to provide the request context to the function
-        if pass_context_arg_name and (has_kwargs or pass_context_arg_name in arguments):
-            kwargs[pass_context_arg_name] = request.context
+        if pass_context_arg and (has_kwargs or CONTEXT_NAME in arguments):
+            kwargs[CONTEXT_NAME] = request.context
 
         return function(**kwargs)
 

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -78,7 +78,7 @@ class SecurityAPI(AbstractSpecAPI):
         **kwargs
     ):
         super().__init__(specification, *args, **kwargs)
-        self.security_handler_factory = SecurityHandlerFactory("context")
+        self.security_handler_factory = SecurityHandlerFactory()
 
         if auth_all_paths:
             self.add_auth_on_not_found()

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -57,6 +57,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
+        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -85,6 +86,8 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
+        :param pass_context_arg: If True will try to inject the request context to the function using the `context_` name.
+        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -100,8 +103,9 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         self._pythonic_params = pythonic_params
         self._uri_parser_class = uri_parser_class
         self._randomize_endpoint = randomize_endpoint
-
+        self._pass_context_arg = pass_context_arg
         self._operation_id = self._operation.get("operationId")
+
         self._resolution = resolver.resolve(self)
         self._operation_id = self._resolution.operation_id
 
@@ -387,6 +391,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
             self,
             self._resolution.function,
             self.pythonic_params,
+            self._pass_context_arg,
         )
 
         if self.validate_responses:

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -57,7 +57,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
-        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -86,8 +85,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
-        :param pass_context_arg: If True will try to inject the request context to the function using the `context_` name.
-        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -103,7 +100,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         self._pythonic_params = pythonic_params
         self._uri_parser_class = uri_parser_class
         self._randomize_endpoint = randomize_endpoint
-        self._pass_context_arg = pass_context_arg
         self._operation_id = self._operation.get("operationId")
 
         self._resolution = resolver.resolve(self)
@@ -391,7 +387,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
             self,
             self._resolution.function,
             self.pythonic_params,
-            self._pass_context_arg,
         )
 
         if self.validate_responses:

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -58,7 +58,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         validator_map=None,
         pythonic_params=False,
         uri_parser_class=None,
-        pass_context_arg_name=None,
     ):
         """
         :param api: api that this operation is attached to
@@ -88,9 +87,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :type pythonic_params: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
-        :param pass_context_arg_name: If not None will try to inject the request context to the function using this
-            name.
-        :type pass_context_arg_name: str|None
         """
         self._api = api
         self._method = method
@@ -103,7 +99,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         self._strict_validation = strict_validation
         self._pythonic_params = pythonic_params
         self._uri_parser_class = uri_parser_class
-        self._pass_context_arg_name = pass_context_arg_name
         self._randomize_endpoint = randomize_endpoint
 
         self._operation_id = self._operation.get("operationId")
@@ -392,7 +387,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
             self,
             self._resolution.function,
             self.pythonic_params,
-            self._pass_context_arg_name,
         )
 
         if self.validate_responses:

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -38,7 +38,6 @@ class OpenAPIOperation(AbstractOperation):
         validator_map=None,
         pythonic_params=False,
         uri_parser_class=None,
-        pass_context_arg_name=None,
     ):
         """
         This class uses the OperationID identify the module and function that will handle the operation
@@ -80,9 +79,6 @@ class OpenAPIOperation(AbstractOperation):
         :type pythonic_params: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
-        :param pass_context_arg_name: If not None will try to inject the request context to the function using this
-            name.
-        :type pass_context_arg_name: str|None
         """
         self.components = components or {}
 
@@ -104,7 +100,6 @@ class OpenAPIOperation(AbstractOperation):
             validator_map=validator_map,
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
-            pass_context_arg_name=pass_context_arg_name,
         )
 
         self._request_body = operation.get("requestBody", {})

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -37,6 +37,7 @@ class OpenAPIOperation(AbstractOperation):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
+        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -77,6 +78,8 @@ class OpenAPIOperation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
+        :param pass_context_arg: If True will try to inject the request context to the function using `context_` name.
+        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -99,6 +102,7 @@ class OpenAPIOperation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            pass_context_arg=pass_context_arg,
             uri_parser_class=uri_parser_class,
         )
 

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -37,7 +37,6 @@ class OpenAPIOperation(AbstractOperation):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
-        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -78,8 +77,6 @@ class OpenAPIOperation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
-        :param pass_context_arg: If True will try to inject the request context to the function using `context_` name.
-        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -102,7 +99,6 @@ class OpenAPIOperation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg=pass_context_arg,
             uri_parser_class=uri_parser_class,
         )
 

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -45,7 +45,6 @@ class Swagger2Operation(AbstractOperation):
         validator_map=None,
         pythonic_params=False,
         uri_parser_class=None,
-        pass_context_arg_name=None,
     ):
         """
         :param api: api that this operation is attached to
@@ -85,9 +84,6 @@ class Swagger2Operation(AbstractOperation):
         :type pythonic_params: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
-        :param pass_context_arg_name: If not None will try to inject the request context to the function using this
-            name.
-        :type pass_context_arg_name: str|None
         """
         uri_parser_class = uri_parser_class or Swagger2URIParser
 
@@ -107,7 +103,6 @@ class Swagger2Operation(AbstractOperation):
             validator_map=validator_map,
             pythonic_params=pythonic_params,
             uri_parser_class=uri_parser_class,
-            pass_context_arg_name=pass_context_arg_name,
         )
 
         self._produces = operation.get("produces", app_produces)

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -44,7 +44,6 @@ class Swagger2Operation(AbstractOperation):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
-        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -83,8 +82,6 @@ class Swagger2Operation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
-        :param pass_context_arg: If True will try to inject the request context to the function using `context_` name.
-        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -105,7 +102,6 @@ class Swagger2Operation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
-            pass_context_arg=pass_context_arg,
             uri_parser_class=uri_parser_class,
         )
 

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -44,6 +44,7 @@ class Swagger2Operation(AbstractOperation):
         randomize_endpoint=None,
         validator_map=None,
         pythonic_params=False,
+        pass_context_arg=False,
         uri_parser_class=None,
     ):
         """
@@ -82,6 +83,8 @@ class Swagger2Operation(AbstractOperation):
         :param pythonic_params: When True CamelCase parameters are converted to snake_case and an underscore is appended
             to any shadowed built-ins
         :type pythonic_params: bool
+        :param pass_context_arg: If True will try to inject the request context to the function using `context_` name.
+        :type pass_context_arg: bool
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
@@ -102,6 +105,7 @@ class Swagger2Operation(AbstractOperation):
             randomize_endpoint=randomize_endpoint,
             validator_map=validator_map,
             pythonic_params=pythonic_params,
+            pass_context_arg=pass_context_arg,
             uri_parser_class=uri_parser_class,
         )
 

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -42,7 +42,7 @@ class SecurityHandlerFactory:
 
     no_value = object()
     required_scopes_kw = "required_scopes"
-    context_kw = "context"
+    context_kw = "context_"
     client = None
 
     @staticmethod

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -333,7 +333,7 @@ class SecurityHandlerFactory:
 
     def _need_to_add_context_or_scopes(self, func):
         arguments, has_kwargs = inspect_function_arguments(func)
-        need_context = has_kwargs or self.context_kw in arguments
+        need_context = self.context_kw in arguments
         need_required_scopes = has_kwargs or self.required_scopes_kw in arguments
         return need_context, need_required_scopes
 

--- a/examples/openapi3/helloworld/hello.py
+++ b/examples/openapi3/helloworld/hello.py
@@ -3,7 +3,12 @@
 import connexion
 
 
-def post_greeting(name: str) -> str:
+async def test():
+    pass
+
+
+async def post_greeting(name: str) -> str:
+    await test()
     return f"Hello {name}"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,7 @@ def secure_endpoint_app(request):
         "secure_endpoint",
         request.param,
         validate_responses=True,
+        pass_context_arg=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,7 +249,6 @@ def secure_endpoint_app(request):
         "secure_endpoint",
         request.param,
         validate_responses=True,
-        pass_context_arg=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def oauth_requests(monkeypatch):
 
 @pytest.fixture
 def security_handler_factory():
-    security_handler_factory = SecurityHandlerFactory(None)
+    security_handler_factory = SecurityHandlerFactory()
     yield security_handler_factory
 
 
@@ -249,7 +249,6 @@ def secure_endpoint_app(request):
         "secure_endpoint",
         request.param,
         validate_responses=True,
-        pass_context_arg_name="req_context",
     )
 
 

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -25,25 +25,21 @@ def test_injection():
 
 
 def test_injection_with_context():
-    request = MagicMock(
-        name="request", path_params={"p1": "123"}, params={"context_": {"user": "456"}}
-    )
-    request.args = {}
-    request.headers = {}
+    request = MagicMock(name="request")
 
     func = MagicMock()
 
-    def handler(**kwargs):
-        func(**kwargs)
+    def handler(context_, **kwargs):
+        func(context_, **kwargs)
 
     class Op2:
         consumes = ["application/json"]
 
         def get_arguments(self, *args, **kwargs):
-            return {"p1": "123", "context_": {"user": "456"}}
+            return {"p1": "123"}
 
     parameter_to_arg(Op2(), handler)(request)
-    func.assert_called_with(p1="123", context_={"user": "456"})
+    func.assert_called_with(request.context, p1="123")
 
 
 def test_pythonic_params():

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -22,10 +22,8 @@ def test_injection():
 
     parameter_to_arg(Op(), handler)(request)
     func.assert_called_with(p1="123")
-    parameter_to_arg(Op(), handler, pass_context_arg_name="framework_request_ctx")(
-        request
-    )
-    func.assert_called_with(p1="123", framework_request_ctx=request.context)
+    parameter_to_arg(Op(), handler, pass_context_arg=True)(request)
+    func.assert_called_with(p1="123", context_=request.context)
 
 
 def test_pythonic_params():

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -23,11 +23,6 @@ def test_injection():
     parameter_to_arg(Op(), handler)(request)
     func.assert_called_with(p1="123")
 
-    parameter_to_arg(Op(), handler, pass_context_arg_name="framework_request_ctx")(
-        request
-    )
-    func.assert_called_with(p1="123", framework_request_ctx=request.context)
-
 
 def test_pythonic_params():
     assert pythonic("orderBy[eq]") == "order_by_eq"

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -22,6 +22,10 @@ def test_injection():
 
     parameter_to_arg(Op(), handler)(request)
     func.assert_called_with(p1="123")
+    parameter_to_arg(Op(), handler, pass_context_arg_name="framework_request_ctx")(
+        request
+    )
+    func.assert_called_with(p1="123", framework_request_ctx=request.context)
 
 
 def test_pythonic_params():

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -22,8 +22,28 @@ def test_injection():
 
     parameter_to_arg(Op(), handler)(request)
     func.assert_called_with(p1="123")
-    parameter_to_arg(Op(), handler, pass_context_arg=True)(request)
-    func.assert_called_with(p1="123", context_=request.context)
+
+
+def test_injection_with_context():
+    request = MagicMock(
+        name="request", path_params={"p1": "123"}, params={"context_": {"user": "456"}}
+    )
+    request.args = {}
+    request.headers = {}
+
+    func = MagicMock()
+
+    def handler(**kwargs):
+        func(**kwargs)
+
+    class Op2:
+        consumes = ["application/json"]
+
+        def get_arguments(self, *args, **kwargs):
+            return {"p1": "123", "context_": {"user": "456"}}
+
+    parameter_to_arg(Op2(), handler)(request)
+    func.assert_called_with(p1="123", context_={"user": "456"})
 
 
 def test_pythonic_params():

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -87,8 +87,8 @@ def get_bye_secure_from_flask():
     return "Goodbye {user} (Secure!)".format(user=context["user"])
 
 
-def get_bye_secure_from_connexion():
-    return "Goodbye {user} (Secure!)".format(user=context["user"])
+def get_bye_secure_from_connexion(req_context):
+    return "Goodbye {user} (Secure!)".format(user=req_context["user"])
 
 
 def get_bye_secure_ignoring_context(name):

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -87,8 +87,8 @@ def get_bye_secure_from_flask():
     return "Goodbye {user} (Secure!)".format(user=context["user"])
 
 
-def get_bye_secure_from_connexion(req_context):
-    return "Goodbye {user} (Secure!)".format(user=req_context["user"])
+def get_bye_secure_from_connexion():
+    return "Goodbye {user} (Secure!)".format(user=context["user"])
 
 
 def get_bye_secure_ignoring_context(name):

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -87,8 +87,8 @@ def get_bye_secure_from_flask():
     return "Goodbye {user} (Secure!)".format(user=context["user"])
 
 
-def get_bye_secure_from_connexion(req_context):
-    return "Goodbye {user} (Secure!)".format(user=req_context["user"])
+def get_bye_secure_from_connexion(context_):
+    return "Goodbye {user} (Secure!)".format(user=context_["user"])
 
 
 def get_bye_secure_ignoring_context(name):


### PR DESCRIPTION
Fixes #1532 .



Changes proposed in this pull request:

 - I removed the parameter _pass_context_arg_name_ passed internally as asked from the various constructors, and left in the _SecurityHandlerFactory_ a constant called **_context_kw_**, following the same pattern of _required_scopes_kw_. 

I don't know if it is better to put in uppercase both values (_context_kw and required_scopes_kw_), now they are constants in the end. 

I left as the other one to have consistency, but if you prefer I can change them both.