### PR TITLE
Enable enforcing defaults

### DIFF
--- a/connexion/decorators/main.py
+++ b/connexion/decorators/main.py
@@ -166,10 +166,7 @@ class ASGIDecorator(BaseDecorator):
                 uri_parser=self.uri_parser, scope=scope, receive=receive
             )
             decorated_function = self.decorate(function)
-            response = decorated_function(request)
-            while asyncio.iscoroutine(response):
-                response = await response
-            return response
+            return await decorated_function(request)
 
         return wrapper
 

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -25,7 +25,7 @@ class SpecMiddleware(abc.ABC):
     @abc.abstractmethod
     def add_api(
         self, specification: t.Union[pathlib.Path, str, dict], **kwargs
-    ) -> None:
+    ) -> t.Any:
         """
         Register an API represented by a single OpenAPI specification on this middleware.
         Multiple APIs can be registered on a single middleware.
@@ -246,11 +246,10 @@ class RoutedMiddleware(SpecMiddleware, t.Generic[API]):
         self.app = app
         self.apis: t.Dict[str, API] = {}
 
-    def add_api(
-        self, specification: t.Union[pathlib.Path, str, dict], **kwargs
-    ) -> None:
+    def add_api(self, specification: t.Union[pathlib.Path, str, dict], **kwargs) -> API:
         api = self.api_cls(specification, next_app=self.app, **kwargs)
         self.apis[api.base_path] = api
+        return api
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Fetches the operation related to the request and calls it."""

--- a/connexion/validators/__init__.py
+++ b/connexion/validators/__init__.py
@@ -1,6 +1,7 @@
 from connexion.datastructures import MediaTypeDict
 
 from .form_data import FormDataValidator, MultiPartFormDataValidator
+from .json import DefaultsJSONRequestBodyValidator  # NOQA
 from .json import (
     JSONRequestBodyValidator,
     JSONResponseBodyValidator,

--- a/examples/enforcedefaults/app.py
+++ b/examples/enforcedefaults/app.py
@@ -1,42 +1,18 @@
 from pathlib import Path
 
 import connexion
-import jsonschema
-from connexion.json_schema import Draft4RequestValidator
-from connexion.validators import JSONRequestBodyValidator
+from connexion.validators import DefaultsJSONRequestBodyValidator
 
 
-# TODO: should work as sync endpoint when parameter decorator is fixed
-async def echo(data):
+def echo(data):
     return data
 
 
-# via https://python-jsonschema.readthedocs.io/
-def extend_with_set_default(validator_class):
-    validate_properties = validator_class.VALIDATORS["properties"]
-
-    def set_defaults(validator, properties, instance, schema):
-        for property, subschema in properties.items():
-            if "default" in subschema:
-                instance.setdefault(property, subschema["default"])
-
-        yield from validate_properties(validator, properties, instance, schema)
-
-    return jsonschema.validators.extend(validator_class, {"properties": set_defaults})
-
-
-DefaultsEnforcingDraft4Validator = extend_with_set_default(Draft4RequestValidator)
-
-
-class DefaultsEnforcingRequestBodyValidator(JSONRequestBodyValidator):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, validator=DefaultsEnforcingDraft4Validator, **kwargs)
-
-
-validator_map = {"body": {"application/json": DefaultsEnforcingRequestBodyValidator}}
+validator_map = {"body": {"application/json": DefaultsJSONRequestBodyValidator}}
 
 
 app = connexion.AsyncApp(__name__, specification_dir="spec")
+app.add_api("openapi.yaml", validator_map=validator_map)
 app.add_api("swagger.yaml", validator_map=validator_map)
 
 

--- a/examples/enforcedefaults/spec/openapi.yaml
+++ b/examples/enforcedefaults/spec/openapi.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  version: '1'
+  title: Custom Validator Example
+servers:
+  - url: '/openapi'
+
+paths:
+  /echo:
+    post:
+      description: Echo passed data
+      operationId: app.echo
+      requestBody:
+        x-body-name: data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data'
+      responses:
+        '200':
+          description: Data with defaults filled in by validator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Data'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Data:
+      type: object
+      properties:
+        outer-object:
+          type: object
+          default: {}
+          properties:
+            inner-object:
+              type: string
+              default: foo
+    Error:
+      type: string

--- a/examples/enforcedefaults/spec/swagger.yaml
+++ b/examples/enforcedefaults/spec/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   version: '1'
   title: Custom Validator Example
-basePath: '/v1'
+basePath: '/swagger'
 consumes:
   - application/json
 produces:

--- a/examples/sqlalchemy/spec/openapi.yaml
+++ b/examples/sqlalchemy/spec/openapi.yaml
@@ -62,10 +62,10 @@ paths:
         '201':
           description: New pet created
       requestBody:
+        x-body-name: pet
         content:
           application/json:
             schema:
-              x-body-name: pet
               $ref: '#/components/schemas/Pet'
     delete:
       tags:


### PR DESCRIPTION
This PR is a proposal to enforce defaults in json bodies.

I'm not sure which way to go here
- I think connexion should offer the functionality to fill in the defaults, as this helps enforce the contract. If a value is not provided, the application gets the default. We should probably offer this using a simple `default` flag instead of the custom validator now needed.
- I don't like that validation adapts the body. Validation is a read-only operation and it would be nice to keep it that way.
- Splitting enforcing defaults from validation would be less efficient since we'd need to traverse the body multiple times.

If we do want to go this way, we should probably implement a similar fix for form data, as we also use json validators there.
