### PR TITLE
Flask apps only signal an exception on real server errors

### DIFF
--- a/connexion/apps/flask_app.py
+++ b/connexion/apps/flask_app.py
@@ -64,7 +64,6 @@ class FlaskApp(AbstractApp):
         :type exception: Exception
         """
         if isinstance(exception, ProblemException):
-            is_server_error = exception.status >= 500
             response = problem(
                 status=exception.status,
                 title=exception.title,
@@ -77,9 +76,6 @@ class FlaskApp(AbstractApp):
         else:
             if not isinstance(exception, werkzeug.exceptions.HTTPException):
                 exception = werkzeug.exceptions.InternalServerError()
-                is_server_error = True
-            else:
-                is_server_error = exception.code >= 500
 
             response = problem(
                 title=exception.name,
@@ -88,7 +84,7 @@ class FlaskApp(AbstractApp):
                 headers=exception.get_headers(),
             )
 
-        if is_server_error:
+        if response.status_code >= 500:
             signals.got_request_exception.send(self.app, exception=exception)
 
         return FlaskApi.get_response(response)


### PR DESCRIPTION
Fixes the problem of non-exceptional "exceptions" being recorded by telemetry systems as a serious error. This expands on the changes made in #1326. The intention of that other change seems to be making telemetry systems like Sentry record serious errors. Diving into the Sentry implementation even shows that the signalled exception is recorded at "level" = "error". 

The root of the problem is that exceptions are being used for control flow, which is not ideal - convenient for app writers but not always for library maintainers. The connexion BadRequestProblem and NotFoundProblem, for example, should not be recorded as an error in a telemetry system. In my case [elastic-apm-python](https://github.com/elastic/apm-agent-python) is receiving these signals and recording 4xx events as serious errors. 

This pull request only propagates an exception signal to flask if it's a serious error. 

Aiohttp applications have a similar problem with exceptions being used for control flow - the problems middleware will convert the exception into an appropriate problem response but things like the elastic apm python telemetry middleware will see that exception and record it as a serious error. Interestingly aiohttp also uses exceptions for control flow and the elastic apm agent was patched to specifically ignore aio web exceptions below the 5xx status response range. Elastic apm and sentry cannot be expected to be aware of non-serious control flow exceptions used by various libraries though. So, a solution for Aiohttp applications is a separate problem.
