### PR TITLE
Resolve $ref referring to another $ref

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -85,8 +85,11 @@ def resolve_refs(spec, store=None, handlers=None):
             path = node["$ref"][2:].split("/")
             try:
                 # resolve known references
-                node.update(deep_get(spec, path))
-                del node["$ref"]
+                retrieved = deep_get(spec, path)
+                node.update(retrieved)
+                if isinstance(retrieved, Mapping) and '$ref' in retrieved:
+                    node = _do_resolve(node)
+                node.pop('$ref', None)
                 return node
             except KeyError:
                 # resolve external references

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -97,3 +97,24 @@ def test_resolve_web_reference(api):
 
     spec = resolve_refs(op_spec, store=store)
     assert spec["parameters"][0]["name"] == "test"
+
+
+def test_resolve_ref_referring_to_another_ref(api):
+    expected = {"type": "string"}
+    op_spec = {
+        "parameters": [
+            {
+                "schema": {"$ref": "#/definitions/A"},
+            }
+        ],
+        "definitions": {
+            "A": {
+                "$ref": "#/definitions/B",
+            },
+            "B": expected,
+        }
+    }
+
+    spec = resolve_refs(op_spec)
+    assert spec["parameters"][0]["schema"] == expected
+    assert spec["definitions"]["A"] == expected


### PR DESCRIPTION
Fixes #1581.

Changes proposed in this pull request:

 - Support to resolve `$ref` referring to another `$ref`.
