### PR TITLE
Remove AbstractSwaggerUIAPI class

### DIFF
--- a/connexion/apis/__init__.py
+++ b/connexion/apis/__init__.py
@@ -13,4 +13,4 @@ on the framework app.
 """
 
 
-from .abstract import AbstractAPI, AbstractRoutingAPI, AbstractSwaggerUIAPI  # NOQA
+from .abstract import AbstractAPI, AbstractRoutingAPI  # NOQA

--- a/connexion/apis/abstract.py
+++ b/connexion/apis/abstract.py
@@ -96,38 +96,6 @@ class AbstractSpecAPI(metaclass=AbstractAPIMeta):
         cls.jsonifier = Jsonifier()
 
 
-class AbstractSwaggerUIAPI(AbstractSpecAPI):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.options.openapi_spec_available:
-            self.add_openapi_json()
-            self.add_openapi_yaml()
-
-        if self.options.openapi_console_ui_available:
-            self.add_swagger_ui()
-
-    @abc.abstractmethod
-    def add_openapi_json(self):
-        """
-        Adds openapi spec to {base_path}/openapi.json
-             (or {base_path}/swagger.json for swagger2)
-        """
-
-    @abc.abstractmethod
-    def add_openapi_yaml(self):
-        """
-        Adds openapi spec to {base_path}/openapi.yaml
-             (or {base_path}/swagger.yaml for swagger2)
-        """
-
-    @abc.abstractmethod
-    def add_swagger_ui(self):
-        """
-        Adds swagger ui to {base_path}/ui/
-        """
-
-
 class AbstractRoutingAPI(AbstractSpecAPI):
     def __init__(
         self,

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -11,7 +11,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from connexion.apis import AbstractSwaggerUIAPI
+from connexion.apis.abstract import AbstractSpecAPI
 from connexion.middleware import AppMiddleware
 from connexion.utils import yamldumper
 
@@ -71,11 +71,18 @@ class SwaggerUIMiddleware(AppMiddleware):
         await self.app(original_scope, receive, send)
 
 
-class SwaggerUIAPI(AbstractSwaggerUIAPI):
+class SwaggerUIAPI(AbstractSpecAPI):
     def __init__(self, *args, default: ASGIApp, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.router = Router(default=default)
 
-        super().__init__(*args, **kwargs)
+        if self.options.openapi_spec_available:
+            self.add_openapi_json()
+            self.add_openapi_yaml()
+
+        if self.options.openapi_console_ui_available:
+            self.add_swagger_ui()
 
         self._templates = Jinja2Templates(
             directory=str(self.options.openapi_console_ui_from_dir)


### PR DESCRIPTION
This PR removes the `AbstractSwaggerUIAPI` class, which was a temporary base class used to support the swagger UI both in the Flask App & Middleware. Since the swagger UI has been moved completely into the middleware, we don't need it anymore.
