### PR TITLE
Remove "type: ignore" by using list(dict), not dict.keys()

### DIFF
--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -73,14 +73,14 @@ def main():
 @click.option(
     "--wsgi-server",
     "-w",
-    type=click.Choice(AVAILABLE_SERVERS.keys()),  # type: ignore
+    type=click.Choice(list(AVAILABLE_SERVERS)),
     callback=validate_server_requirements,
     help="Which WSGI server container to use. (deprecated, use --server instead)",
 )
 @click.option(
     "--server",
     "-s",
-    type=click.Choice(AVAILABLE_SERVERS.keys()),  # type: ignore
+    type=click.Choice(list(AVAILABLE_SERVERS)),
     callback=validate_server_requirements,
     help="Which server container to use.",
 )
@@ -147,7 +147,7 @@ def main():
     "--app-framework",
     "-f",
     default=FLASK_APP,
-    type=click.Choice(AVAILABLE_APPS.keys()),  # type: ignore
+    type=click.Choice(list(AVAILABLE_APPS)),
     help="The app framework used to run the server",
 )
 def run(


### PR DESCRIPTION
In Python 3, `list(dict)` is often a better way to express `dict.keys()`

Related to #1560 -- @RobbeSneyders @nielsbox Your review, please.