### PR TITLE
Allow enums with nullable defaults

### DIFF
--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -17,7 +17,7 @@ from jsonschema import Draft4Validator
 from jsonschema.validators import extend as extend_validator
 
 from .exceptions import InvalidSpecification
-from .json_schema import NullableTypeValidator, resolve_refs
+from .json_schema import NullableEnumValidator, NullableTypeValidator, resolve_refs
 from .operations import OpenAPIOperation, Swagger2Operation
 from .utils import deep_get
 
@@ -32,7 +32,10 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
     # Create an instance validator, which validates defaults against the spec itself instead of
     # against the OpenAPI schema.
     InstanceValidator = extend_validator(
-        Draft4Validator, {"type": NullableTypeValidator}
+        Draft4Validator, {
+            "type": NullableTypeValidator,
+            "enum": NullableEnumValidator,
+        }
     )
     instance_validator = InstanceValidator(spec)
 

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -32,10 +32,11 @@ def create_spec_validator(spec: dict) -> Draft4Validator:
     # Create an instance validator, which validates defaults against the spec itself instead of
     # against the OpenAPI schema.
     InstanceValidator = extend_validator(
-        Draft4Validator, {
+        Draft4Validator,
+        {
             "type": NullableTypeValidator,
             "enum": NullableEnumValidator,
-        }
+        },
     )
     instance_validator = InstanceValidator(spec)
 

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -645,5 +645,9 @@ def nullable_default(test):
     return
 
 
+def nullable_enum(test):
+    return
+
+
 def get_streaming_response():
     return send_file(__file__)

--- a/tests/fixtures/json_validation/openapi.yaml
+++ b/tests/fixtures/json_validation/openapi.yaml
@@ -97,6 +97,21 @@ paths:
         204:
           description: OK
 
+  /nullable_enum:
+    get:
+      operationId: fakeapi.hello.nullable_enum
+      parameters:
+        - name: test
+          in: query
+          schema:
+            type: string
+            enum: ["good", "bad"]
+            nullable: true
+            default: null
+      responses:
+        204:
+          description: OK
+
   /multipart_form_json:
     post:
       operationId: fakeapi.hello.post_multipart_form

--- a/tests/fixtures/json_validation/swagger.yaml
+++ b/tests/fixtures/json_validation/swagger.yaml
@@ -80,3 +80,16 @@ paths:
       responses:
         204:
           description: OK
+
+  /nullable_enum:
+    get:
+      operationId: fakeapi.hello.nullable_enum
+      parameters:
+        - name: test
+          in: query
+          type: string
+          x-nullable: true
+          default: null
+      responses:
+        204:
+          description: OK


### PR DESCRIPTION
The following two PRs added better support for nullable defaults:
https://github.com/spec-first/connexion/pull/1463
https://github.com/spec-first/connexion/pull/1464

However, it looks like it missed adding `NullableEnumValidator` to `create_spec_validator`.

Also see https://github.com/OAI/OpenAPI-Specification/issues/1900 , which establishes that you can't just put `null` into the enum.

I'd never used openapi or jsonschema or whatever before this week, so maybe I'm totally misunderstanding something. Apologies if so.