### PR TITLE
Explicitly support Flask async routes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
 
 flask_require = [
-    'flask>=2.2,<3',
+    'flask[async]>=2.2,<3',
     'a2wsgi>=1.4,<2',
 ]
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -361,3 +361,9 @@ def test_using_all_fields_in_path_item(simple_api_spec_dir):
             continue
         test_methods.update({method.lower() for method in rule.methods})
     assert set(test_methods) == METHODS
+
+
+def test_async_route(simple_app):
+    app_client = simple_app.app.test_client()
+    resp = app_client.get("/v1.0/async-route")
+    assert resp.status_code == 200

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -647,3 +647,7 @@ def nullable_default(test):
 
 def get_streaming_response():
     return send_file(__file__)
+
+
+async def async_route():
+    return {}, 200

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1239,6 +1239,13 @@ paths:
       responses:
         '200':
           description: Echo the validated request.
+  /async-route:
+    get:
+      operationId: fakeapi.hello.async_route
+      responses:
+        200:
+          description: 'OK'
+
 
 servers:
   - url: http://localhost:{port}/{basePath}

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -1046,6 +1046,13 @@ paths:
           schema:
             type: file
 
+  /async-route:
+    get:
+      operationId: fakeapi.hello.async_route
+      responses:
+        200:
+          description: 'OK'
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
Fixes #1529

Flask async routes were already supported due to the async logic used for `aiohttp`. This PR just makes it explicit by:

- Installing Flask with the `async` extra.  
The additional `asgiref` dependency it adds is already a subdependency of connexion though, so in practice this has no effect.
- Adding a test checking if async routes work
