### PR TITLE
Use Flask request_ctx instead of _request_ctx_stack

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -31,4 +31,4 @@ App = FlaskApp
 Api = FlaskApi
 
 # This version is replaced during release process.
-__version__ = "2020.0.dev1"
+__version__ = "3.0.dev0"

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -165,7 +165,7 @@ class FlaskApi(AbstractAPI):
         flask_request = flask.request
         scope = flask_request.environ["asgi.scope"]
         context_dict = scope.get("extensions", {}).get("connexion_context", {})
-        setattr(flask._request_ctx_stack.top, "connexion_context", context_dict)
+        setattr(flask.globals.request_ctx, "connexion_context", context_dict)
         request = ConnexionRequest(
             flask_request.url,
             flask_request.method,
@@ -198,7 +198,7 @@ class FlaskApi(AbstractAPI):
 
 
 def _get_context():
-    return getattr(flask._request_ctx_stack.top, "connexion_context")
+    return getattr(flask.globals.request_ctx, "connexion_context")
 
 
 context = LocalProxy(_get_context)

--- a/connexion/jsonifier.py
+++ b/connexion/jsonifier.py
@@ -49,6 +49,11 @@ def wrap_default(default_fn: t.Callable) -> t.Callable:
 class JSONEncoder(json.JSONEncoder):
     """The default Connexion JSON encoder. Handles extra types compared to the
     built-in :class:`json.JSONEncoder`.
+
+    -   :class:`datetime.datetime` and :class:`datetime.date` are
+        serialized to :rfc:`822` strings. This is the same as the HTTP
+        date format.
+    -   :class:`uuid.UUID` is serialized to a string.
     """
 
     @wrap_default

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -8,6 +8,8 @@ from conftest import SPECS, build_app_from_fixture
 class TestMiddleware:
     """Middleware to check if operation is accessible on scope."""
 
+    __test__ = False
+
     def __init__(self, app):
         self.app = app
 


### PR DESCRIPTION
Fixes #1576 

Another deprecation warning for Flask 2.3.

Also suppressed first party `DeprecationWarning`s for which I had to add a `pytest.ini` file. Since we have quite a lot of config files, we might want to move them to a `pyproject.toml` file in the future.
