### PR TITLE
Fix tests for flask 2.2

### DIFF
--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -237,17 +237,19 @@ def test_swagger_json_content_type(simple_app):
     assert response.content_type == 'application/json'
 
 
-def test_single_route(simple_app):
+def test_single_route():
+    app = App(__name__)
+
     def route1():
         return 'single 1'
 
-    @simple_app.route('/single2', methods=['POST'])
+    @app.route('/single2', methods=['POST'])
     def route2():
         return 'single 2'
 
-    app_client = simple_app.app.test_client()
+    app_client = app.app.test_client()
 
-    simple_app.add_url_rule('/single1', 'single1', route1, methods=['GET'])
+    app.add_url_rule('/single1', 'single1', route1, methods=['GET'])
 
     get_single1 = app_client.get('/single1')  # type: flask.Response
     assert get_single1.data == b'single 1'


### PR DESCRIPTION
Flask no longer allows you to register routes on an application after it has processed its first request. This broke one of our tests adding routes to an application provided by a fixture. I changed this so a new application object is constructed for the test.
