### PR TITLE
Feature/multiple yaml same base path

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -4,7 +4,8 @@ This module defines a FlaskApp, a Connexion application to wrap a Flask applicat
 
 import logging
 import pathlib
-from types import FunctionType  # NOQA
+from types import FunctionType
+from typing import Optional  # NOQA
 
 import a2wsgi
 import flask
@@ -87,9 +88,16 @@ class FlaskApp(AbstractApp):
 
         return FlaskApi.get_response(response)
 
-    def add_api(self, specification, **kwargs):
+    def add_api(self, specification, name=None, **kwargs):
         api = super().add_api(specification, **kwargs)
-        self.app.register_blueprint(api.blueprint)
+
+        # if name is available, it will use the name passed,
+        # otherwise it will as name the base path, which is the default behaviour
+        if name:
+            self.app.register_blueprint(api.blueprint, name=name)
+        else:
+            self.app.register_blueprint(api.blueprint)
+
         if isinstance(specification, (str, pathlib.Path)):
             self.extra_files.append(self.specification_dir / specification)
         return api

--- a/tests/api/test_bootstrap_multiple_spec.py
+++ b/tests/api/test_bootstrap_multiple_spec.py
@@ -1,0 +1,49 @@
+import json
+
+import pytest
+from connexion import App
+
+from conftest import TEST_FOLDER
+
+SPECS = [
+    pytest.param(
+        [
+            {"specification": "swagger_greeting.yaml", "name": "greeting"},
+            {"specification": "swagger_bye.yaml", "name": "bye"},
+        ],
+        id="swagger",
+    ),
+    pytest.param(
+        [
+            {"specification": "openapi_greeting.yaml", "name": "greeting"},
+            {"specification": "openapi_bye.yaml", "name": "bye"},
+        ],
+        id="openapi",
+    ),
+]
+
+
+@pytest.mark.parametrize("spec", SPECS)
+def test_app_with_multiple_definition(multiple_yaml_same_basepath_dir, spec):
+    # Create the app with a relative path and run the test_app testcase below.
+    app = App(
+        __name__,
+        port=5001,
+        specification_dir=".."
+        / multiple_yaml_same_basepath_dir.relative_to(TEST_FOLDER),
+        debug=True,
+    )
+
+    for s in spec:
+        app.add_api(**s)
+
+    app_client = app.app.test_client()
+
+    post_greeting = app_client.post("/v1.0/greeting/jsantos")  # type: flask.Response
+    assert post_greeting.status_code == 200
+    greeting_response = json.loads(post_greeting.data.decode("utf-8"))
+    assert greeting_response["greeting"] == "Hello jsantos"
+
+    get_bye = app_client.get("/v1.0/bye/jsantos")  # type: flask.Response
+    assert get_bye.status_code == 200
+    assert get_bye.data == b"Goodbye jsantos"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,11 @@ def json_validation_spec_dir():
     return FIXTURES_FOLDER / "json_validation"
 
 
+@pytest.fixture
+def multiple_yaml_same_basepath_dir():
+    return FIXTURES_FOLDER / "multiple_yaml_same_basepath"
+
+
 @pytest.fixture(scope="session")
 def json_datetime_dir():
     return FIXTURES_FOLDER / "datetime_support"

--- a/tests/fixtures/multiple_yaml_same_basepath/openapi_bye.yaml
+++ b/tests/fixtures/multiple_yaml_same_basepath/openapi_bye.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/bye/{name}':
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye
+      responses:
+        '200':
+          description: goodbye response
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: unexpected error
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          schema:
+            type: string
+servers:
+  - url: /v1.0

--- a/tests/fixtures/multiple_yaml_same_basepath/openapi_greeting.yaml
+++ b/tests/fixtures/multiple_yaml_same_basepath/openapi_greeting.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: '{{title}}'
+  version: '1.0'
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            '*/*':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string
+
+      
+servers:
+  - url: /v1.0

--- a/tests/fixtures/multiple_yaml_same_basepath/swagger_bye.yaml
+++ b/tests/fixtures/multiple_yaml_same_basepath/swagger_bye.yaml
@@ -1,0 +1,29 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+  /bye/{name}:
+    get:
+      summary: Generate goodbye
+      description: Generates a goodbye message.
+      operationId: fakeapi.hello.get_bye
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: goodbye response
+          schema:
+            type: string
+        default:
+          description: "unexpected error"
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to say bye.
+          required: true
+          type: string

--- a/tests/fixtures/multiple_yaml_same_basepath/swagger_greeting.yaml
+++ b/tests/fixtures/multiple_yaml_same_basepath/swagger_greeting.yaml
@@ -1,0 +1,25 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /v1.0
+
+paths:
+ /greeting/{name}:
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        200:
+          description: greeting response
+          schema:
+            type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          type: string


### PR DESCRIPTION
Fixes #1542 .

Changes proposed in this pull request:

 - It is possible to pass a name parameter to the connexion.app_api(..) method
 - the name parameter will be assigned to the Flask blueprint
 - in case you don't pass the name, it will rely on  previous/default behaviour (base path as name in Flask case)

Having multiple specification in the same path, opens to new conflicting case. 
- In case the same endpoint is defined from 2 specs, the first one added and covering the case will be accepted, the second one ignored. 
- A more niche case, in case you define 2 operation on the same path but different method, the second one won't work, even if they are complementary. 

Eg: 
- spec1 get foo/
- spec2 post foo/ 

if you call post foo/ --> response will be 405, method not allowed (it ignores 2nd definition of the same path)

I think these cases can be fine as long they are documented (let me know where do you think I should amend the documentation). 

Let me know if you want more unit tests