### PR TITLE
Update json for Flask 2.3

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -184,6 +184,8 @@ class FlaskApp(AbstractApp):
 
 
 class FlaskJSONProvider(flask.json.provider.DefaultJSONProvider):
+    """Custom JSONProvider which adds connexion defaults on top of Flask's"""
+
     @jsonifier.wrap_default
     def default(self, o):
         return super().default(o)

--- a/connexion/jsonifier.py
+++ b/connexion/jsonifier.py
@@ -11,6 +11,16 @@ from decimal import Decimal
 
 
 def wrap_default(default_fn: t.Callable) -> t.Callable:
+    """The Connexion defaults for JSON encoding. Handles extra types compared to the
+    built-in :class:`json.JSONEncoder`.
+
+    -   :class:`datetime.datetime` and :class:`datetime.date` are
+        serialized to :rfc:`822` strings. This is the same as the HTTP
+        date format.
+    -   :class:`decimal.Decimal` is serialized to a float.
+    -   :class:`uuid.UUID` is serialized to a string.
+    """
+
     @functools.wraps(default_fn)
     def wrapped_default(self, o):
         if isinstance(o, datetime.datetime):
@@ -39,11 +49,6 @@ def wrap_default(default_fn: t.Callable) -> t.Callable:
 class JSONEncoder(json.JSONEncoder):
     """The default Connexion JSON encoder. Handles extra types compared to the
     built-in :class:`json.JSONEncoder`.
-
-    -   :class:`datetime.datetime` and :class:`datetime.date` are
-        serialized to :rfc:`822` strings. This is the same as the HTTP
-        date format.
-    -   :class:`uuid.UUID` is serialized to a string.
     """
 
     @wrap_default

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -12,7 +12,6 @@ from starlette.templating import Jinja2Templates
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.apis import AbstractSwaggerUIAPI
-from connexion.jsonifier import JSONEncoder, Jsonifier
 from connexion.middleware import AppMiddleware
 from connexion.utils import yamldumper
 
@@ -207,7 +206,3 @@ class SwaggerUIAPI(AbstractSwaggerUIAPI):
             media_type="application/json",
             content=self.jsonifier.dumps(self.options.openapi_console_ui_config),
         )
-
-    @classmethod
-    def _set_jsonifier(cls):
-        cls.jsonifier = Jsonifier(cls=JSONEncoder)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
     'PyYAML>=5.1,<7',
     'requests>=2.27,<3',
     'inflection>=0.3.1,<0.6',
-    'werkzeug>=2,<3',
+    'werkzeug>=2.2.1,<3',
     'starlette>=0.15,<1',
     'httpx>=0.15,<1',
 ]
@@ -33,7 +33,7 @@ install_requires = [
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
 
 flask_require = [
-    'flask>=2,<3',
+    'flask>=2.2,<3',
     'a2wsgi>=1.4,<2',
 ]
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -2,7 +2,7 @@ import json
 from struct import unpack
 
 import yaml
-from connexion.apps.flask_app import FlaskJSONEncoder
+from connexion.apps.flask_app import FlaskJSONProvider
 from werkzeug.test import Client, EnvironBuilder
 
 
@@ -279,15 +279,15 @@ def test_nested_additional_properties(simple_openapi_app):
     assert response == {"nested": {"object": True}}
 
 
-def test_custom_encoder(simple_app):
-    class CustomEncoder(FlaskJSONEncoder):
+def test_custom_provider(simple_app):
+    class CustomProvider(FlaskJSONProvider):
         def default(self, o):
             if o.__class__.__name__ == "DummyClass":
                 return "cool result"
-            return FlaskJSONEncoder.default(self, o)
+            return super().default(o)
 
     flask_app = simple_app.app
-    flask_app.json_encoder = CustomEncoder
+    flask_app.json = CustomProvider(flask_app)
     app_client = flask_app.test_client()
 
     resp = app_client.get("/v1.0/custom-json-response")

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -4,31 +4,33 @@ import math
 from decimal import Decimal
 
 import pytest
-from connexion.apps.flask_app import FlaskJSONEncoder
+from connexion.apps.flask_app import FlaskJSONProvider
 
 from conftest import build_app_from_fixture
 
 SPECS = ["swagger.yaml", "openapi.yaml"]
 
 
-def test_json_encoder():
-    s = json.dumps({1: 2}, cls=FlaskJSONEncoder)
+def test_json_encoder(simple_app):
+    flask_app = simple_app.app
+
+    s = FlaskJSONProvider(flask_app).dumps({1: 2})
     assert '{"1": 2}' == s
 
-    s = json.dumps(datetime.date.today(), cls=FlaskJSONEncoder)
+    s = FlaskJSONProvider(flask_app).dumps(datetime.date.today())
     assert len(s) == 12
 
-    s = json.dumps(datetime.datetime.utcnow(), cls=FlaskJSONEncoder)
+    s = FlaskJSONProvider(flask_app).dumps(datetime.datetime.utcnow())
     assert s.endswith('Z"')
 
-    s = json.dumps(Decimal(1.01), cls=FlaskJSONEncoder)
+    s = FlaskJSONProvider(flask_app).dumps(Decimal(1.01))
     assert s == "1.01"
 
-    s = json.dumps(math.expm1(1e-10), cls=FlaskJSONEncoder)
+    s = FlaskJSONProvider(flask_app).dumps(math.expm1(1e-10))
     assert s == "1.00000000005e-10"
 
 
-def test_json_encoder_datetime_with_timezone():
+def test_json_encoder_datetime_with_timezone(simple_app):
     class DummyTimezone(datetime.tzinfo):
         def utcoffset(self, dt):
             return datetime.timedelta(0)
@@ -36,7 +38,8 @@ def test_json_encoder_datetime_with_timezone():
         def dst(self, dt):
             return datetime.timedelta(0)
 
-    s = json.dumps(datetime.datetime.now(DummyTimezone()), cls=FlaskJSONEncoder)
+    flask_app = simple_app.app
+    s = FlaskJSONProvider(flask_app).dumps(datetime.datetime.now(DummyTimezone()))
     assert s.endswith('+00:00"')
 
 


### PR DESCRIPTION
Partially fixes #1576 by updating the jsonifier and related code to be compatible with Flask 2.3.
Since this new json interface in Flask was only introduced in Flask 2.2, we'll have to pin it as the lower bound version.

I'm doubting if we should backport this to v2. It introduces some breaking changes for users who use custom json encoders, and it would force us to bump the lower bound version of Flask to 2.2 there as well.

If we don't do a backport, we should pin the upper bound Flask version on v2 to 2.2 instead.
