### PR TITLE
Extract boilerplate code into Routed base classes

### DIFF
--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,4 +1,4 @@
-from .abstract import AppMiddleware  # NOQA
+from .abstract import AppMiddleware, RoutedMiddleware  # NOQA
 from .main import ConnexionMiddleware  # NOQA
 from .routing import RoutingMiddleware  # NOQA
 from .swagger_ui import SwaggerUIMiddleware  # NOQA

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -93,11 +93,8 @@ class RoutedMiddleware(AppMiddleware, t.Generic[API]):
     operation_id lookup.
     """
 
-    @property
-    @abc.abstractmethod
-    def api_cls(self) -> t.Type[API]:
-        """The subclass of RoutedAPI this middleware uses."""
-        raise NotImplementedError
+    api_cls: t.Type[API]
+    """The subclass of RoutedAPI this middleware uses."""
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import typing as t
 
+import typing_extensions as te
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.apis.abstract import AbstractSpecAPI
@@ -27,7 +28,7 @@ class AppMiddleware(abc.ABC):
         pass
 
 
-class RoutedOperation(t.Protocol):
+class RoutedOperation(te.Protocol):
     def __init__(self, next_app: ASGIApp, **kwargs) -> None:
         ...
 

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -1,6 +1,19 @@
 import abc
+import logging
 import pathlib
 import typing as t
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.apis.abstract import AbstractSpecAPI
+from connexion.exceptions import MissingMiddleware
+from connexion.http_facts import METHODS
+from connexion.operations import AbstractOperation
+from connexion.resolver import ResolverError
+
+logger = logging.getLogger("connexion.middleware.abstract")
+
+ROUTING_CONTEXT = "connexion_routing"
 
 
 class AppMiddleware(abc.ABC):
@@ -12,3 +25,120 @@ class AppMiddleware(abc.ABC):
         self, specification: t.Union[pathlib.Path, str, dict], **kwargs
     ) -> None:
         pass
+
+
+class RoutedOperation(t.Protocol):
+    def __init__(self, next_app: ASGIApp, **kwargs) -> None:
+        ...
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        ...
+
+
+OP = t.TypeVar("OP", bound=RoutedOperation)
+
+
+class RoutedAPI(AbstractSpecAPI, t.Generic[OP]):
+
+    operation_cls: t.Type[OP]
+    """The operation this middleware uses, which should implement the RoutingOperation protocol."""
+
+    def __init__(
+        self,
+        specification: t.Union[pathlib.Path, str, dict],
+        *args,
+        next_app: ASGIApp,
+        **kwargs,
+    ) -> None:
+        super().__init__(specification, *args, **kwargs)
+        self.next_app = next_app
+        self.operations: t.MutableMapping[str, OP] = {}
+
+    def add_paths(self) -> None:
+        paths = self.specification.get("paths", {})
+        for path, methods in paths.items():
+            for method in methods:
+                if method not in METHODS:
+                    continue
+                try:
+                    self.add_operation(path, method)
+                except ResolverError:
+                    # ResolverErrors are either raised or handled in routing middleware.
+                    pass
+
+    def add_operation(self, path: str, method: str) -> None:
+        operation_spec_cls = self.specification.operation_cls
+        operation = operation_spec_cls.from_spec(
+            self.specification, self, path, method, self.resolver
+        )
+        routed_operation = self.make_operation(operation)
+        self.operations[operation.operation_id] = routed_operation
+
+    @abc.abstractmethod
+    def make_operation(self, operation: AbstractOperation) -> OP:
+        """Create an operation of the `operation_cls` type."""
+        raise NotImplementedError
+
+
+API = t.TypeVar("API", bound="RoutedAPI")
+
+
+class RoutedMiddleware(AppMiddleware, t.Generic[API]):
+    """Baseclass for middleware that wants to leverage the RoutingMiddleware to route requests to
+    its operations.
+
+    The RoutingMiddleware adds the operation_id to the ASGI scope. This middleware registers its
+    operations by operation_id at startup. At request time, the operation is fetched by an
+    operation_id lookup.
+    """
+
+    @property
+    @abc.abstractmethod
+    def api_cls(self) -> t.Type[API]:
+        """The subclass of RoutedAPI this middleware uses."""
+        raise NotImplementedError
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self.apis: t.Dict[str, API] = {}
+
+    def add_api(
+        self, specification: t.Union[pathlib.Path, str, dict], **kwargs
+    ) -> None:
+        api = self.api_cls(specification, next_app=self.app, **kwargs)
+        self.apis[api.base_path] = api
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Fetches the operation related to the request and calls it."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            connexion_context = scope["extensions"][ROUTING_CONTEXT]
+        except KeyError:
+            raise MissingMiddleware(
+                "Could not find routing information in scope. Please make sure "
+                "you have a routing middleware registered upstream. "
+            )
+        api_base_path = connexion_context.get("api_base_path")
+        if api_base_path:
+            api = self.apis[api_base_path]
+            operation_id = connexion_context.get("operation_id")
+            try:
+                operation = api.operations[operation_id]
+            except KeyError as e:
+                if operation_id is None:
+                    logger.debug("Skipping validation check for operation without id.")
+                    await self.app(scope, receive, send)
+                    return
+                else:
+                    raise MissingOperation("Encountered unknown operation_id.") from e
+            else:
+                return await operation(scope, receive, send)
+
+        await self.app(scope, receive, send)
+
+
+class MissingOperation(Exception):
+    """Missing operation"""

--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -39,7 +39,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
 
     def http_exception(self, request: Request, exc: HTTPException) -> Response:
         try:
-            headers = exc.headers
+            headers = exc.headers  # type: ignore
         except AttributeError:
             # Starlette < 0.19
             headers = {}

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -6,14 +6,78 @@ from starlette.routing import Router
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.apis import AbstractRoutingAPI
-from connexion.middleware import AppMiddleware
+from connexion.middleware.abstract import ROUTING_CONTEXT, AppMiddleware
 from connexion.operations import AbstractOperation
 from connexion.resolver import Resolver
 
-ROUTING_CONTEXT = "connexion_routing"
-
-
 _scope: ContextVar[dict] = ContextVar("SCOPE")
+
+
+class RoutingOperation:
+    def __init__(self, operation_id: t.Optional[str], next_app: ASGIApp) -> None:
+        self.operation_id = operation_id
+        self.next_app = next_app
+
+    @classmethod
+    def from_operation(cls, operation: AbstractOperation, next_app: ASGIApp):
+        return cls(operation.operation_id, next_app)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Attach operation to scope and pass it to the next app"""
+        original_scope = _scope.get()
+
+        api_base_path = scope.get("root_path", "")[
+            len(original_scope.get("root_path", "")) :
+        ]
+
+        extensions = original_scope.setdefault("extensions", {})
+        connexion_routing = extensions.setdefault(ROUTING_CONTEXT, {})
+        connexion_routing.update(
+            {"api_base_path": api_base_path, "operation_id": self.operation_id}
+        )
+        await self.next_app(original_scope, receive, send)
+
+
+class RoutingAPI(AbstractRoutingAPI):
+    def __init__(
+        self,
+        specification: t.Union[pathlib.Path, str, dict],
+        *,
+        next_app: ASGIApp,
+        base_path: t.Optional[str] = None,
+        arguments: t.Optional[dict] = None,
+        resolver: t.Optional[Resolver] = None,
+        resolver_error_handler: t.Optional[t.Callable] = None,
+        debug: bool = False,
+        **kwargs
+    ) -> None:
+        """API implementation on top of Starlette Router for Connexion middleware."""
+        self.next_app = next_app
+        self.router = Router(default=RoutingOperation(None, next_app))
+
+        super().__init__(
+            specification,
+            base_path=base_path,
+            arguments=arguments,
+            resolver=resolver,
+            resolver_error_handler=resolver_error_handler,
+            debug=debug,
+        )
+
+    def add_operation(self, path: str, method: str) -> None:
+        operation_cls = self.specification.operation_cls
+        operation = operation_cls.from_spec(
+            self.specification, self, path, method, self.resolver
+        )
+        routing_operation = RoutingOperation.from_operation(
+            operation, next_app=self.next_app
+        )
+        self._add_operation_internal(method, path, routing_operation)
+
+    def _add_operation_internal(
+        self, method: str, path: str, operation: "RoutingOperation"
+    ) -> None:
+        self.router.add_route(path, operation, methods=[method])
 
 
 class RoutingMiddleware(AppMiddleware):
@@ -61,70 +125,3 @@ class RoutingMiddleware(AppMiddleware):
         # Needs to be set so starlette router throws exceptions instead of returning error responses
         scope["app"] = self
         await self.router(scope, receive, send)
-
-
-class RoutingAPI(AbstractRoutingAPI):
-    def __init__(
-        self,
-        specification: t.Union[pathlib.Path, str, dict],
-        *,
-        next_app: ASGIApp,
-        base_path: t.Optional[str] = None,
-        arguments: t.Optional[dict] = None,
-        resolver: t.Optional[Resolver] = None,
-        resolver_error_handler: t.Optional[t.Callable] = None,
-        debug: bool = False,
-        **kwargs
-    ) -> None:
-        """API implementation on top of Starlette Router for Connexion middleware."""
-        self.next_app = next_app
-        self.router = Router(default=RoutingOperation(None, next_app))
-
-        super().__init__(
-            specification,
-            base_path=base_path,
-            arguments=arguments,
-            resolver=resolver,
-            resolver_error_handler=resolver_error_handler,
-            debug=debug,
-        )
-
-    def add_operation(self, path: str, method: str) -> None:
-        operation_cls = self.specification.operation_cls
-        operation = operation_cls.from_spec(
-            self.specification, self, path, method, self.resolver
-        )
-        routing_operation = RoutingOperation.from_operation(
-            operation, next_app=self.next_app
-        )
-        self._add_operation_internal(method, path, routing_operation)
-
-    def _add_operation_internal(
-        self, method: str, path: str, operation: "RoutingOperation"
-    ) -> None:
-        self.router.add_route(path, operation, methods=[method])
-
-
-class RoutingOperation:
-    def __init__(self, operation_id: t.Optional[str], next_app: ASGIApp) -> None:
-        self.operation_id = operation_id
-        self.next_app = next_app
-
-    @classmethod
-    def from_operation(cls, operation: AbstractOperation, next_app: ASGIApp):
-        return cls(operation.operation_id, next_app)
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """Attach operation to scope and pass it to the next app"""
-        original_scope = _scope.get()
-
-        api_base_path = scope.get("root_path", "")[
-            len(original_scope.get("root_path", "")) :
-        ]
-
-        extensions = original_scope.setdefault("extensions", {})
-        connexion_routing = extensions.setdefault(ROUTING_CONTEXT, {})
-        connexion_routing.update(
-            {"api_base_path": api_base_path, "operation_id": self.operation_id}
-        )
-        await self.next_app(original_scope, receive, send)

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -236,9 +236,7 @@ class SecurityAPI(RoutedAPI[SecurityOperation]):
 class SecurityMiddleware(RoutedMiddleware[SecurityAPI]):
     """Middleware to check if operation is accessible on scope."""
 
-    @property
-    def api_cls(self) -> t.Type[SecurityAPI]:
-        return SecurityAPI
+    api_cls = SecurityAPI
 
 
 class MissingSecurityOperation(ProblemException):

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -21,56 +21,6 @@ logger = logging.getLogger("connexion.middleware.swagger_ui")
 _original_scope: ContextVar[Scope] = ContextVar("SCOPE")
 
 
-class SwaggerUIMiddleware(AppMiddleware):
-    def __init__(self, app: ASGIApp) -> None:
-        """Middleware that hosts a swagger UI.
-
-        :param app: app to wrap in middleware.
-        """
-        self.app = app
-        # Set default to pass unknown routes to next app
-        self.router = Router(default=self.default_fn)
-
-    def add_api(
-        self,
-        specification: t.Union[pathlib.Path, str, dict],
-        base_path: t.Optional[str] = None,
-        arguments: t.Optional[dict] = None,
-        **kwargs
-    ) -> None:
-        """Add an API to the router based on a OpenAPI spec.
-
-        :param specification: OpenAPI spec as dict or path to file.
-        :param base_path: Base path where to add this API.
-        :param arguments: Jinja arguments to replace in the spec.
-        """
-        api = SwaggerUIAPI(
-            specification,
-            base_path=base_path,
-            arguments=arguments,
-            default=self.default_fn,
-            **kwargs
-        )
-        self.router.mount(api.base_path, app=api.router)
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        _original_scope.set(scope.copy())  # type: ignore
-        await self.router(scope, receive, send)
-
-    async def default_fn(self, _scope: Scope, receive: Receive, send: Send) -> None:
-        """
-        Callback to call next app as default when no matching route is found.
-
-        Unfortunately we cannot just pass the next app as default, since the router manipulates
-        the scope when descending into mounts, losing information about the base path. Therefore,
-        we use the original scope instead.
-
-        This is caused by https://github.com/encode/starlette/issues/1336.
-        """
-        original_scope = _original_scope.get()
-        await self.app(original_scope, receive, send)
-
-
 class SwaggerUIAPI(AbstractSwaggerUIAPI):
     def __init__(self, *args, default: ASGIApp, **kwargs):
         self.router = Router(default=default)
@@ -206,3 +156,53 @@ class SwaggerUIAPI(AbstractSwaggerUIAPI):
             media_type="application/json",
             content=self.jsonifier.dumps(self.options.openapi_console_ui_config),
         )
+
+
+class SwaggerUIMiddleware(AppMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        """Middleware that hosts a swagger UI.
+
+        :param app: app to wrap in middleware.
+        """
+        self.app = app
+        # Set default to pass unknown routes to next app
+        self.router = Router(default=self.default_fn)
+
+    def add_api(
+        self,
+        specification: t.Union[pathlib.Path, str, dict],
+        base_path: t.Optional[str] = None,
+        arguments: t.Optional[dict] = None,
+        **kwargs
+    ) -> None:
+        """Add an API to the router based on a OpenAPI spec.
+
+        :param specification: OpenAPI spec as dict or path to file.
+        :param base_path: Base path where to add this API.
+        :param arguments: Jinja arguments to replace in the spec.
+        """
+        api = SwaggerUIAPI(
+            specification,
+            base_path=base_path,
+            arguments=arguments,
+            default=self.default_fn,
+            **kwargs
+        )
+        self.router.mount(api.base_path, app=api.router)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        _original_scope.set(scope.copy())  # type: ignore
+        await self.router(scope, receive, send)
+
+    async def default_fn(self, _scope: Scope, receive: Receive, send: Send) -> None:
+        """
+        Callback to call next app as default when no matching route is found.
+
+        Unfortunately we cannot just pass the next app as default, since the router manipulates
+        the scope when descending into mounts, losing information about the base path. Therefore,
+        we use the original scope instead.
+
+        This is caused by https://github.com/encode/starlette/issues/1336.
+        """
+        original_scope = _original_scope.get()
+        await self.app(original_scope, receive, send)

--- a/connexion/middleware/validation.py
+++ b/connexion/middleware/validation.py
@@ -2,19 +2,14 @@
 Validation Middleware.
 """
 import logging
-import pathlib
 import typing as t
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from connexion.apis.abstract import AbstractSpecAPI
 from connexion.decorators.uri_parsing import AbstractURIParser
-from connexion.exceptions import MissingMiddleware, UnsupportedMediaTypeProblem
-from connexion.http_facts import METHODS
-from connexion.middleware import AppMiddleware
-from connexion.middleware.routing import ROUTING_CONTEXT
+from connexion.exceptions import UnsupportedMediaTypeProblem
+from connexion.middleware.abstract import RoutedAPI, RoutedMiddleware
 from connexion.operations import AbstractOperation
-from connexion.resolver import ResolverError
 from connexion.utils import is_nullable
 from connexion.validators import JSONBodyValidator
 
@@ -30,130 +25,19 @@ VALIDATOR_MAP = {
 }
 
 
-class ValidationMiddleware(AppMiddleware):
-    """Middleware for validating requests according to the API contract."""
-
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
-        self.apis: t.Dict[str, ValidationAPI] = {}
-
-    def add_api(
-        self, specification: t.Union[pathlib.Path, str, dict], **kwargs
-    ) -> None:
-        api = ValidationAPI(specification, next_app=self.app, **kwargs)
-        self.apis[api.base_path] = api
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-
-        try:
-            connexion_context = scope["extensions"][ROUTING_CONTEXT]
-        except KeyError:
-            raise MissingMiddleware(
-                "Could not find routing information in scope. Please make sure "
-                "you have a routing middleware registered upstream. "
-            )
-        api_base_path = connexion_context.get("api_base_path")
-        if api_base_path:
-            api = self.apis[api_base_path]
-            operation_id = connexion_context.get("operation_id")
-            try:
-                operation = api.operations[operation_id]
-            except KeyError as e:
-                if operation_id is None:
-                    logger.debug("Skipping validation check for operation without id.")
-                    await self.app(scope, receive, send)
-                    return
-                else:
-                    raise MissingValidationOperation(
-                        "Encountered unknown operation_id."
-                    ) from e
-            else:
-                return await operation(scope, receive, send)
-
-        await self.app(scope, receive, send)
-
-
-class ValidationAPI(AbstractSpecAPI):
-    """Validation API."""
-
-    def __init__(
-        self,
-        specification: t.Union[pathlib.Path, str, dict],
-        *args,
-        next_app: ASGIApp,
-        validate_responses=False,
-        strict_validation=False,
-        validator_map=None,
-        uri_parser_class=None,
-        **kwargs,
-    ):
-        super().__init__(specification, *args, **kwargs)
-        self.next_app = next_app
-
-        self.validator_map = validator_map
-
-        logger.debug("Validate Responses: %s", str(validate_responses))
-        self.validate_responses = validate_responses
-
-        logger.debug("Strict Request Validation: %s", str(strict_validation))
-        self.strict_validation = strict_validation
-
-        self.uri_parser_class = uri_parser_class
-
-        self.operations: t.Dict[str, ValidationOperation] = {}
-        self.add_paths()
-
-    def add_paths(self):
-        paths = self.specification.get("paths", {})
-        for path, methods in paths.items():
-            for method in methods:
-                if method not in METHODS:
-                    continue
-                try:
-                    self.add_operation(path, method)
-                except ResolverError:
-                    # ResolverErrors are either raised or handled in routing middleware.
-                    pass
-
-    def add_operation(self, path: str, method: str) -> None:
-        operation_cls = self.specification.operation_cls
-        operation = operation_cls.from_spec(
-            self.specification, self, path, method, self.resolver
-        )
-        validation_operation = self.make_operation(operation)
-        self._add_operation_internal(operation.operation_id, validation_operation)
-
-    def make_operation(self, operation: AbstractOperation):
-        return ValidationOperation(
-            operation,
-            self.next_app,
-            validate_responses=self.validate_responses,
-            strict_validation=self.strict_validation,
-            validator_map=self.validator_map,
-            uri_parser_class=self.uri_parser_class,
-        )
-
-    def _add_operation_internal(
-        self, operation_id: str, operation: "ValidationOperation"
-    ):
-        self.operations[operation_id] = operation
-
-
 class ValidationOperation:
     def __init__(
         self,
-        operation: AbstractOperation,
         next_app: ASGIApp,
+        *,
+        operation: AbstractOperation,
         validate_responses: bool = False,
         strict_validation: bool = False,
         validator_map: t.Optional[dict] = None,
         uri_parser_class: t.Optional[AbstractURIParser] = None,
     ) -> None:
-        self._operation = operation
         self.next_app = next_app
+        self._operation = operation
         self.validate_responses = validate_responses
         self.strict_validation = strict_validation
         self._validator_map = VALIDATOR_MAP
@@ -226,6 +110,52 @@ class ValidationOperation:
             return await validator(scope, receive, send)
 
         await self.next_app(scope, receive, send)
+
+
+class ValidationAPI(RoutedAPI[ValidationOperation]):
+    """Validation API."""
+
+    operation_cls = ValidationOperation
+
+    def __init__(
+        self,
+        *args,
+        validate_responses=False,
+        strict_validation=False,
+        validator_map=None,
+        uri_parser_class=None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.validator_map = validator_map
+
+        logger.debug("Validate Responses: %s", str(validate_responses))
+        self.validate_responses = validate_responses
+
+        logger.debug("Strict Request Validation: %s", str(strict_validation))
+        self.strict_validation = strict_validation
+
+        self.uri_parser_class = uri_parser_class
+
+        self.add_paths()
+
+    def make_operation(self, operation: AbstractOperation) -> ValidationOperation:
+        return ValidationOperation(
+            self.next_app,
+            operation=operation,
+            validate_responses=self.validate_responses,
+            strict_validation=self.strict_validation,
+            validator_map=self.validator_map,
+            uri_parser_class=self.uri_parser_class,
+        )
+
+
+class ValidationMiddleware(RoutedMiddleware[ValidationAPI]):
+    """Middleware for validating requests according to the API contract."""
+
+    @property
+    def api_cls(self) -> t.Type[ValidationAPI]:
+        return ValidationAPI
 
 
 class MissingValidationOperation(Exception):

--- a/connexion/middleware/validation.py
+++ b/connexion/middleware/validation.py
@@ -153,9 +153,7 @@ class ValidationAPI(RoutedAPI[ValidationOperation]):
 class ValidationMiddleware(RoutedMiddleware[ValidationAPI]):
     """Middleware for validating requests according to the API contract."""
 
-    @property
-    def api_cls(self) -> t.Type[ValidationAPI]:
-        return ValidationAPI
+    api_cls = ValidationAPI
 
 
 class MissingValidationOperation(Exception):

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ install_requires = [
     'werkzeug>=2.2.1,<3',
     'starlette>=0.15,<1',
     'httpx>=0.15,<1',
+    'typing-extensions>=4,<5',
+    'mock>=3,<4'
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ install_requires = [
     'starlette>=0.15,<1',
     'httpx>=0.15,<1',
     'typing-extensions>=4,<5',
-    'mock>=3,<4'
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -3,8 +3,8 @@ import logging
 import math
 import pathlib
 import types
+from unittest import mock
 
-import mock
 import pytest
 from connexion.apis.flask_api import Jsonifier
 from connexion.exceptions import InvalidSpecification
@@ -425,7 +425,7 @@ def test_operation_remote_token_info(security_handler_factory):
     )
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_REMOTE,
@@ -495,7 +495,7 @@ def test_operation_local_security_oauth2(security_handler_factory):
     security_handler_factory.verify_oauth = verify_oauth
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_LOCAL,
@@ -511,7 +511,7 @@ def test_operation_local_security_duplicate_token_info(security_handler_factory)
     security_handler_factory.verify_oauth = verify_oauth
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_BOTH,
@@ -548,7 +548,7 @@ def test_multi_body(api):
 
 def test_no_token_info(security_handler_factory):
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_WO_INFO,
@@ -569,7 +569,7 @@ def test_multiple_security_schemes_and(security_handler_factory):
     security = [{"key1": [], "key2": []}]
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_2_KEYS,
@@ -594,7 +594,7 @@ def test_multiple_oauth_in_and(security_handler_factory, caplog):
     security = [{"oauth_1": ["uid"], "oauth_2": ["uid"]}]
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_2_OAUTH,
@@ -691,7 +691,7 @@ def test_oauth_scopes_in_or(security_handler_factory):
     security = [{"oauth": ["myscope"]}, {"oauth": ["myscope2"]}]
 
     SecurityOperation(
-        next_app=mock.AsyncMock,
+        next_app=mock.Mock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_LOCAL,

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -425,6 +425,7 @@ def test_operation_remote_token_info(security_handler_factory):
     )
 
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_REMOTE,
@@ -494,6 +495,7 @@ def test_operation_local_security_oauth2(security_handler_factory):
     security_handler_factory.verify_oauth = verify_oauth
 
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_LOCAL,
@@ -509,7 +511,8 @@ def test_operation_local_security_duplicate_token_info(security_handler_factory)
     security_handler_factory.verify_oauth = verify_oauth
 
     SecurityOperation(
-        security_handler_factory,
+        next_app=mock.AsyncMock,
+        security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_BOTH,
     )
@@ -545,6 +548,7 @@ def test_multi_body(api):
 
 def test_no_token_info(security_handler_factory):
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=[{"oauth": ["uid"]}],
         security_schemes=SECURITY_DEFINITIONS_WO_INFO,
@@ -565,6 +569,7 @@ def test_multiple_security_schemes_and(security_handler_factory):
     security = [{"key1": [], "key2": []}]
 
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_2_KEYS,
@@ -589,6 +594,7 @@ def test_multiple_oauth_in_and(security_handler_factory, caplog):
     security = [{"oauth_1": ["uid"], "oauth_2": ["uid"]}]
 
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_2_OAUTH,
@@ -685,6 +691,7 @@ def test_oauth_scopes_in_or(security_handler_factory):
     security = [{"oauth": ["myscope"]}, {"oauth": ["myscope2"]}]
 
     SecurityOperation(
+        next_app=mock.AsyncMock,
         security_handler_factory=security_handler_factory,
         security=security,
         security_schemes=SECURITY_DEFINITIONS_LOCAL,

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -3,8 +3,8 @@ import logging
 import math
 import pathlib
 import types
-from unittest import mock
 
+import mock
 import pytest
 from connexion.apis.flask_api import Jsonifier
 from connexion.exceptions import InvalidSpecification


### PR DESCRIPTION
As mentioned in #1588, we're repeating a lot of boilerplate across the middlewares. This PR extracts this boilerplate into shared base classes. Feel free to propose better naming for them :slightly_smiling_face: 

I had to revert the order of Middleware - Api - Operation to Operation - Api - Middleware due to dependencies in the typing.