### PR TITLE
Switch to own maintained version of swagger-ui

### DIFF
--- a/connexion/options.py
+++ b/connexion/options.py
@@ -6,9 +6,9 @@ import logging
 from typing import Optional  # NOQA
 
 try:
-    from swagger_ui_bundle import swagger_ui_2_path, swagger_ui_3_path
+    from py_swagger_ui import swagger_ui_path
 except ImportError:
-    swagger_ui_2_path = swagger_ui_3_path = None
+    swagger_ui_path = None
 
 from connexion.uri_parsing import AbstractURIParser
 
@@ -26,12 +26,11 @@ class ConnexionOptions:
     def __init__(self, options=None, oas_version=(2,)):
         self._options = {}
         self.oas_version = oas_version
+        self.swagger_ui_local_path = swagger_ui_path
         if self.oas_version >= (3, 0, 0):
             self.openapi_spec_name = "/openapi.json"
-            self.swagger_ui_local_path = swagger_ui_3_path
         else:
             self.openapi_spec_name = "/swagger.json"
-            self.swagger_ui_local_path = swagger_ui_2_path
 
         if options:
             self._options.update(filter_values(options))

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'python-multipart>=0.0.5',
 ]
 
-swagger_ui_require = 'swagger-ui-bundle>=0.0.2,<0.1'
+swagger_ui_require = 'py-swagger-ui>=1.1.0,<2'
 
 flask_require = [
     'flask[async]>=2.2,<3',

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -69,7 +69,7 @@ def test_openapi_yaml_behind_proxy(reverse_proxied_app):
     spec = yaml.load(openapi_yaml.data.decode("utf-8"), Loader=yaml.BaseLoader)
 
     if reverse_proxied_app._spec_file == "swagger.yaml":
-        assert b'url = "/behind/proxy/v1.0/swagger.json"' in swagger_ui.data
+        assert b'url: "/behind/proxy/v1.0/swagger.json"' in swagger_ui.data
         assert (
             spec.get("basePath") == "/behind/proxy/v1.0"
         ), "basePath should contains original URI"


### PR DESCRIPTION
Fixes #1412
Fixes #1516 

Since [swagger-ui-bundle](https://github.com/dtkav/swagger_ui_bundle) is no longer maintained, I forked it under the spec-first organization as [py-swagger-ui](https://github.com/spec-first/py-swagger-ui). This PR updates connexion to use it instead.
