### PR TITLE
fix: don't interpret simple parameter as deepObject

### DIFF
--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -201,6 +201,9 @@ class OpenAPIURIParser(AbstractURIParser):
             if k == root_key:
                 return k, v, False
 
+        if not self._is_deep_object_style_param(root_key):
+            return k, v, False
+
         key_path = re.findall(r'\[([^\[\]]*)\]', k)
         root = prev = node = {}
         for k in key_path:
@@ -209,6 +212,11 @@ class OpenAPIURIParser(AbstractURIParser):
             node = node[k]
         prev[k] = v[0]
         return root_key, [root], True
+    
+    def _is_deep_object_style_param(self, param_name):
+        default_style = self.style_defaults["query"] 
+        style = self.param_defns.get(param_name, {}).get('style', default_style)
+        return style == "deepObject"
 
     def _preprocess_deep_objects(self, query_data):
         """ deep objects provide a way of rendering nested objects using query

--- a/connexion/decorators/uri_parsing.py
+++ b/connexion/decorators/uri_parsing.py
@@ -212,9 +212,9 @@ class OpenAPIURIParser(AbstractURIParser):
             node = node[k]
         prev[k] = v[0]
         return root_key, [root], True
-    
+
     def _is_deep_object_style_param(self, param_name):
-        default_style = self.style_defaults["query"] 
+        default_style = self.style_defaults["query"]
         style = self.param_defns.get(param_name, {}).get('style', default_style)
         return style == "deepObject"
 

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -168,3 +168,31 @@ def test_uri_parser_query_params_with_underscores(parser_class, expected, query_
     p = parser_class(parameters, body_defn)
     res = p(lambda x: x)(request)
     assert res.query["letters_eq"] == expected
+
+
+@pytest.mark.parametrize("parser_class, query_in, collection_format, explode, expected", [
+        (OpenAPIURIParser, MultiDict([("letters[eq]_unrelated", "a")]), None, False,{"letters[eq]_unrelated": ["a"]}),
+        (OpenAPIURIParser, MultiDict([("letters[eq][unrelated]", "a")]), "csv", True,{"letters[eq][unrelated]": ["a"]}),
+    ])
+def test_uri_parser_query_params_with_malformed_names(parser_class, query_in, collection_format, explode, expected):
+    class Request:
+        query = query_in
+        path_params = {}
+        form = {}
+
+    request = Request()
+    parameters = [
+        {"name": "letters[eq]",
+         "in": "query",
+         "explode": explode,
+         "collectionFormat": collection_format,
+         "schema": {
+            "type": "array",
+            "items": {"type": "string"},
+         }
+        }
+    ]
+    body_defn = {}
+    p = parser_class(parameters, body_defn)
+    res = p(lambda x: x)(request)
+    assert res.query == expected


### PR DESCRIPTION
Fixes #1565
