### PR TITLE
Expose additional context 

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -9,9 +9,8 @@ import flask
 from flask import Response as FlaskResponse
 
 from connexion.apis.abstract import AbstractAPI
-from connexion.decorators import SyncDecorator
+from connexion.decorators import FlaskDecorator
 from connexion.frameworks import flask as flask_utils
-from connexion.frameworks.flask import Flask as FlaskFramework
 from connexion.jsonifier import Jsonifier
 from connexion.operations import AbstractOperation
 from connexion.uri_parsing import AbstractURIParser
@@ -91,12 +90,9 @@ class FlaskOperation:
 
     @property
     def fn(self) -> t.Callable:
-        decorator = SyncDecorator(
+        decorator = FlaskDecorator(
             self._operation,
             uri_parser_cls=self.uri_parser_class,
-            framework=FlaskFramework,
-            parameter=True,
-            response=True,
             pythonic_params=self.pythonic_params,
             jsonifier=self.api.jsonifier,
         )

--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -91,8 +91,6 @@ class FlaskOperation:
     @property
     def fn(self) -> t.Callable:
         decorator = FlaskDecorator(
-            self._operation,
-            uri_parser_cls=self.uri_parser_class,
             pythonic_params=self.pythonic_params,
             jsonifier=self.api.jsonifier,
         )

--- a/connexion/apps/async_app.py
+++ b/connexion/apps/async_app.py
@@ -15,9 +15,8 @@ from starlette.types import Receive, Scope, Send
 
 from connexion.apis.abstract import AbstractAPI
 from connexion.apps.abstract import AbstractApp
-from connexion.decorators import AsyncDecorator
+from connexion.decorators import StarletteDecorator
 from connexion.exceptions import MissingMiddleware, ProblemException
-from connexion.frameworks.starlette import Starlette as StarletteFramework
 from connexion.middleware.main import ConnexionMiddleware
 from connexion.middleware.routing import ROUTING_CONTEXT
 from connexion.operations import AbstractOperation
@@ -192,12 +191,9 @@ class AsyncOperation:
 
     @property
     def fn(self) -> t.Callable:
-        decorator = AsyncDecorator(
+        decorator = StarletteDecorator(
             self._operation,
             uri_parser_cls=self._operation.uri_parser_class,
-            framework=StarletteFramework,
-            parameter=True,
-            response=True,
             pythonic_params=self.pythonic_params,
             jsonifier=self.api.jsonifier,
         )

--- a/connexion/apps/async_app.py
+++ b/connexion/apps/async_app.py
@@ -192,8 +192,6 @@ class AsyncOperation:
     @property
     def fn(self) -> t.Callable:
         decorator = StarletteDecorator(
-            self._operation,
-            uri_parser_cls=self._operation.uri_parser_class,
             pythonic_params=self.pythonic_params,
             jsonifier=self.api.jsonifier,
         )

--- a/connexion/context.py
+++ b/connexion/context.py
@@ -1,12 +1,24 @@
 from contextvars import ContextVar
 
-from starlette.types import Scope
+from starlette.types import Receive, Scope
+from werkzeug.local import LocalProxy
+
+from connexion.operations import AbstractOperation
+
+UNBOUND_MESSAGE = (
+    "Working outside of operation context. Make sure your app is wrapped in a "
+    "ContextMiddleware and you're processing a request while accessing the context."
+)
+
+
+_context: ContextVar[dict] = ContextVar("CONTEXT")
+context = LocalProxy(_context, unbound_message=UNBOUND_MESSAGE)
+
+_operation: ContextVar[AbstractOperation] = ContextVar("OPERATION")
+operation = LocalProxy(_operation, unbound_message=UNBOUND_MESSAGE)
+
+_receive: ContextVar[Receive] = ContextVar("RECEIVE")
+receive = LocalProxy(_receive, unbound_message=UNBOUND_MESSAGE)
 
 _scope: ContextVar[Scope] = ContextVar("SCOPE")
-
-
-def __getattr__(name):
-    if name == "scope":
-        return _scope.get()
-    if name == "context":
-        return _scope.get().get("extensions", {}).get("connexion_context", {})
+scope = LocalProxy(_scope, unbound_message=UNBOUND_MESSAGE)

--- a/connexion/decorators/__init__.py
+++ b/connexion/decorators/__init__.py
@@ -1,4 +1,4 @@
 """
 This module defines decorators which Connexion uses to wrap user provided view functions.
 """
-from .main import AsyncDecorator, SyncDecorator  # noqa
+from .main import FlaskDecorator, StarletteDecorator  # noqa

--- a/connexion/decorators/main.py
+++ b/connexion/decorators/main.py
@@ -61,7 +61,6 @@ class BaseDecorator:
 
         parameter_decorator = self._parameter_decorator_cls(
             operation,
-            get_body_fn=self.framework.get_body,
             pythonic_params=self.pythonic_params,
         )
         function = parameter_decorator(function)

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -32,11 +32,9 @@ class BaseParameterDecorator:
         self,
         operation: AbstractOperation,
         *,
-        get_body_fn: t.Callable,
         pythonic_params: bool = False,
     ) -> None:
         self.operation = operation
-        self.get_body_fn = get_body_fn
         self.sanitize_fn = pythonic if pythonic_params else sanitized
 
         self.uri_parser = operation.uri_parser_class(
@@ -57,7 +55,7 @@ class BaseParameterDecorator:
             request.mimetype in FORM_CONTENT_TYPES
             and isinstance(self.operation, Swagger2Operation)
         ):
-            return self.get_body_fn(request)
+            return request.get_body()
         else:
             return None
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -153,13 +153,13 @@ class BaseResponseDecorator:
 class SyncResponseDecorator(BaseResponseDecorator):
     def __call__(self, function: t.Callable) -> t.Callable:
         @functools.wraps(function)
-        def wrapper(request):
+        def wrapper():
             """
             This method converts a handler response to a framework response.
             The handler response can be a ConnexionResponse, a framework response, a tuple or an
             object.
             """
-            handler_response = function(request)
+            handler_response = function()
             if self.framework.is_framework_response(handler_response):
                 return handler_response
             elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):
@@ -173,13 +173,13 @@ class SyncResponseDecorator(BaseResponseDecorator):
 class AsyncResponseDecorator(BaseResponseDecorator):
     def __call__(self, function: t.Callable) -> t.Callable:
         @functools.wraps(function)
-        async def wrapper(request):
+        async def wrapper():
             """
             This method converts a handler response to a framework response.
             The handler response can be a ConnexionResponse, a framework response, a tuple or an
             object.
             """
-            handler_response = await function(request)
+            handler_response = await function()
             if self.framework.is_framework_response(handler_response):
                 return handler_response
             elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):

--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -11,10 +11,8 @@ import flask
 import werkzeug
 
 from connexion.frameworks.abstract import Framework
-from connexion.http_facts import FORM_CONTENT_TYPES
 from connexion.lifecycle import ConnexionRequest
 from connexion.uri_parsing import AbstractURIParser
-from connexion.utils import is_json_mimetype
 
 
 class Flask(Framework):
@@ -57,16 +55,6 @@ class Flask(Framework):
     @staticmethod
     def get_request(*, uri_parser: AbstractURIParser, **kwargs) -> ConnexionRequest:  # type: ignore
         return ConnexionRequest(flask.request, uri_parser=uri_parser)
-
-    @staticmethod
-    def get_body(request):
-        if is_json_mimetype(request.content_type):
-            return request.get_json(silent=True)
-        elif request.mimetype in FORM_CONTENT_TYPES:
-            return request.form
-        else:
-            # Return explicit None instead of empty bytestring so it is handled as null downstream
-            return request.get_data() or None
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/frameworks/starlette.py
+++ b/connexion/frameworks/starlette.py
@@ -8,9 +8,7 @@ from starlette.responses import Response as StarletteResponse
 from starlette.types import Receive, Scope
 
 from connexion.frameworks.abstract import Framework
-from connexion.http_facts import FORM_CONTENT_TYPES
 from connexion.lifecycle import MiddlewareRequest, MiddlewareResponse
-from connexion.utils import is_json_mimetype
 
 
 class Starlette(Framework):
@@ -53,16 +51,6 @@ class Starlette(Framework):
     @staticmethod
     def get_request(*, scope: Scope, receive: Receive, **kwargs) -> MiddlewareRequest:  # type: ignore
         return MiddlewareRequest(scope, receive)
-
-    @staticmethod
-    async def get_body(request):
-        if is_json_mimetype(request.content_type):
-            return await request.json()
-        elif request.mimetype in FORM_CONTENT_TYPES:
-            return await request.form()
-        else:
-            # Return explicit None instead of empty bytestring so it is handled as null downstream
-            return await request.data() or None
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -40,10 +40,6 @@ OP = t.TypeVar("OP", bound=RoutedOperation)
 
 
 class RoutedAPI(AbstractSpecAPI, t.Generic[OP]):
-
-    operation_cls: t.Type[OP]
-    """The operation this middleware uses, which should implement the RoutingOperation protocol."""
-
     def __init__(
         self,
         specification: t.Union[pathlib.Path, str, dict],

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -66,7 +66,12 @@ class RoutedAPI(AbstractSpecAPI, t.Generic[OP]):
     def add_operation(self, path: str, method: str) -> None:
         operation_spec_cls = self.specification.operation_cls
         operation = operation_spec_cls.from_spec(
-            self.specification, self, path, method, self.resolver
+            self.specification,
+            self,
+            path,
+            method,
+            self.resolver,
+            uri_parser_class=self.options.uri_parser_class,
         )
         routed_operation = self.make_operation(operation)
         self.operations[operation.operation_id] = routed_operation

--- a/connexion/middleware/context.py
+++ b/connexion/middleware/context.py
@@ -2,13 +2,39 @@
 middleware stack, so it exposes the scope passed to the application"""
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from connexion.context import _scope
+from connexion.context import _context, _operation, _receive, _scope
+from connexion.middleware.abstract import RoutedAPI, RoutedMiddleware
+from connexion.operations import AbstractOperation
 
 
-class ContextMiddleware:
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
+class ContextOperation:
+    def __init__(
+        self,
+        next_app: ASGIApp,
+        *,
+        operation: AbstractOperation,
+    ) -> None:
+        self.next_app = next_app
+        self.operation = operation
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        _context.set(scope.get("extensions", {}).get("connexion_context", {}))
+        _operation.set(self.operation)
+        _receive.set(receive)
         _scope.set(scope)
-        await self.app(scope, receive, send)
+        await self.next_app(scope, receive, send)
+
+
+class ContextAPI(RoutedAPI[ContextOperation]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.add_paths()
+
+    def make_operation(self, operation: AbstractOperation) -> ContextOperation:
+        return ContextOperation(self.next_app, operation=operation)
+
+
+class ContextMiddleware(RoutedMiddleware[ContextAPI]):
+    """Middleware to expose operation specific context to application."""
+
+    api_cls = ContextAPI

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -120,8 +120,6 @@ class RequestValidationOperation:
 class RequestValidationAPI(RoutedAPI[RequestValidationOperation]):
     """Validation API."""
 
-    operation_cls = RequestValidationOperation
-
     def __init__(
         self,
         *args,

--- a/connexion/middleware/response_validation.py
+++ b/connexion/middleware/response_validation.py
@@ -125,8 +125,6 @@ class ResponseValidationOperation:
 class ResponseValidationAPI(RoutedAPI[ResponseValidationOperation]):
     """Validation API."""
 
-    operation_cls = ResponseValidationOperation
-
     def __init__(
         self,
         *args,

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -68,12 +68,18 @@ class RoutingAPI(AbstractRoutingAPI):
             resolver=resolver,
             resolver_error_handler=resolver_error_handler,
             debug=debug,
+            **kwargs,
         )
 
     def add_operation(self, path: str, method: str) -> None:
         operation_cls = self.specification.operation_cls
         operation = operation_cls.from_spec(
-            self.specification, self, path, method, self.resolver
+            self.specification,
+            self,
+            path,
+            method,
+            self.resolver,
+            uri_parser_class=self.options.uri_parser_class,
         )
         routing_operation = RoutingOperation.from_operation(
             operation, next_app=self.next_app

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -205,9 +205,6 @@ class SecurityOperation:
 
 
 class SecurityAPI(RoutedAPI[SecurityOperation]):
-
-    operation_cls = SecurityOperation
-
     def __init__(self, *args, auth_all_paths: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/connexion/problem.py
+++ b/connexion/problem.py
@@ -4,8 +4,6 @@ This module contains a Python interface for Problem Details for HTTP APIs
 to communicate distinct "problem types" to non-human consumers.
 """
 
-from .lifecycle import ConnexionResponse
-
 
 def problem(status, title, detail, type=None, instance=None, headers=None, ext=None):
     """
@@ -33,6 +31,8 @@ def problem(status, title, detail, type=None, instance=None, headers=None, ext=N
     :return: error response
     :rtype: ConnexionResponse
     """
+    from .lifecycle import ConnexionResponse  # prevent circular import
+
     if not type:
         type = "about:blank"
 

--- a/connexion/testing.py
+++ b/connexion/testing.py
@@ -1,0 +1,72 @@
+import contextvars
+import typing as t
+from unittest.mock import MagicMock
+
+from starlette.types import Receive, Scope
+
+from connexion.context import _context, _operation, _receive, _scope
+from connexion.operations import AbstractOperation
+
+
+class TestContext:
+    __test__ = False  # Pytest
+
+    def __init__(
+        self,
+        *,
+        context: dict = None,
+        operation: AbstractOperation = None,
+        receive: Receive = None,
+        scope: Scope = None,
+    ) -> None:
+        self.context = context if context is not None else self.build_context()
+        self.operation = operation if operation is not None else self.build_operation()
+        self.receive = receive if receive is not None else self.build_receive()
+        self.scope = scope if scope is not None else self.build_scope()
+
+        self.tokens: t.Dict[str, contextvars.Token] = {}
+
+    def __enter__(self) -> None:
+        self.tokens["context"] = _context.set(self.context)
+        self.tokens["operation"] = _operation.set(self.operation)
+        self.tokens["receive"] = _receive.set(self.receive)
+        self.tokens["scope"] = _scope.set(self.scope)
+        return
+
+    def __exit__(self, type, value, traceback):
+        _context.reset(self.tokens["context"])
+        _operation.reset(self.tokens["operation"])
+        _receive.reset(self.tokens["receive"])
+        _scope.reset(self.tokens["scope"])
+        return False
+
+    @staticmethod
+    def build_context() -> dict:
+        return {}
+
+    @staticmethod
+    def build_operation() -> AbstractOperation:
+        return MagicMock(name="operation")
+
+    @staticmethod
+    def build_receive() -> Receive:
+        async def receive() -> t.MutableMapping[str, t.Any]:
+            return {
+                "type": "http.request",
+                "body": b"",
+            }
+
+        return receive
+
+    @staticmethod
+    def build_scope(**kwargs) -> Scope:
+        scope = {
+            "type": "http",
+            "query_string": b"",
+            "headers": [(b"Content-Type", b"application/octet-stream")],
+        }
+
+        for key, value in kwargs.items():
+            scope[key] = value
+
+        return scope

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -3,14 +3,13 @@ from unittest.mock import MagicMock
 from connexion.decorators.parameter import (
     AsyncParameterDecorator,
     SyncParameterDecorator,
-    inspect_function_arguments,
     pythonic,
 )
+from connexion.testing import TestContext
 
 
 def test_sync_injection():
     request = MagicMock(name="request")
-    request.query_params = {}
     request.path_params = {"p1": "123"}
 
     func = MagicMock()
@@ -18,25 +17,18 @@ def test_sync_injection():
     def handler(**kwargs):
         func(**kwargs)
 
-    def get_body_fn(_request):
-        return {}
-
     operation = MagicMock(name="operation")
     operation.body_name = lambda _: "body"
 
-    arguments, has_kwargs = inspect_function_arguments(handler)
-
-    parameter_decorator = SyncParameterDecorator(
-        operation, get_body_fn=get_body_fn, arguments=arguments, has_kwargs=has_kwargs
-    )
-    decorated_handler = parameter_decorator(handler)
-    decorated_handler(request)
+    with TestContext(operation=operation):
+        parameter_decorator = SyncParameterDecorator()
+        decorated_handler = parameter_decorator(handler)
+        decorated_handler(request)
     func.assert_called_with(p1="123")
 
 
 async def test_async_injection():
     request = MagicMock(name="request")
-    request.query_params = {}
     request.path_params = {"p1": "123"}
 
     func = MagicMock()
@@ -44,74 +36,56 @@ async def test_async_injection():
     async def handler(**kwargs):
         func(**kwargs)
 
-    def get_body_fn(_request):
-        return {}
-
     operation = MagicMock(name="operation")
     operation.body_name = lambda _: "body"
 
-    arguments, has_kwargs = inspect_function_arguments(handler)
-
-    parameter_decorator = AsyncParameterDecorator(
-        operation, get_body_fn=get_body_fn, arguments=arguments, has_kwargs=has_kwargs
-    )
-    decorated_handler = parameter_decorator(handler)
-    await decorated_handler(request)
+    with TestContext(operation=operation):
+        parameter_decorator = AsyncParameterDecorator()
+        decorated_handler = parameter_decorator(handler)
+        await decorated_handler(request)
     func.assert_called_with(p1="123")
 
 
 def test_sync_injection_with_context():
     request = MagicMock(name="request")
-    request.query_params = {}
     request.path_params = {"p1": "123"}
-    request.context = {}
 
     func = MagicMock()
 
     def handler(context_, **kwargs):
         func(context_, **kwargs)
 
-    def get_body_fn(_request):
-        return {}
+    context = {"test": "success"}
 
     operation = MagicMock(name="operation")
     operation.body_name = lambda _: "body"
 
-    arguments, has_kwargs = inspect_function_arguments(handler)
-
-    parameter_decorator = SyncParameterDecorator(
-        operation, get_body_fn=get_body_fn, arguments=arguments, has_kwargs=has_kwargs
-    )
-    decorated_handler = parameter_decorator(handler)
-    decorated_handler(request)
-    func.assert_called_with(request.context, p1="123")
+    with TestContext(context=context, operation=operation):
+        parameter_decorator = SyncParameterDecorator()
+        decorated_handler = parameter_decorator(handler)
+        decorated_handler(request)
+        func.assert_called_with(context, p1="123", test="success")
 
 
 async def test_async_injection_with_context():
     request = MagicMock(name="request")
-    request.query_params = {}
     request.path_params = {"p1": "123"}
-    request.context = {}
 
     func = MagicMock()
 
     async def handler(context_, **kwargs):
         func(context_, **kwargs)
 
-    def get_body_fn(_request):
-        return {}
+    context = {"test": "success"}
 
     operation = MagicMock(name="operation")
     operation.body_name = lambda _: "body"
 
-    arguments, has_kwargs = inspect_function_arguments(handler)
-
-    parameter_decorator = AsyncParameterDecorator(
-        operation, get_body_fn=get_body_fn, arguments=arguments, has_kwargs=has_kwargs
-    )
-    decorated_handler = parameter_decorator(handler)
-    await decorated_handler(request)
-    func.assert_called_with(request.context, p1="123")
+    with TestContext(context=context, operation=operation):
+        parameter_decorator = AsyncParameterDecorator()
+        decorated_handler = parameter_decorator(handler)
+        await decorated_handler(request)
+        func.assert_called_with(context, p1="123", test="success")
 
 
 def test_pythonic_params():


### PR DESCRIPTION
This PR contains 2 main changes:
- Expose additional context. We now expose the scope, operation, connexion context, and receive channel as context aware globals. This makes them available to the decorators independent of the framework in between. The user will also be able to use these.
- Rename the decorators to be framework specific. This is part of a bigger change for which I'll submit a follow up PR.
