### PR TITLE
Avoid warning with jsonschema 4.16.0

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -8,7 +8,7 @@ import functools
 import logging
 import typing as t
 
-from jsonschema import Draft4Validator, ValidationError, draft4_format_checker
+from jsonschema import Draft4Validator, ValidationError
 from jsonschema.validators import extend
 from werkzeug.datastructures import FileStorage
 
@@ -21,6 +21,11 @@ from ..utils import boolean, is_null, is_nullable
 logger = logging.getLogger("connexion.decorators.validation")
 
 TYPE_MAP = {"integer": int, "number": float, "boolean": boolean, "object": dict}
+
+try:
+    draft4_format_checker = Draft4Validator.FORMAT_CHECKER
+except AttributeError:  # jsonschema < 4.5.0
+    from jsonschema import draft4_format_checker
 
 
 class TypeValidationError(Exception):


### PR DESCRIPTION
Changes proposed in this pull request:

 - Accessing jsonschema.draftN_format_checker is now deprecated. Use Draft4Validator.FORMAT_CHECKER when possible (jsonschema >= 4.5.0)
