### PR TITLE
Move Swagger 2 form validation to middleware

### DIFF
--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -86,8 +86,8 @@ class RequestValidationOperation:
             validator = body_validator(
                 scope,
                 receive,
-                schema=self._operation.body_schema,
-                nullable=utils.is_nullable(self._operation.body_definition),
+                schema=self._operation.body_schema(mime_type),
+                nullable=utils.is_nullable(self._operation.body_definition(mime_type)),
                 encoding=encoding,
                 strict_validation=self.strict_validation,
                 uri_parser=self._operation._uri_parsing_decorator,

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -280,16 +280,14 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         Content-Types that the operation consumes
         """
 
-    @property
     @abc.abstractmethod
-    def body_schema(self):
+    def body_schema(self, content_type: str = None) -> dict:
         """
         The body schema definition for this operation.
         """
 
-    @property
     @abc.abstractmethod
-    def body_definition(self):
+    def body_definition(self, content_type: str = None) -> dict:
         """
         The body definition for this operation.
         :rtype: dict
@@ -371,7 +369,7 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         Returns a decorator that parses request data and handles things like
         array types, and duplicate parameter definitions.
         """
-        return self._uri_parser_class(self.parameters, self.body_definition)
+        return self._uri_parser_class(self.parameters, self.body_definition())
 
     @property
     def function(self):

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -252,15 +252,13 @@ class OpenAPIOperation(AbstractOperation):
             types[path_defn["name"]] = path_type
         return types
 
-    @property
-    def body_schema(self):
+    def body_schema(self, content_type: str = None) -> dict:
         """
         The body schema definition for this operation.
         """
-        return self.body_definition.get("schema", {})
+        return self.body_definition(content_type).get("schema", {})
 
-    @property
-    def body_definition(self):
+    def body_definition(self, content_type: str = None) -> dict:
         """
         The body complete definition for this operation.
 
@@ -269,12 +267,15 @@ class OpenAPIOperation(AbstractOperation):
         :rtype: dict
         """
         if self._request_body:
+            if content_type is None:
+                # TODO: make content type required
+                content_type = self.consumes[0]
             if len(self.consumes) > 1:
                 logger.warning(
                     "this operation accepts multiple content types, using %s",
-                    self.consumes[0],
+                    content_type,
                 )
-            res = self._request_body.get("content", {}).get(self.consumes[0], {})
+            res = self._request_body.get("content", {}).get(content_type, {})
             return self.with_definitions(res)
         return {}
 
@@ -283,7 +284,7 @@ class OpenAPIOperation(AbstractOperation):
             return {}
 
         # get the deprecated name from the body-schema for legacy connexion compat
-        x_body_name = sanitize(self.body_schema.get("x-body-name"))
+        x_body_name = sanitize(self.body_schema().get("x-body-name"))
 
         if x_body_name:
             warnings.warn(
@@ -310,25 +311,26 @@ class OpenAPIOperation(AbstractOperation):
     def _get_body_argument_json(self, body):
         # if the body came in null, and the schema says it can be null, we decide
         # to include no value for the body argument, rather than the default body
-        if is_nullable(self.body_schema) and is_null(body):
+        if is_nullable(self.body_schema()) and is_null(body):
             return None
 
         if body is None:
-            default_body = self.body_schema.get("default", {})
+            default_body = self.body_schema().get("default", {})
             return deepcopy(default_body)
 
         return body
 
     def _get_body_argument_form(self, body):
         # now determine the actual value for the body (whether it came in or is default)
-        default_body = self.body_schema.get("default", {})
+        default_body = self.body_schema().get("default", {})
         body_props = {
-            k: {"schema": v} for k, v in self.body_schema.get("properties", {}).items()
+            k: {"schema": v}
+            for k, v in self.body_schema().get("properties", {}).items()
         }
 
         # by OpenAPI specification `additionalProperties` defaults to `true`
         # see: https://github.com/OAI/OpenAPI-Specification/blame/3.0.2/versions/3.0.2.md#L2305
-        additional_props = self.body_schema.get("additionalProperties", True)
+        additional_props = self.body_schema().get("additionalProperties", True)
 
         body_arg = deepcopy(default_body)
         body_arg.update(body or {})

--- a/tests/decorators/test_validation.py
+++ b/tests/decorators/test_validation.py
@@ -193,22 +193,3 @@ def test_writeonly_required_error():
     }
     with pytest.raises(ValidationError):
         Draft4RequestValidator(schema).validate({"bar": "baz"})
-
-
-def test_formdata_extra_parameter_strict():
-    """Tests that connexion handles explicitly defined formData parameters well across Swagger 2
-    and OpenApi 3. In Swagger 2, any formData parameter should be defined explicitly, while in
-    OpenAPI 3 this is not allowed. See issues #1020 #1160 #1340 #1343."""
-    request = MagicMock(form={"param": "value", "extra_param": "extra_value"})
-
-    # OAS3
-    validator = ParameterValidator([], FlaskApi, strict_validation=True)
-    errors = validator.validate_formdata_parameter_list(request)
-    assert not errors
-
-    # Swagger 2
-    validator = ParameterValidator(
-        [{"in": "formData", "name": "param"}], FlaskApi, strict_validation=True
-    )
-    errors = validator.validate_formdata_parameter_list(request)
-    assert errors

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -414,7 +414,7 @@ def test_operation(api, security_handler_factory):
 
     expected_body_schema = op_spec["parameters"][0]["schema"]
     expected_body_schema.update({"definitions": DEFINITIONS})
-    assert operation.body_schema == expected_body_schema
+    assert operation.body_schema() == expected_body_schema
 
 
 def test_operation_remote_token_info(security_handler_factory):
@@ -463,7 +463,7 @@ def test_operation_array(api):
         "items": DEFINITIONS["new_stack"],
         "definitions": DEFINITIONS,
     }
-    assert operation.body_schema == expected_body_schema
+    assert operation.body_schema() == expected_body_schema
 
 
 def test_operation_composed_definition(api):
@@ -487,7 +487,7 @@ def test_operation_composed_definition(api):
 
     expected_body_schema = op_spec["parameters"][0]["schema"]
     expected_body_schema.update({"definitions": DEFINITIONS})
-    assert operation.body_schema == expected_body_schema
+    assert operation.body_schema() == expected_body_schema
 
 
 def test_operation_local_security_oauth2(security_handler_factory):
@@ -536,7 +536,7 @@ def test_multi_body(api):
             definitions=DEFINITIONS,
             resolver=Resolver(),
         )
-        operation.body_schema
+        operation.body_schema()
 
     exception = exc_info.value
     assert str(exception) == "GET endpoint There can be one 'body' parameter at most"


### PR DESCRIPTION
This PR moves Swagger 2 form validation to the middleware by translating the Swagger 2 form parameter definition into an OpenAPI 3 RequestBody JsonSchema spec. This allows us to use the `FormDataValidator` introduced in #1595 for Swagger 2 as well instead of the old `ParameterValidator`.
