### PR TITLE
Add form data validator for validation middleware

### DIFF
--- a/connexion/datastructures.py
+++ b/connexion/datastructures.py
@@ -1,0 +1,31 @@
+from fnmatch import fnmatch
+
+
+class MediaTypeDict(dict):
+    """
+    A dictionary where keys can be either media types or media type ranges. When fetching a
+    value from the dictionary, the provided key is checked against the ranges. The most specific
+    key is chosen as prescribed by the OpenAPI spec, with `type/*` being preferred above
+    `*/subtype`.
+    """
+
+    def __getitem__(self, item):
+        # Sort keys in order of specificity
+        for key in sorted(self, key=lambda k: ("*" not in k, k), reverse=True):
+            if fnmatch(item, key):
+                return super().__getitem__(key)
+        raise super().__getitem__(item)
+
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
+    def __contains__(self, item):
+        try:
+            self[item]
+        except KeyError:
+            return False
+        else:
+            return True

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -8,8 +8,6 @@ import functools
 import logging
 
 from jsonschema import Draft4Validator, ValidationError
-from jsonschema.validators import extend
-from werkzeug.datastructures import FileStorage
 
 from ..exceptions import BadRequestProblem, ExtraParameterProblem
 from ..utils import boolean, is_null, is_nullable
@@ -19,7 +17,7 @@ logger = logging.getLogger("connexion.decorators.validation")
 TYPE_MAP = {"integer": int, "number": float, "boolean": boolean, "object": dict}
 
 try:
-    draft4_format_checker = Draft4Validator.FORMAT_CHECKER
+    draft4_format_checker = Draft4Validator.FORMAT_CHECKER  # type: ignore
 except AttributeError:  # jsonschema < 4.5.0
     from jsonschema import draft4_format_checker
 
@@ -127,20 +125,9 @@ class ParameterValidator:
             if "required" in param:
                 del param["required"]
             try:
-                if parameter_type == "formdata" and param.get("type") == "file":
-                    extend(
-                        Draft4Validator,
-                        type_checker=Draft4Validator.TYPE_CHECKER.redefine(
-                            "file",
-                            lambda checker, instance: isinstance(instance, FileStorage),
-                        ),
-                    )(param, format_checker=draft4_format_checker).validate(
-                        converted_value
-                    )
-                else:
-                    Draft4Validator(
-                        param, format_checker=draft4_format_checker
-                    ).validate(converted_value)
+                Draft4Validator(param, format_checker=draft4_format_checker).validate(
+                    converted_value
+                )
             except ValidationError as exception:
                 debug_msg = (
                     "Error while converting value {converted_value} from param "
@@ -165,14 +152,6 @@ class ParameterValidator:
         spec_params = [x["name"] for x in self.parameters.get("query", [])]
         return validate_parameter_list(request_params, spec_params)
 
-    def validate_formdata_parameter_list(self, request):
-        request_params = request.form.keys()
-        if "formData" in self.parameters:  # Swagger 2:
-            spec_params = [x["name"] for x in self.parameters["formData"]]
-        else:  # OAS 3
-            return set()
-        return validate_parameter_list(request_params, spec_params)
-
     def validate_query_parameter(self, param, request):
         """
         Validate a single query parameter (request.args in Flask)
@@ -195,14 +174,6 @@ class ParameterValidator:
         val = request.cookies.get(param["name"])
         return self.validate_parameter("cookie", val, param)
 
-    def validate_formdata_parameter(self, param_name, param, request):
-        if param.get("type") == "file" or param.get("format") == "binary":
-            val = request.files.get(param_name)
-        else:
-            val = request.form.get(param_name)
-
-        return self.validate_parameter("formdata", val, param)
-
     def __call__(self, function):
         """
         :type function: types.FunctionType
@@ -215,10 +186,9 @@ class ParameterValidator:
 
             if self.strict_validation:
                 query_errors = self.validate_query_parameter_list(request)
-                formdata_errors = self.validate_formdata_parameter_list(request)
 
-                if formdata_errors or query_errors:
-                    raise ExtraParameterProblem(formdata_errors, query_errors)
+                if query_errors:
+                    raise ExtraParameterProblem([], query_errors)
 
             for param in self.parameters.get("query", []):
                 error = self.validate_query_parameter(param, request)
@@ -237,11 +207,6 @@ class ParameterValidator:
 
             for param in self.parameters.get("cookie", []):
                 error = self.validate_cookie_parameter(param, request)
-                if error:
-                    raise BadRequestProblem(detail=error)
-
-            for param in self.parameters.get("formData", []):
-                error = self.validate_formdata_parameter(param["name"], param, request)
                 if error:
                     raise BadRequestProblem(detail=error)
 

--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -6,16 +6,12 @@ import collections
 import copy
 import functools
 import logging
-import typing as t
 
 from jsonschema import Draft4Validator, ValidationError
 from jsonschema.validators import extend
 from werkzeug.datastructures import FileStorage
 
 from ..exceptions import BadRequestProblem, ExtraParameterProblem
-from ..http_facts import FORM_CONTENT_TYPES
-from ..json_schema import Draft4RequestValidator
-from ..lifecycle import ConnexionResponse
 from ..utils import boolean, is_null, is_nullable
 
 logger = logging.getLogger("connexion.decorators.validation")
@@ -99,106 +95,6 @@ def validate_parameter_list(request_params, spec_params):
     spec_params = set(spec_params)
 
     return request_params.difference(spec_params)
-
-
-class RequestBodyValidator:
-    def __init__(
-        self,
-        schema,
-        consumes,
-        api,
-        is_null_value_valid=False,
-        validator=None,
-        strict_validation=False,
-    ):
-        """
-        :param schema: The schema of the request body
-        :param consumes: The list of content types the operation consumes
-        :param is_null_value_valid: Flag to indicate if null is accepted as valid value.
-        :param validator: Validator class that should be used to validate passed data
-                          against API schema. Default is jsonschema.Draft4Validator.
-        :type validator: jsonschema.IValidator
-        :param strict_validation: Flag indicating if parameters not in spec are allowed
-        """
-        self.consumes = consumes
-        self.schema = schema
-        self.has_default = schema.get("default", False)
-        self.is_null_value_valid = is_null_value_valid
-        validatorClass = validator or Draft4RequestValidator
-        self.validator = validatorClass(schema, format_checker=draft4_format_checker)
-        self.api = api
-        self.strict_validation = strict_validation
-
-    def validate_formdata_parameter_list(self, request):
-        request_params = request.form.keys()
-        spec_params = self.schema.get("properties", {}).keys()
-        return validate_parameter_list(request_params, spec_params)
-
-    def __call__(self, function):
-        """
-        :type function: types.FunctionType
-        :rtype: types.FunctionType
-        """
-
-        @functools.wraps(function)
-        def wrapper(request):
-            if self.consumes[0] in FORM_CONTENT_TYPES:
-                data = dict(request.form.items()) or (
-                    request.body if len(request.body) > 0 else {}
-                )
-                data.update(
-                    dict.fromkeys(request.files, "")
-                )  # validator expects string..
-                logger.debug("%s validating schema...", request.url)
-
-                if self.strict_validation:
-                    formdata_errors = self.validate_formdata_parameter_list(request)
-                    if formdata_errors:
-                        raise ExtraParameterProblem(formdata_errors, [])
-
-                if data:
-                    props = self.schema.get("properties", {})
-                    errs = []
-                    for k, param_defn in props.items():
-                        if k in data:
-                            try:
-                                data[k] = coerce_type(
-                                    param_defn, data[k], "requestBody", k
-                                )
-                            except TypeValidationError as e:
-                                errs += [str(e)]
-                                print(errs)
-                    if errs:
-                        raise BadRequestProblem(detail=errs)
-
-                self.validate_schema(data, request.url)
-
-            response = function(request)
-            return response
-
-        return wrapper
-
-    @classmethod
-    def _error_path_message(cls, exception):
-        error_path = ".".join(str(item) for item in exception.path)
-        error_path_msg = f" - '{error_path}'" if error_path else ""
-        return error_path_msg
-
-    def validate_schema(self, data: dict, url: str) -> t.Optional[ConnexionResponse]:
-        if self.is_null_value_valid and is_null(data):
-            return None
-
-        try:
-            self.validator.validate(data)
-        except ValidationError as exception:
-            error_path_msg = self._error_path_message(exception=exception)
-            logger.error(
-                f"{str(url)} validation error: {exception.message}{error_path_msg}",
-                extra={"validator": "body"},
-            )
-            raise BadRequestProblem(detail=f"{exception.message}{error_path_msg}")
-
-        return None
 
 
 class ParameterValidator:

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -7,6 +7,7 @@ import typing as t
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion import utils
+from connexion.datastructures import MediaTypeDict
 from connexion.decorators.uri_parsing import AbstractURIParser
 from connexion.exceptions import UnsupportedMediaTypeProblem
 from connexion.middleware.abstract import RoutedAPI, RoutedMiddleware
@@ -59,7 +60,11 @@ class RequestValidationOperation:
 
         :param mime_type: mime type from content type header
         """
-        if mime_type.lower() not in [c.lower() for c in self._operation.consumes]:
+        # Convert to MediaTypeDict to handle media-ranges
+        media_type_dict = MediaTypeDict(
+            [(c.lower(), None) for c in self._operation.consumes]
+        )
+        if mime_type.lower() not in media_type_dict:
             raise UnsupportedMediaTypeProblem(
                 detail=f"Invalid Content-type ({mime_type}), "
                 f"expected {self._operation.consumes}"

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -86,8 +86,8 @@ class RequestValidationOperation:
             validator = body_validator(
                 scope,
                 receive,
-                schema=self._operation.body_schema,
-                nullable=utils.is_nullable(self._operation.body_definition),
+                schema=self._operation.body_schema(mime_type),
+                nullable=utils.is_nullable(self._operation.body_definition(mime_type)),
                 encoding=encoding,
                 strict_validation=self.strict_validation,
                 uri_parser=self._operation._uri_parsing_decorator,

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -90,6 +90,7 @@ class RequestValidationOperation:
                 nullable=utils.is_nullable(self._operation.body_definition),
                 encoding=encoding,
                 strict_validation=self.strict_validation,
+                uri_parser=self._operation._uri_parsing_decorator,
             )
             receive_fn = await validator.wrapped_receive()
 

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -29,7 +29,7 @@ class RequestValidationOperation:
         self.next_app = next_app
         self._operation = operation
         self.strict_validation = strict_validation
-        self._validator_map = VALIDATOR_MAP
+        self._validator_map = VALIDATOR_MAP.copy()
         self._validator_map.update(validator_map or {})
         self.uri_parser_class = uri_parser_class
 
@@ -89,8 +89,9 @@ class RequestValidationOperation:
                 schema=self._operation.body_schema,
                 nullable=utils.is_nullable(self._operation.body_definition),
                 encoding=encoding,
+                strict_validation=self.strict_validation,
             )
-            receive_fn = validator.receive
+            receive_fn = await validator.wrapped_receive()
 
         await self.next_app(scope, receive_fn, send)
 

--- a/connexion/middleware/response_validation.py
+++ b/connexion/middleware/response_validation.py
@@ -25,7 +25,7 @@ class ResponseValidationOperation:
     ) -> None:
         self.next_app = next_app
         self._operation = operation
-        self._validator_map = VALIDATOR_MAP
+        self._validator_map = VALIDATOR_MAP.copy()
         self._validator_map.update(validator_map or {})
 
     def extract_content_type(

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -280,16 +280,14 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         Content-Types that the operation consumes
         """
 
-    @property
     @abc.abstractmethod
-    def body_schema(self):
+    def body_schema(self, content_type: str = None) -> dict:
         """
         The body schema definition for this operation.
         """
 
-    @property
     @abc.abstractmethod
-    def body_definition(self):
+    def body_definition(self, content_type: str = None) -> dict:
         """
         The body definition for this operation.
         :rtype: dict
@@ -371,7 +369,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         Returns a decorator that parses request data and handles things like
         array types, and duplicate parameter definitions.
         """
-        return self._uri_parser_class(self.parameters, self.body_definition)
+        return self._uri_parser_class(self.parameters, self.body_definition())
 
     @property
     def function(self):

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -9,8 +9,8 @@ import logging
 from ..decorators.decorator import RequestResponseDecorator
 from ..decorators.parameter import parameter_to_arg
 from ..decorators.produces import BaseSerializer, Produces
-from ..decorators.validation import ParameterValidator, RequestBodyValidator
-from ..utils import all_json, is_nullable
+from ..decorators.validation import ParameterValidator
+from ..utils import all_json
 
 logger = logging.getLogger("connexion.operations.abstract")
 
@@ -18,7 +18,6 @@ DEFAULT_MIMETYPE = "application/json"
 
 VALIDATOR_MAP = {
     "parameter": ParameterValidator,
-    "body": RequestBodyValidator,
 }
 
 
@@ -454,15 +453,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         if self.parameters:
             yield ParameterValidator(
                 self.parameters, self.api, strict_validation=self.strict_validation
-            )
-        if self.body_schema:
-            # TODO: temporarily hardcoded, remove RequestBodyValidator completely
-            yield RequestBodyValidator(
-                self.body_schema,
-                self.consumes,
-                self.api,
-                is_nullable(self.body_definition),
-                strict_validation=self.strict_validation,
             )
 
     def json_loads(self, data):

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -251,15 +251,13 @@ class OpenAPIOperation(AbstractOperation):
             types[path_defn["name"]] = path_type
         return types
 
-    @property
-    def body_schema(self):
+    def body_schema(self, content_type: str = None) -> dict:
         """
         The body schema definition for this operation.
         """
-        return self.body_definition.get("schema", {})
+        return self.body_definition(content_type).get("schema", {})
 
-    @property
-    def body_definition(self):
+    def body_definition(self, content_type: str = None) -> dict:
         """
         The body complete definition for this operation.
 
@@ -268,12 +266,15 @@ class OpenAPIOperation(AbstractOperation):
         :rtype: dict
         """
         if self._request_body:
+            if content_type is None:
+                # TODO: make content type required
+                content_type = self.consumes[0]
             if len(self.consumes) > 1:
                 logger.warning(
                     "this operation accepts multiple content types, using %s",
-                    self.consumes[0],
+                    content_type,
                 )
-            res = self._request_body.get("content", {}).get(self.consumes[0], {})
+            res = self._request_body.get("content", {}).get(content_type, {})
             return self.with_definitions(res)
         return {}
 
@@ -295,25 +296,26 @@ class OpenAPIOperation(AbstractOperation):
     def _get_body_argument_json(self, body):
         # if the body came in null, and the schema says it can be null, we decide
         # to include no value for the body argument, rather than the default body
-        if is_nullable(self.body_schema) and is_null(body):
+        if is_nullable(self.body_schema()) and is_null(body):
             return None
 
         if body is None:
-            default_body = self.body_schema.get("default", {})
+            default_body = self.body_schema().get("default", {})
             return deepcopy(default_body)
 
         return body
 
     def _get_body_argument_form(self, body):
         # now determine the actual value for the body (whether it came in or is default)
-        default_body = self.body_schema.get("default", {})
+        default_body = self.body_schema().get("default", {})
         body_props = {
-            k: {"schema": v} for k, v in self.body_schema.get("properties", {}).items()
+            k: {"schema": v}
+            for k, v in self.body_schema().get("properties", {}).items()
         }
 
         # by OpenAPI specification `additionalProperties` defaults to `true`
         # see: https://github.com/OAI/OpenAPI-Specification/blame/3.0.2/versions/3.0.2.md#L2305
-        additional_props = self.body_schema.get("additionalProperties", True)
+        additional_props = self.body_schema().get("additionalProperties", True)
 
         body_arg = deepcopy(default_body)
         body_arg.update(body or {})

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -5,6 +5,7 @@ This module defines an OpenAPIOperation class, a Connexion operation specific fo
 import logging
 from copy import copy, deepcopy
 
+from connexion.datastructures import MediaTypeDict
 from connexion.operations.abstract import AbstractOperation
 
 from ..decorators.uri_parsing import OpenAPIURIParser
@@ -274,7 +275,8 @@ class OpenAPIOperation(AbstractOperation):
                     "this operation accepts multiple content types, using %s",
                     content_type,
                 )
-            res = self._request_body.get("content", {}).get(content_type, {})
+            content_type_dict = MediaTypeDict(self._request_body.get("content", {}))
+            res = content_type_dict.get(content_type, {})
             return self.with_definitions(res)
         return {}
 

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -3,15 +3,25 @@ This module defines a Swagger2Operation class, a Connexion operation specific fo
 """
 
 import logging
+import typing as t
 from copy import deepcopy
 
 from connexion.operations.abstract import AbstractOperation
 
 from ..decorators.uri_parsing import Swagger2URIParser
 from ..exceptions import InvalidSpecification
+from ..http_facts import FORM_CONTENT_TYPES
 from ..utils import deep_get, is_null, is_nullable, make_type
 
 logger = logging.getLogger("connexion.operations.swagger2")
+
+
+COLLECTION_FORMAT_MAPPING = {
+    "multi": {"style": "form", "explode": True},
+    "csv": {"style": "form", "explode": False},
+    "ssv": {"style": "spaceDelimited", "explode": False},
+    "pipes": {"style": "pipeDelimited", "explode": False},
+}
 
 
 class Swagger2Operation(AbstractOperation):
@@ -135,7 +145,7 @@ class Swagger2Operation(AbstractOperation):
             security_schemes=spec.security_schemes,
             definitions=spec.definitions,
             *args,
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -224,15 +234,14 @@ class Swagger2Operation(AbstractOperation):
         except KeyError:
             raise
 
-    @property
-    def body_schema(self):
+    def body_schema(self, content_type: str = None) -> dict:
         """
         The body schema definition for this operation.
         """
-        return self.with_definitions(self.body_definition).get("schema", {})
+        body_definition = self.body_definition(content_type)
+        return self.with_definitions(body_definition).get("schema", {})
 
-    @property
-    def body_definition(self):
+    def body_definition(self, content_type: str = None) -> dict:
         """
         The body complete definition for this operation.
 
@@ -240,14 +249,83 @@ class Swagger2Operation(AbstractOperation):
 
         :rtype: dict
         """
-        body_parameters = [p for p in self.parameters if p["in"] == "body"]
-        if len(body_parameters) > 1:
-            raise InvalidSpecification(
-                "{method} {path} There can be one 'body' parameter at most".format(
-                    method=self.method, path=self.path
+        if content_type in FORM_CONTENT_TYPES:
+            form_parameters = [p for p in self.parameters if p["in"] == "formData"]
+            body_definition = self._transform_form(form_parameters)
+        else:
+            body_parameters = [p for p in self.parameters if p["in"] == "body"]
+            if len(body_parameters) > 1:
+                raise InvalidSpecification(
+                    "{method} {path} There can be one 'body' parameter at most".format(
+                        method=self.method, path=self.path
+                    )
                 )
-            )
-        return body_parameters[0] if body_parameters else {}
+            body_definition = body_parameters[0] if body_parameters else {}
+        return body_definition
+
+    def _transform_form(self, form_parameters: t.List[dict]) -> dict:
+        """Translate Swagger2 form parameters into OpenAPI 3 jsonschema spec."""
+        properties = {}
+        required = []
+        encoding = {}
+
+        for param in form_parameters:
+            prop = {}
+
+            if param["type"] == "file":
+                prop.update(
+                    {
+                        "type": "string",
+                        "format": "binary",
+                    }
+                )
+            else:
+                prop["type"] = param["type"]
+
+                format_ = param.get("format")
+                if format_ is not None:
+                    prop["format"] = format_
+
+            default = param.get("default")
+            if default is not None:
+                prop["default"] = default
+
+            nullable = param.get("x-nullable")
+            if nullable is not None:
+                prop["nullable"] = nullable
+
+            if param["type"] == "array":
+                prop["items"] = param.get("items", {})
+
+                collection_format = param.get("collectionFormat", "csv")
+                try:
+                    encoding[param["name"]] = COLLECTION_FORMAT_MAPPING[
+                        collection_format
+                    ]
+                except KeyError:
+                    raise InvalidSpecification(
+                        f"The collection format ({collection_format}) is not supported by "
+                        f"Connexion as it cannot be mapped to OpenAPI 3."
+                    )
+
+            properties[param["name"]] = prop
+
+            if param.get("required", False):
+                required.append(param["name"])
+
+        definition: t.Dict[str, t.Any] = {
+            "schema": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": not self.strict_validation,
+            }
+        }
+
+        if encoding:
+            definition["encoding"] = encoding
+
+        return definition
 
     def _get_query_arguments(self, query, arguments, has_kwargs, sanitize):
         query_defns = {p["name"]: p for p in self.parameters if p["in"] == "query"}

--- a/connexion/validators.py
+++ b/connexion/validators.py
@@ -10,6 +10,7 @@ from starlette.datastructures import FormData, Headers, UploadFile
 from starlette.formparsers import FormParser, MultiPartParser
 from starlette.types import Receive, Scope, Send
 
+from connexion.datastructures import MediaTypeDict
 from connexion.decorators.uri_parsing import AbstractURIParser
 from connexion.decorators.validation import (
     ParameterValidator,
@@ -306,13 +307,17 @@ class MultiPartFormDataValidator(FormDataValidator):
 
 VALIDATOR_MAP = {
     "parameter": ParameterValidator,
-    "body": {
-        "application/json": JSONRequestBodyValidator,
-        "application/x-www-form-urlencoded": FormDataValidator,
-        "multipart/form-data": MultiPartFormDataValidator,
-    },
-    "response": {
-        "application/json": JSONResponseBodyValidator,
-        "text/plain": TextResponseBodyValidator,
-    },
+    "body": MediaTypeDict(
+        {
+            "*/*json": JSONRequestBodyValidator,
+            "application/x-www-form-urlencoded": FormDataValidator,
+            "multipart/form-data": MultiPartFormDataValidator,
+        }
+    ),
+    "response": MediaTypeDict(
+        {
+            "*/*json": JSONResponseBodyValidator,
+            "text/plain": TextResponseBodyValidator,
+        }
+    ),
 }

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'starlette>=0.15,<1',
     'httpx>=0.15,<1',
     'typing-extensions>=4,<5',
+    'python-multipart>=0.0.5',
 ]
 
 swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -309,3 +309,13 @@ def test_global_response_definitions(schema_app):
     app_client = schema_app.app.test_client()
     resp = app_client.get("/v1.0/define_global_response")
     assert json.loads(resp.data.decode("utf-8", "replace")) == ["general", "list"]
+
+
+def test_media_range(schema_app):
+    app_client = schema_app.app.test_client()
+    headers = {"Content-type": "application/json"}
+
+    array_request = app_client.post(
+        "/v1.0/media_range", headers=headers, data=json.dumps({})
+    )
+    assert array_request.status_code == 200, array_request.text

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -193,22 +193,3 @@ def test_writeonly_required_error():
     }
     with pytest.raises(ValidationError):
         Draft4RequestValidator(schema).validate({"bar": "baz"})
-
-
-def test_formdata_extra_parameter_strict():
-    """Tests that connexion handles explicitly defined formData parameters well across Swagger 2
-    and OpenApi 3. In Swagger 2, any formData parameter should be defined explicitly, while in
-    OpenAPI 3 this is not allowed. See issues #1020 #1160 #1340 #1343."""
-    request = MagicMock(form={"param": "value", "extra_param": "extra_value"})
-
-    # OAS3
-    validator = ParameterValidator([], FlaskApi, strict_validation=True)
-    errors = validator.validate_formdata_parameter_list(request)
-    assert not errors
-
-    # Swagger 2
-    validator = ParameterValidator(
-        [{"in": "formData", "name": "param"}], FlaskApi, strict_validation=True
-    )
-    errors = validator.validate_formdata_parameter_list(request)
-    assert errors

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -389,6 +389,10 @@ def test_global_response_definition():
     return ["general", "list"], 200
 
 
+def test_media_range():
+    return "OK"
+
+
 def test_nullable_parameters(time_start):
     if time_start is None:
         return "it was None"

--- a/tests/fixtures/different_schemas/openapi.yaml
+++ b/tests/fixtures/different_schemas/openapi.yaml
@@ -264,6 +264,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/GeneralList'
+  /media_range:
+    post:
+      description: Test media range
+      operationId: fakeapi.hello.test_media_range
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
 components:
   responses:
     GeneralList:

--- a/tests/fixtures/different_schemas/swagger.yaml
+++ b/tests/fixtures/different_schemas/swagger.yaml
@@ -291,6 +291,21 @@ paths:
         200:
           $ref: '#/responses/GeneralList'
 
+  /media_range:
+    post:
+      description: Test media range
+      operationId: fakeapi.hello.test_media_range
+      consumes:
+        - '*/*'
+      parameters:
+        - name: body
+          in: body
+          schema:
+            type: object
+      responses:
+        '200':
+          description: OK
+
 definitions:
   new_stack:
     type: object


### PR DESCRIPTION
This PR moves form data validation to the middleware, which is quite complex due to differences between Swagger 2 and OpenAPI 3 in how form data is represented.

For OpenAPI 3, this is quite simple. The form data is represented as an object in the request body, which means we can just use a request body validator.

For Swagger 2, this is more complicated. The form data is represented as parameters instead. I see two options here:
- We validate the form data as parameters, which is what Connexion is currently doing. The advantage is that you can easily use the current parameter validation with the spec. The downside is that it's different from OpenAPI 3 and you need to consume the stream in the parameter validation.
- We transform the FormData parameters in the Swagger2Operation to a body schema spec as in OpenAPI 3. Advantage is that we can then use the same request body validator and only consume the stream there. The downside is additional complexity in the Swagger2Operation.

This PR implements option 2.

Some open points still to address with the request body validator in this PR:
- I implemented `strict_validation`, which makes less sense for OpenAPI 3 form validation, as this can now be controlled by `additionalProperties` in the schema.instead. 