### PR TITLE
Make tests framework agnostic

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -18,8 +18,6 @@ from .resolver import Resolution, Resolver, RestyResolver  # NOQA
 from .utils import not_installed_error  # NOQA
 
 try:
-    from flask import request  # NOQA
-
     from connexion.apps.flask import FlaskApi, FlaskApp
 except ImportError as e:  # pragma: no cover
     _flask_not_installed_error = not_installed_error(e)
@@ -27,6 +25,7 @@ except ImportError as e:  # pragma: no cover
     FlaskApp = _flask_not_installed_error  # type: ignore
 
 from connexion.apps.asynchronous import AsyncApi, AsyncApp
+from connexion.context import request
 from connexion.middleware import ConnexionMiddleware
 
 App = FlaskApp

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -6,6 +6,7 @@ import abc
 import pathlib
 import typing as t
 
+from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
 from connexion.middleware import ConnexionMiddleware, SpecMiddleware
@@ -224,6 +225,7 @@ class AbstractApp:
     @abc.abstractmethod
     def test_client(self, **kwargs):
         """Creates a test client for this application."""
+        return TestClient(self, **kwargs)
 
     def run(self, import_string: str = None, **kwargs):
         """Run the application using uvicorn.

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -222,7 +222,6 @@ class AbstractApp:
         :param function: Callable that will handle exception.
         """
 
-    @abc.abstractmethod
     def test_client(self, **kwargs):
         """Creates a test client for this application."""
         return TestClient(self, **kwargs)

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -8,6 +8,7 @@ import typing as t
 
 from starlette.responses import Response as StarletteResponse
 from starlette.routing import Router
+from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
 from connexion.apps.abstract import AbstractApp
@@ -187,4 +188,4 @@ class AsyncApp(AbstractApp):
         """TODO: implement"""
 
     def test_client(self, **kwargs):
-        """TODO: implement"""
+        return TestClient(self)

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -8,7 +8,6 @@ import typing as t
 
 from starlette.responses import Response as StarletteResponse
 from starlette.routing import Router
-from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
 from connexion.apps.abstract import AbstractApp
@@ -186,6 +185,3 @@ class AsyncApp(AbstractApp):
         self, code_or_exception: t.Union[int, t.Type[Exception]], function: t.Callable
     ) -> None:
         """TODO: implement"""
-
-    def test_client(self, **kwargs):
-        return TestClient(self)

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -184,4 +184,4 @@ class AsyncApp(AbstractApp):
     def add_error_handler(
         self, code_or_exception: t.Union[int, t.Type[Exception]], function: t.Callable
     ) -> None:
-        """TODO: implement"""
+        self.middleware.add_error_handler(code_or_exception, function)

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -5,12 +5,10 @@ This module defines a FlaskApp, a Connexion application to wrap a Flask applicat
 import pathlib
 import typing as t
 
-import a2wsgi
 import flask
 import werkzeug.exceptions
 from flask import Response as FlaskResponse
 from flask import signals
-from flask.testing import FlaskClient
 from starlette.types import Receive, Scope, Send
 
 from connexion.apps.abstract import AbstractApp
@@ -251,15 +249,3 @@ class FlaskApp(AbstractApp):
         self, code_or_exception: t.Union[int, t.Type[Exception]], function: t.Callable
     ) -> None:
         self.app.register_error_handler(code_or_exception, function)
-
-    def test_client(self, **kwargs):
-        self.app.wsgi_app = a2wsgi.ASGIMiddleware(self.middleware)
-        self.app.test_client_class = ConnexionTestClient
-        return self.app.test_client(**kwargs)
-
-
-class ConnexionTestClient(FlaskClient):
-    def open(self, *args, **kwargs):
-        # Align with async test client
-        kwargs["query_string"] = kwargs.pop("params", None)
-        return super().open(*args, **kwargs)

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -10,6 +10,7 @@ import flask
 import werkzeug.exceptions
 from flask import Response as FlaskResponse
 from flask import signals
+from flask.testing import FlaskClient
 from starlette.types import Receive, Scope, Send
 
 from connexion.apps.abstract import AbstractApp
@@ -253,4 +254,12 @@ class FlaskApp(AbstractApp):
 
     def test_client(self, **kwargs):
         self.app.wsgi_app = a2wsgi.ASGIMiddleware(self.middleware)
+        self.app.test_client_class = ConnexionTestClient
         return self.app.test_client(**kwargs)
+
+
+class ConnexionTestClient(FlaskClient):
+    def open(self, *args, **kwargs):
+        # Align with async test client
+        kwargs["query_string"] = kwargs.pop("params", None)
+        return super().open(*args, **kwargs)

--- a/connexion/context.py
+++ b/connexion/context.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 from starlette.types import Receive, Scope
 from werkzeug.local import LocalProxy
 
+from connexion.lifecycle import ASGIRequest
 from connexion.operations import AbstractOperation
 
 UNBOUND_MESSAGE = (
@@ -22,3 +23,7 @@ receive = LocalProxy(_receive, unbound_message=UNBOUND_MESSAGE)
 
 _scope: ContextVar[Scope] = ContextVar("SCOPE")
 scope = LocalProxy(_scope, unbound_message=UNBOUND_MESSAGE)
+
+request = LocalProxy(
+    lambda: ASGIRequest(scope, receive), unbound_message=UNBOUND_MESSAGE
+)

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -10,7 +10,7 @@ from connexion.context import operation
 from connexion.datastructures import NoContent
 from connexion.exceptions import NonConformingResponseHeaders
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import ConnexionResponse, MiddlewareResponse
+from connexion.lifecycle import ConnexionResponse
 from connexion.utils import is_json_mimetype
 
 logger = logging.getLogger(__name__)
@@ -160,7 +160,7 @@ class SyncResponseDecorator(BaseResponseDecorator):
             handler_response = function(*args, **kwargs)
             if self.framework.is_framework_response(handler_response):
                 return handler_response
-            elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):
+            elif isinstance(handler_response, ConnexionResponse):
                 return self.framework.connexion_to_framework_response(handler_response)
             else:
                 return self.build_framework_response(handler_response)
@@ -180,7 +180,7 @@ class AsyncResponseDecorator(BaseResponseDecorator):
             handler_response = await function(*args, **kwargs)
             if self.framework.is_framework_response(handler_response):
                 return handler_response
-            elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):
+            elif isinstance(handler_response, ConnexionResponse):
                 return self.framework.connexion_to_framework_response(handler_response)
             else:
                 return self.build_framework_response(handler_response)

--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -12,7 +12,7 @@ import werkzeug.routing
 
 from connexion import jsonifier
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import ConnexionRequest
+from connexion.lifecycle import WSGIRequest
 from connexion.uri_parsing import AbstractURIParser
 
 
@@ -54,8 +54,10 @@ class Flask(Framework):
         return flask.current_app.response_class(**kwargs)
 
     @staticmethod
-    def get_request(*, uri_parser: AbstractURIParser, **kwargs) -> ConnexionRequest:  # type: ignore
-        return ConnexionRequest(flask.request, uri_parser=uri_parser)
+    def get_request(*, uri_parser: AbstractURIParser, **kwargs) -> WSGIRequest:  # type: ignore
+        return WSGIRequest(
+            flask.request, uri_parser=uri_parser, view_args=flask.request.view_args
+        )
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/frameworks/starlette.py
+++ b/connexion/frameworks/starlette.py
@@ -8,15 +8,14 @@ from starlette.responses import Response as StarletteResponse
 from starlette.types import Receive, Scope
 
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import MiddlewareRequest, MiddlewareResponse
+from connexion.lifecycle import ASGIRequest
+from connexion.uri_parsing import AbstractURIParser
 
 
 class Starlette(Framework):
     @staticmethod
     def is_framework_response(response: t.Any) -> bool:
-        return isinstance(response, StarletteResponse) and not isinstance(
-            response, MiddlewareResponse
-        )
+        return isinstance(response, StarletteResponse)
 
     @classmethod
     def connexion_to_framework_response(cls, response):
@@ -49,8 +48,8 @@ class Starlette(Framework):
         )
 
     @staticmethod
-    def get_request(*, scope: Scope, receive: Receive, **kwargs) -> MiddlewareRequest:  # type: ignore
-        return MiddlewareRequest(scope, receive)
+    def get_request(*, scope: Scope, receive: Receive, uri_parser: AbstractURIParser, **kwargs) -> ASGIRequest:  # type: ignore
+        return ASGIRequest(scope, receive, uri_parser=uri_parser)
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -70,7 +70,7 @@ class WSGIRequest(_RequestInterface):
 
     @property
     def content_type(self) -> str:
-        return self._werkzeug_request.content_type
+        return self._werkzeug_request.content_type or "application/octet-stream"
 
     @property
     def mimetype(self) -> str:
@@ -96,7 +96,7 @@ class WSGIRequest(_RequestInterface):
         return self._form
 
     def files(self):
-        return self._werkzeug_request.files
+        return self._werkzeug_request.files.to_dict(flat=False)
 
     def get_body(self):
         """Get body based on content type"""

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -272,7 +272,7 @@ class RoutedMiddleware(SpecMiddleware, t.Generic[API]):
                 operation = api.operations[operation_id]
             except KeyError as e:
                 if operation_id is None:
-                    logger.debug("Skipping validation check for operation without id.")
+                    logger.debug("Skipping operation without id.")
                     await self.app(scope, receive, send)
                     return
                 else:

--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -1,9 +1,11 @@
 import json
 
+import werkzeug.exceptions
 from starlette.exceptions import ExceptionMiddleware as StarletteExceptionMiddleware
 from starlette.exceptions import HTTPException
-from starlette.requests import Request
+from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response
+from starlette.types import Receive, Scope, Send
 
 from connexion.exceptions import ProblemException, problem
 
@@ -15,11 +17,9 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.add_exception_handler(ProblemException, self.problem_handler)
+        self.add_exception_handler(Exception, self.common_error_handler)
 
-    def problem_handler(self, _, exception: ProblemException):
-        """
-        :type exception: Exception
-        """
+    def problem_handler(self, _request: StarletteRequest, exception: ProblemException):
         connexion_response = problem(
             status=exception.status,
             title=exception.title,
@@ -37,12 +37,10 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
             headers=connexion_response.headers,
         )
 
-    def http_exception(self, request: Request, exc: HTTPException) -> Response:
-        try:
-            headers = exc.headers  # type: ignore
-        except AttributeError:
-            # Starlette < 0.19
-            headers = {}
+    def http_exception(
+        self, _request: StarletteRequest, exc: HTTPException
+    ) -> Response:
+        headers = exc.headers
 
         connexion_response = problem(
             title=exc.detail, detail=exc.detail, status=exc.status_code, headers=headers
@@ -54,3 +52,26 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
             media_type=connexion_response.mimetype,
             headers=connexion_response.headers,
         )
+
+    def common_error_handler(
+        self, _request: StarletteRequest, exc: HTTPException
+    ) -> Response:
+        exception = werkzeug.exceptions.InternalServerError()
+
+        response = problem(
+            title=exception.name,
+            detail=exception.description,
+            status=exception.code,
+        )
+
+        return Response(
+            content=json.dumps(response.body),
+            status_code=response.status_code,
+            media_type=response.mimetype,
+            headers=response.headers,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Needs to be set so starlette router throws exceptions instead of returning error responses
+        scope["app"] = self
+        await super().__call__(scope, receive, send)

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -276,6 +276,13 @@ class ConnexionMiddleware:
         # Api registered on the inner application.
         return api
 
+    def add_error_handler(
+        self, code_or_exception: t.Union[int, t.Type[Exception]], function: t.Callable
+    ) -> None:
+        for app in self.apps:
+            if isinstance(app, ExceptionMiddleware):
+                app.add_exception_handler(code_or_exception, function)
+
     def run(self, import_string: str = None, **kwargs):
         """Run the application using uvicorn.
 

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -139,6 +139,4 @@ class RoutingMiddleware(SpecMiddleware):
 
         _scope.set(scope.copy())  # type: ignore
 
-        # Needs to be set so starlette router throws exceptions instead of returning error responses
-        scope["app"] = self
         await self.router(scope, receive, send)

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.exceptions import ProblemException
-from connexion.lifecycle import MiddlewareRequest
+from connexion.lifecycle import ASGIRequest
 from connexion.middleware.abstract import RoutedAPI, RoutedMiddleware
 from connexion.operations import AbstractOperation
 from connexion.security import SecurityHandlerFactory
@@ -199,7 +199,7 @@ class SecurityOperation:
         return self.security_handler_factory.verify_security(auth_funcs)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        request = MiddlewareRequest(scope)
+        request = ASGIRequest(scope)
         await self.verification_fn(request)
         await self.next_app(scope, receive, send)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Jinja2 = "^3.0.0"
 python-multipart = "~0.0.5"
 PyYAML = ">= 5.1, < 7"
 requests = "^2.27"
-starlette = "^0.19"
+starlette = "^0.22"
 typing-extensions = "^4"
 werkzeug = "^2.2.1"
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -7,17 +7,21 @@ from conftest import FIXTURES_FOLDER, OPENAPI3_SPEC, build_app_from_fixture
 
 
 @pytest.fixture(scope="session")
-def simple_app(spec):
-    return build_app_from_fixture("simple", validate_responses=True)
+def simple_app(spec, app_class):
+    return build_app_from_fixture(
+        "simple", app_class=app_class, spec_file=spec, validate_responses=True
+    )
 
 
 @pytest.fixture(scope="session")
-def simple_openapi_app():
-    return build_app_from_fixture("simple", OPENAPI3_SPEC, validate_responses=True)
+def simple_openapi_app(app_class):
+    return build_app_from_fixture(
+        "simple", app_class=app_class, spec_file=OPENAPI3_SPEC, validate_responses=True
+    )
 
 
 @pytest.fixture(scope="session")
-def reverse_proxied_app(spec):
+def reverse_proxied_app(spec, app_class):
     class ReverseProxied:
         def __init__(self, app, root_path=None, scheme=None, server=None):
             self.app = app
@@ -47,62 +51,90 @@ def reverse_proxied_app(spec):
 
             return await self.app(scope, receive, send)
 
-    app = build_app_from_fixture("simple", spec, validate_responses=True)
+    app = build_app_from_fixture(
+        "simple", app_class=app_class, spec_file=spec, validate_responses=True
+    )
     app.middleware = ReverseProxied(app.middleware, root_path="/reverse_proxied/")
     return app
 
 
 @pytest.fixture(scope="session")
-def snake_case_app(spec):
+def snake_case_app(spec, app_class):
     return build_app_from_fixture(
-        "snake_case", spec, validate_responses=True, pythonic_params=True
+        "snake_case",
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
+        pythonic_params=True,
     )
 
 
 @pytest.fixture(scope="session")
-def invalid_resp_allowed_app(spec):
-    return build_app_from_fixture("simple", spec, validate_responses=False)
-
-
-@pytest.fixture(scope="session")
-def strict_app(spec):
+def invalid_resp_allowed_app(spec, app_class):
     return build_app_from_fixture(
-        "simple", spec, validate_responses=True, strict_validation=True
+        "simple", app_class=app_class, spec_file=spec, validate_responses=False
     )
 
 
 @pytest.fixture(scope="session")
-def problem_app(spec):
-    return build_app_from_fixture("problem", spec, validate_responses=True)
-
-
-@pytest.fixture(scope="session")
-def schema_app(spec):
-    return build_app_from_fixture("different_schemas", spec, validate_responses=True)
-
-
-@pytest.fixture(scope="session")
-def secure_endpoint_app(spec):
+def strict_app(spec, app_class):
     return build_app_from_fixture(
-        "secure_endpoint",
-        spec,
+        "simple",
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
+        strict_validation=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def problem_app(spec, app_class):
+    return build_app_from_fixture(
+        "problem", app_class=app_class, spec_file=spec, validate_responses=True
+    )
+
+
+@pytest.fixture(scope="session")
+def schema_app(spec, app_class):
+    return build_app_from_fixture(
+        "different_schemas",
+        app_class=app_class,
+        spec_file=spec,
         validate_responses=True,
     )
 
 
 @pytest.fixture(scope="session")
-def secure_api_app(spec):
-    options = {"swagger_ui": False}
+def secure_endpoint_app(spec, app_class):
     return build_app_from_fixture(
-        "secure_api", spec, options=options, auth_all_paths=True
+        "secure_endpoint",
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
     )
 
 
 @pytest.fixture(scope="session")
-def unordered_definition_app(spec):
-    return build_app_from_fixture("unordered_definition", spec)
+def secure_api_app(spec, app_class):
+    options = {"swagger_ui": False}
+    return build_app_from_fixture(
+        "secure_api",
+        app_class=app_class,
+        spec_file=spec,
+        options=options,
+        auth_all_paths=True,
+    )
 
 
 @pytest.fixture(scope="session")
-def bad_operations_app(spec):
-    return build_app_from_fixture("bad_operations", spec, resolver_error=501)
+def unordered_definition_app(spec, app_class):
+    return build_app_from_fixture(
+        "unordered_definition", app_class=app_class, spec_file=spec
+    )
+
+
+@pytest.fixture(scope="session")
+def bad_operations_app(spec, app_class):
+    return build_app_from_fixture(
+        "bad_operations", app_class=app_class, spec_file=spec, resolver_error=501
+    )

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -22,7 +22,7 @@ def test_app_with_relative_path(simple_api_spec_dir, spec):
     app.add_api(spec)
 
     app_client = app.test_client()
-    get_bye = app_client.get("/v1.0/bye/jsantos")  # type: flask.Response
+    get_bye = app_client.get("/v1.0/bye/jsantos")
     assert get_bye.status_code == 200
     assert get_bye.data == b"Goodbye jsantos"
 
@@ -51,9 +51,7 @@ def test_app_with_different_uri_parser(simple_api_spec_dir):
     app.add_api("swagger.yaml")
 
     app_client = app.test_client()
-    resp = app_client.get(
-        "/v1.0/test_array_csv_query_param?items=a,b,c&items=d,e,f"
-    )  # type: flask.Response
+    resp = app_client.get("/v1.0/test_array_csv_query_param?items=a,b,c&items=d,e,f")
     assert resp.status_code == 200
     j = json.loads(resp.get_data(as_text=True))
     assert j == ["a", "b", "c"]
@@ -63,7 +61,7 @@ def test_swagger_ui(simple_api_spec_dir, spec):
     app = App(__name__, specification_dir=simple_api_spec_dir)
     app.add_api(spec)
     app_client = app.test_client()
-    swagger_ui = app_client.get("/v1.0/ui/")  # type: flask.Response
+    swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 200
     spec_json_filename = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
     assert spec_json_filename.encode() in swagger_ui.data
@@ -81,7 +79,7 @@ def test_swagger_ui_with_config(simple_api_spec_dir, spec):
     )
     app.add_api(spec)
     app_client = app.test_client()
-    swagger_ui = app_client.get("/v1.0/ui/")  # type: flask.Response
+    swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 200
     if "openapi" in spec:
         assert b'configUrl: "swagger-ui-config.json"' in swagger_ui.data
@@ -97,13 +95,13 @@ def test_no_swagger_ui(simple_api_spec_dir, spec):
     app.add_api(spec)
 
     app_client = app.test_client()
-    swagger_ui = app_client.get("/v1.0/ui/")  # type: flask.Response
+    swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 404
 
     app2 = App(__name__, specification_dir=simple_api_spec_dir)
     app2.add_api(spec, swagger_ui_options={"swagger_ui": False})
     app2_client = app2.test_client()
-    swagger_ui2 = app2_client.get("/v1.0/ui/")  # type: flask.Response
+    swagger_ui2 = app2_client.get("/v1.0/ui/")
     assert swagger_ui2.status_code == 404
 
 
@@ -119,7 +117,7 @@ def test_swagger_ui_config_json(simple_api_spec_dir, spec):
     app.add_api(spec)
     app_client = app.test_client()
     url = "/v1.0/ui/swagger-ui-config.json"
-    swagger_ui_config_json = app_client.get(url)  # type: flask.Response
+    swagger_ui_config_json = app_client.get(url)
     assert swagger_ui_config_json.status_code == 200
     assert swagger_ui_config == json.loads(
         swagger_ui_config_json.get_data(as_text=True)
@@ -132,7 +130,7 @@ def test_no_swagger_ui_config_json(simple_api_spec_dir, spec):
     app.add_api(spec)
     app_client = app.test_client()
     url = "/v1.0/ui/swagger-ui-config.json"
-    swagger_ui_config_json = app_client.get(url)  # type: flask.Response
+    swagger_ui_config_json = app_client.get(url)
     assert swagger_ui_config_json.status_code == 404
 
 
@@ -143,7 +141,7 @@ def test_swagger_json_app(simple_api_spec_dir, spec):
     app_client = app.test_client()
     url = "/v1.0/{spec}"
     url = url.format(spec=spec.replace("yaml", "json"))
-    spec_json = app_client.get(url)  # type: flask.Response
+    spec_json = app_client.get(url)
     assert spec_json.status_code == 200
 
 
@@ -154,7 +152,7 @@ def test_swagger_yaml_app(simple_api_spec_dir, spec):
     app_client = app.test_client()
     url = "/v1.0/{spec}"
     url = url.format(spec=spec)
-    spec_response = app_client.get(url)  # type: flask.Response
+    spec_response = app_client.get(url)
     assert spec_response.status_code == 200
 
 
@@ -171,7 +169,7 @@ def test_no_swagger_json_app(simple_api_spec_dir, spec):
     app_client = app.test_client()
     url = "/v1.0/{spec}"
     url = url.format(spec=spec.replace("yaml", "json"))
-    spec_json = app_client.get(url)  # type: flask.Response
+    spec_json = app_client.get(url)
     assert spec_json.status_code == 404
 
 
@@ -193,7 +191,7 @@ def test_dict_as_yaml_path(simple_api_spec_dir, spec):
 
     app_client = app.test_client()
     url = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
-    swagger_json = app_client.get(url)  # type: flask.Response
+    swagger_json = app_client.get(url)
     assert swagger_json.status_code == 200
 
 
@@ -204,7 +202,7 @@ def test_swagger_json_api(simple_api_spec_dir, spec):
 
     app_client = app.test_client()
     url = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
-    swagger_json = app_client.get(url)  # type: flask.Response
+    swagger_json = app_client.get(url)
     assert swagger_json.status_code == 200
 
 
@@ -215,7 +213,7 @@ def test_no_swagger_json_api(simple_api_spec_dir, spec):
 
     app_client = app.test_client()
     url = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
-    swagger_json = app_client.get(url)  # type: flask.Response
+    swagger_json = app_client.get(url)
     assert swagger_json.status_code == 404
 
 
@@ -223,9 +221,9 @@ def test_swagger_json_content_type(simple_app):
     app_client = simple_app.test_client()
     spec = simple_app._spec_file
     url = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
-    response = app_client.get(url)  # type: flask.Response
+    response = app_client.get(url)
     assert response.status_code == 200
-    assert response.content_type == "application/json"
+    assert response.headers.get("content-type") == "application/json"
 
 
 def test_single_route():
@@ -242,29 +240,29 @@ def test_single_route():
 
     app.add_url_rule("/single1", "single1", route1, methods=["GET"])
 
-    get_single1 = app_client.get("/single1")  # type: flask.Response
+    get_single1 = app_client.get("/single1")
     assert get_single1.data == b"single 1"
 
-    post_single1 = app_client.post("/single1")  # type: flask.Response
+    post_single1 = app_client.post("/single1")
     assert post_single1.status_code == 405
 
-    post_single2 = app_client.post("/single2")  # type: flask.Response
+    post_single2 = app_client.post("/single2")
     assert post_single2.data == b"single 2"
 
-    get_single2 = app_client.get("/single2")  # type: flask.Response
+    get_single2 = app_client.get("/single2")
     assert get_single2.status_code == 405
 
 
 def test_resolve_method(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/resolver-test/method")  # type: flask.Response
-    assert resp.data == b'"DummyClass"\n'
+    resp = app_client.get("/v1.0/resolver-test/method")
+    assert resp.text == '"DummyClass"\n'
 
 
 def test_resolve_classmethod(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/resolver-test/classmethod")  # type: flask.Response
-    assert resp.data.decode("utf-8", "replace") == '"DummyClass"\n'
+    resp = app_client.get("/v1.0/resolver-test/classmethod")
+    assert resp.text == '"DummyClass"\n'
 
 
 def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir, spec):
@@ -273,9 +271,16 @@ def test_add_api_with_function_resolver_function_is_wrapped(simple_api_spec_dir,
     assert api.resolver.resolve_function_from_operation_id("faux")("bah") == "bar"
 
 
-def test_default_query_param_does_not_match_defined_type(default_param_error_spec_dir):
+def test_default_query_param_does_not_match_defined_type(
+    default_param_error_spec_dir, app_class, spec
+):
     with pytest.raises(InvalidSpecification):
-        build_app_from_fixture(default_param_error_spec_dir, validate_responses=True)
+        build_app_from_fixture(
+            default_param_error_spec_dir,
+            app_class=app_class,
+            spec_file=spec,
+            validate_responses=True,
+        )
 
 
 def test_handle_add_operation_error(simple_api_spec_dir, monkeypatch):

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -24,7 +24,7 @@ def test_app_with_relative_path(simple_api_spec_dir, spec):
     app_client = app.test_client()
     get_bye = app_client.get("/v1.0/bye/jsantos")
     assert get_bye.status_code == 200
-    assert get_bye.data == b"Goodbye jsantos"
+    assert get_bye.text == "Goodbye jsantos"
 
 
 def test_app_with_resolver(simple_api_spec_dir, spec):
@@ -53,7 +53,7 @@ def test_app_with_different_uri_parser(simple_api_spec_dir):
     app_client = app.test_client()
     resp = app_client.get("/v1.0/test_array_csv_query_param?items=a,b,c&items=d,e,f")
     assert resp.status_code == 200
-    j = json.loads(resp.get_data(as_text=True))
+    j = resp.json()
     assert j == ["a", "b", "c"]
 
 
@@ -64,9 +64,9 @@ def test_swagger_ui(simple_api_spec_dir, spec):
     swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 200
     spec_json_filename = "/v1.0/{spec}".format(spec=spec.replace("yaml", "json"))
-    assert spec_json_filename.encode() in swagger_ui.data
+    assert spec_json_filename in swagger_ui.text
     if "openapi" in spec:
-        assert b"swagger-ui-config.json" not in swagger_ui.data
+        assert "swagger-ui-config.json" not in swagger_ui.text
 
 
 def test_swagger_ui_with_config(simple_api_spec_dir, spec):
@@ -82,7 +82,7 @@ def test_swagger_ui_with_config(simple_api_spec_dir, spec):
     swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 200
     if "openapi" in spec:
-        assert b'configUrl: "swagger-ui-config.json"' in swagger_ui.data
+        assert 'configUrl: "swagger-ui-config.json"' in swagger_ui.text
 
 
 def test_no_swagger_ui(simple_api_spec_dir, spec):
@@ -119,9 +119,7 @@ def test_swagger_ui_config_json(simple_api_spec_dir, spec):
     url = "/v1.0/ui/swagger-ui-config.json"
     swagger_ui_config_json = app_client.get(url)
     assert swagger_ui_config_json.status_code == 200
-    assert swagger_ui_config == json.loads(
-        swagger_ui_config_json.get_data(as_text=True)
-    )
+    assert swagger_ui_config == swagger_ui_config_json.json()
 
 
 def test_no_swagger_ui_config_json(simple_api_spec_dir, spec):
@@ -241,13 +239,13 @@ def test_single_route():
     app.add_url_rule("/single1", "single1", route1, methods=["GET"])
 
     get_single1 = app_client.get("/single1")
-    assert get_single1.data == b"single 1"
+    assert get_single1.text == "single 1"
 
     post_single1 = app_client.post("/single1")
     assert post_single1.status_code == 405
 
     post_single2 = app_client.post("/single2")
-    assert post_single2.data == b"single 2"
+    assert post_single2.text == "single 2"
 
     get_single2 = app_client.get("/single2")
     assert get_single2.status_code == 405

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -10,8 +10,8 @@ def fix_data(data):
 def test_errors(problem_app):
     app_client = problem_app.test_client()
 
-    greeting404 = app_client.get("/v1.0/greeting")  # type: flask.Response
-    assert greeting404.content_type == "application/problem+json"
+    greeting404 = app_client.get("/v1.0/greeting")
+    assert greeting404.headers.get("content-type") == "application/problem+json"
     assert greeting404.status_code == 404
     error404 = flask.json.loads(fix_data(greeting404.data))
     assert error404["type"] == "about:blank"
@@ -23,19 +23,19 @@ def test_errors(problem_app):
     assert error404["status"] == 404
     assert "instance" not in error404
 
-    get_greeting = app_client.get("/v1.0/greeting/jsantos")  # type: flask.Response
-    assert get_greeting.content_type == "application/problem+json"
+    get_greeting = app_client.get("/v1.0/greeting/jsantos")
+    assert get_greeting.headers.get("content-type") == "application/problem+json"
     assert get_greeting.status_code == 405
-    error405 = json.loads(get_greeting.data.decode("utf-8", "replace"))
+    error405 = json.loads(get_greeting.text)
     assert error405["type"] == "about:blank"
     assert error405["title"] == "Method Not Allowed"
     assert error405["status"] == 405
     assert "instance" not in error405
 
-    get500 = app_client.get("/v1.0/except")  # type: flask.Response
-    assert get500.content_type == "application/problem+json"
+    get500 = app_client.get("/v1.0/except")
+    assert get500.headers.get("content-type") == "application/problem+json"
     assert get500.status_code == 500
-    error500 = json.loads(get500.data.decode("utf-8", "replace"))
+    error500 = json.loads(get500.text)
     assert error500["type"] == "about:blank"
     assert error500["title"] == "Internal Server Error"
     assert (
@@ -46,21 +46,21 @@ def test_errors(problem_app):
     assert error500["status"] == 500
     assert "instance" not in error500
 
-    get_problem = app_client.get("/v1.0/problem")  # type: flask.Response
-    assert get_problem.content_type == "application/problem+json"
+    get_problem = app_client.get("/v1.0/problem")
+    assert get_problem.headers.get("content-type") == "application/problem+json"
     assert get_problem.status_code == 402
     assert get_problem.headers["x-Test-Header"] == "In Test"
-    error_problem = json.loads(get_problem.data.decode("utf-8", "replace"))
+    error_problem = json.loads(get_problem.text)
     assert error_problem["type"] == "http://www.example.com/error"
     assert error_problem["title"] == "Some Error"
     assert error_problem["detail"] == "Something went wrong somewhere"
     assert error_problem["status"] == 402
     assert error_problem["instance"] == "instance1"
 
-    get_problem2 = app_client.get("/v1.0/other_problem")  # type: flask.Response
-    assert get_problem2.content_type == "application/problem+json"
+    get_problem2 = app_client.get("/v1.0/other_problem")
+    assert get_problem2.headers.get("content-type") == "application/problem+json"
     assert get_problem2.status_code == 402
-    error_problem2 = json.loads(get_problem2.data.decode("utf-8", "replace"))
+    error_problem2 = json.loads(get_problem2.text)
     assert error_problem2["type"] == "about:blank"
     assert error_problem2["title"] == "Some Error"
     assert error_problem2["detail"] == "Something went wrong somewhere"
@@ -69,20 +69,18 @@ def test_errors(problem_app):
 
     problematic_json = app_client.get(
         "/v1.0/json_response_with_undefined_value_to_serialize"
-    )  # type: flask.Response
+    )
     assert problematic_json.status_code == 500
 
     custom_problem = app_client.get("/v1.0/customized_problem_response")
     assert custom_problem.status_code == 403
-    problem_body = json.loads(custom_problem.data.decode("utf-8", "replace"))
+    problem_body = json.loads(custom_problem.text)
     assert "amount" in problem_body
     assert problem_body["amount"] == 23.0
 
     problem_as_exception = app_client.get("/v1.0/problem_exception_with_extra_args")
     assert problem_as_exception.status_code == 400
-    problem_as_exception_body = json.loads(
-        problem_as_exception.data.decode("utf-8", "replace")
-    )
+    problem_as_exception_body = json.loads(problem_as_exception.text)
     assert "age" in problem_as_exception_body
     assert problem_as_exception_body["age"] == 30
 
@@ -90,9 +88,7 @@ def test_errors(problem_app):
         "/v1.0/post_wrong_content_type", data="<html></html>", content_type="text/html"
     )
     assert unsupported_media_type.status_code == 415
-    unsupported_media_type_body = json.loads(
-        unsupported_media_type.data.decode("utf-8", "replace")
-    )
+    unsupported_media_type_body = json.loads(unsupported_media_type.text)
     assert unsupported_media_type_body["type"] == "about:blank"
     assert unsupported_media_type_body["title"] == "Unsupported Media Type"
     assert unsupported_media_type_body["detail"].startswith(

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -13,7 +13,7 @@ def test_errors(problem_app):
     greeting404 = app_client.get("/v1.0/greeting")
     assert greeting404.headers.get("content-type") == "application/problem+json"
     assert greeting404.status_code == 404
-    error404 = flask.json.loads(fix_data(greeting404.data))
+    error404 = greeting404.json()
     assert error404["type"] == "about:blank"
     assert error404["title"] == "Not Found"
     assert (
@@ -26,7 +26,7 @@ def test_errors(problem_app):
     get_greeting = app_client.get("/v1.0/greeting/jsantos")
     assert get_greeting.headers.get("content-type") == "application/problem+json"
     assert get_greeting.status_code == 405
-    error405 = json.loads(get_greeting.text)
+    error405 = get_greeting.json()
     assert error405["type"] == "about:blank"
     assert error405["title"] == "Method Not Allowed"
     assert error405["status"] == 405
@@ -35,7 +35,7 @@ def test_errors(problem_app):
     get500 = app_client.get("/v1.0/except")
     assert get500.headers.get("content-type") == "application/problem+json"
     assert get500.status_code == 500
-    error500 = json.loads(get500.text)
+    error500 = get500.json()
     assert error500["type"] == "about:blank"
     assert error500["title"] == "Internal Server Error"
     assert (
@@ -50,7 +50,7 @@ def test_errors(problem_app):
     assert get_problem.headers.get("content-type") == "application/problem+json"
     assert get_problem.status_code == 402
     assert get_problem.headers["x-Test-Header"] == "In Test"
-    error_problem = json.loads(get_problem.text)
+    error_problem = get_problem.json()
     assert error_problem["type"] == "http://www.example.com/error"
     assert error_problem["title"] == "Some Error"
     assert error_problem["detail"] == "Something went wrong somewhere"
@@ -60,7 +60,7 @@ def test_errors(problem_app):
     get_problem2 = app_client.get("/v1.0/other_problem")
     assert get_problem2.headers.get("content-type") == "application/problem+json"
     assert get_problem2.status_code == 402
-    error_problem2 = json.loads(get_problem2.text)
+    error_problem2 = get_problem2.json()
     assert error_problem2["type"] == "about:blank"
     assert error_problem2["title"] == "Some Error"
     assert error_problem2["detail"] == "Something went wrong somewhere"
@@ -74,21 +74,23 @@ def test_errors(problem_app):
 
     custom_problem = app_client.get("/v1.0/customized_problem_response")
     assert custom_problem.status_code == 403
-    problem_body = json.loads(custom_problem.text)
+    problem_body = custom_problem.json()
     assert "amount" in problem_body
     assert problem_body["amount"] == 23.0
 
     problem_as_exception = app_client.get("/v1.0/problem_exception_with_extra_args")
     assert problem_as_exception.status_code == 400
-    problem_as_exception_body = json.loads(problem_as_exception.text)
+    problem_as_exception_body = problem_as_exception.json()
     assert "age" in problem_as_exception_body
     assert problem_as_exception_body["age"] == 30
 
     unsupported_media_type = app_client.post(
-        "/v1.0/post_wrong_content_type", data="<html></html>", content_type="text/html"
+        "/v1.0/post_wrong_content_type",
+        data="<html></html>",
+        headers={"content-type": "text/html"},
     )
     assert unsupported_media_type.status_code == 415
-    unsupported_media_type_body = json.loads(unsupported_media_type.text)
+    unsupported_media_type_body = unsupported_media_type.json()
     assert unsupported_media_type_body["type"] == "about:blank"
     assert unsupported_media_type_body["title"] == "Unsupported Media Type"
     assert unsupported_media_type_body["detail"].startswith(

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -16,10 +16,6 @@ def test_errors(problem_app):
     error404 = greeting404.json()
     assert error404["type"] == "about:blank"
     assert error404["title"] == "Not Found"
-    assert (
-        error404["detail"] == "The requested URL was not found on the server. "
-        "If you entered the URL manually please check your spelling and try again."
-    )
     assert error404["status"] == 404
     assert "instance" not in error404
 

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -82,7 +82,7 @@ def test_errors(problem_app):
 
     unsupported_media_type = app_client.post(
         "/v1.0/post_wrong_content_type",
-        data="<html></html>",
+        content="<html></html>",
         headers={"content-type": "text/html"},
     )
     assert unsupported_media_type.status_code == 415

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -27,7 +27,7 @@ def test_header_not_returned(simple_openapi_app):
         response.status_code == 500
     )  # view_func has not returned what was promised in spec
     assert response.headers.get("content-type") == "application/problem+json"
-    data = json.loads(response.text)
+    data = response.json()
     assert data["type"] == "about:blank"
     assert data["title"] == "Response headers do not conform to specification"
     assert (

--- a/tests/api/test_headers.py
+++ b/tests/api/test_headers.py
@@ -4,7 +4,7 @@ import json
 def test_headers_jsonifier(simple_app):
     app_client = simple_app.test_client()
 
-    response = app_client.post("/v1.0/goodday/dan", data={})  # type: flask.Response
+    response = app_client.post("/v1.0/goodday/dan", data={})
     assert response.status_code == 201
     # Default Werkzeug behavior was changed in 2.1 (https://github.com/pallets/werkzeug/issues/2352)
     assert response.headers["Location"] in ["http://localhost/my/uri", "/my/uri"]
@@ -13,7 +13,7 @@ def test_headers_jsonifier(simple_app):
 def test_headers_produces(simple_app):
     app_client = simple_app.test_client()
 
-    response = app_client.post("/v1.0/goodevening/dan", data={})  # type: flask.Response
+    response = app_client.post("/v1.0/goodevening/dan", data={})
     assert response.status_code == 201
     # Default Werkzeug behavior was changed in 2.1 (https://github.com/pallets/werkzeug/issues/2352)
     assert response.headers["Location"] in ["http://localhost/my/uri", "/my/uri"]
@@ -22,14 +22,12 @@ def test_headers_produces(simple_app):
 def test_header_not_returned(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
 
-    response = app_client.post(
-        "/v1.0/goodday/noheader", data={}
-    )  # type: flask.Response
+    response = app_client.post("/v1.0/goodday/noheader", data={})
     assert (
         response.status_code == 500
     )  # view_func has not returned what was promised in spec
-    assert response.content_type == "application/problem+json"
-    data = json.loads(response.data.decode("utf-8", "replace"))
+    assert response.headers.get("content-type") == "application/problem+json"
+    data = json.loads(response.text)
     assert data["type"] == "about:blank"
     assert data["title"] == "Response headers do not conform to specification"
     assert (

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -89,12 +89,12 @@ def test_array_form_param(simple_app):
     assert array_response == [1, 2, 3]
     url = "/v1.0/test_array_csv_form_param"
     data = "items=A&items=B&items=C&items=D,E,F"
-    response = app_client.post(url, headers=headers, data=data)
+    response = app_client.post(url, headers=headers, content=data)
     array_response: List[str] = response.json()  # multi array with csv format
     assert array_response == ["D", "E", "F"]
     url = "/v1.0/test_array_pipes_form_param"
     data = "items=4&items=5&items=6&items=7|8|9"
-    response = app_client.post(url, headers=headers, data=data)
+    response = app_client.post(url, headers=headers, content=data)
     array_response: List[int] = response.json()  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
@@ -290,8 +290,7 @@ def test_body_not_allowed_additional_properties(simple_app):
     body = {"body1": "bodyString", "additional_property": "test1"}
     resp = app_client.post(
         "/v1.0/body-not-allowed-additional-properties",
-        data=json.dumps(body),
-        headers={"Content-Type": "application/json"},
+        json=body,
     )
     assert resp.status_code == 400
 
@@ -395,14 +394,14 @@ def test_nullable_parameter(simple_app):
     assert resp.json() == "it was None"
 
     headers = {"Content-Type": "application/json"}
-    resp = app_client.put("/v1.0/nullable-parameters", data="null", headers=headers)
+    resp = app_client.put("/v1.0/nullable-parameters", content="null", headers=headers)
     assert resp.json() == "it was None"
 
-    resp = app_client.put("/v1.0/nullable-parameters", data="None", headers=headers)
+    resp = app_client.put("/v1.0/nullable-parameters", content="None", headers=headers)
     assert resp.json() == "it was None"
 
     resp = app_client.put(
-        "/v1.0/nullable-parameters-noargs", data="None", headers=headers
+        "/v1.0/nullable-parameters-noargs", content="None", headers=headers
     )
     assert resp.json() == "hello"
 
@@ -421,8 +420,7 @@ def test_args_kwargs(simple_app):
         body = {"foo": "a", "bar": "b"}
         resp = app_client.post(
             "/v1.0/body-params-as-kwargs",
-            data=json.dumps(body),
-            headers={"Content-Type": "application/json"},
+            json=body,
         )
         assert resp.status_code == 200
         # having only kwargs, the handler would have been passed 'body'
@@ -449,7 +447,7 @@ def test_param_sanitization(simple_app):
     body = {"body1": "bodyString", "body2": "otherString"}
     resp = app_client.post(
         "/v1.0/body-sanitization",
-        data=json.dumps(body),
+        json=body,
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
@@ -458,7 +456,7 @@ def test_param_sanitization(simple_app):
     body = {"body1": "bodyString", "body2": 12, "body3": {"a": "otherString"}}
     resp = app_client.post(
         "/v1.0/body-sanitization-additional-properties",
-        data=json.dumps(body),
+        json=body,
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
@@ -471,7 +469,7 @@ def test_param_sanitization(simple_app):
     }
     resp = app_client.post(
         "/v1.0/body-sanitization-additional-properties-defined",
-        data=json.dumps(body),
+        json=body,
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
@@ -501,25 +499,25 @@ def test_parameters_snake_case(snake_case_app):
     resp = app_client.post(
         "/v1.0/test-post-path-snake/123",
         headers=headers,
-        data=json.dumps({"a": "test"}),
+        json={"a": "test"},
     )
     assert resp.status_code == 200
     resp = app_client.post(
         "/v1.0/test-post-path-shadow/123",
         headers=headers,
-        data=json.dumps({"a": "test"}),
+        json={"a": "test"},
     )
     assert resp.status_code == 200
     resp = app_client.post(
         "/v1.0/test-post-query-snake?someId=123",
         headers=headers,
-        data=json.dumps({"a": "test"}),
+        json={"a": "test"},
     )
     assert resp.status_code == 200
     resp = app_client.post(
         "/v1.0/test-post-query-shadow?id=123&class=header",
         headers=headers,
-        data=json.dumps({"a": "test"}),
+        json={"a": "test"},
     )
     assert resp.status_code == 200
     resp = app_client.get("/v1.0/test-get-path-snake/123")

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -44,35 +44,31 @@ def test_array_query_param(simple_app):
     headers = {"Content-type": "application/json"}
     url = "/v1.0/test_array_csv_query_param"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.text)
+    array_response: List[str] = response.json()
     assert array_response == ["squash", "banana"]
     url = "/v1.0/test_array_csv_query_param?items=one,two,three"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.text)
+    array_response: List[str] = response.json()
     assert array_response == ["one", "two", "three"]
     url = "/v1.0/test_array_pipes_query_param?items=1|2|3"
     response = app_client.get(url, headers=headers)
-    array_response: List[int] = json.loads(response.text)
+    array_response: List[int] = response.json()
     assert array_response == [1, 2, 3]
     url = "/v1.0/test_array_unsupported_query_param?items=1;2;3"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(
-        response.text
-    )  # unsupported collectionFormat
+    array_response: List[str] = response.json()  # unsupported collectionFormat
     assert array_response == ["1;2;3"]
     url = "/v1.0/test_array_csv_query_param?items=A&items=B&items=C&items=D,E,F"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.text)  # multi array with csv format
+    array_response: List[str] = response.json()  # multi array with csv format
     assert array_response == ["D", "E", "F"]
     url = "/v1.0/test_array_multi_query_param?items=A&items=B&items=C&items=D,E,F"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.text)  # multi array with csv format
+    array_response: List[str] = response.json()  # multi array with csv format
     assert array_response == ["A", "B", "C", "D", "E", "F"]
     url = "/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9"
     response = app_client.get(url, headers=headers)
-    array_response: List[int] = json.loads(
-        response.text
-    )  # multi array with pipes format
+    array_response: List[int] = response.json()  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
 
@@ -81,27 +77,25 @@ def test_array_form_param(simple_app):
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     url = "/v1.0/test_array_csv_form_param"
     response = app_client.post(url, headers=headers)
-    array_response: List[str] = json.loads(response.text)
+    array_response: List[str] = response.json()
     assert array_response == ["squash", "banana"]
     url = "/v1.0/test_array_csv_form_param"
     response = app_client.post(url, headers=headers, data={"items": "one,two,three"})
-    array_response: List[str] = json.loads(response.text)
+    array_response: List[str] = response.json()
     assert array_response == ["one", "two", "three"]
     url = "/v1.0/test_array_pipes_form_param"
     response = app_client.post(url, headers=headers, data={"items": "1|2|3"})
-    array_response: List[int] = json.loads(response.text)
+    array_response: List[int] = response.json()
     assert array_response == [1, 2, 3]
     url = "/v1.0/test_array_csv_form_param"
     data = "items=A&items=B&items=C&items=D,E,F"
     response = app_client.post(url, headers=headers, data=data)
-    array_response: List[str] = json.loads(response.text)  # multi array with csv format
+    array_response: List[str] = response.json()  # multi array with csv format
     assert array_response == ["D", "E", "F"]
     url = "/v1.0/test_array_pipes_form_param"
     data = "items=4&items=5&items=6&items=7|8|9"
     response = app_client.post(url, headers=headers, data=data)
-    array_response: List[int] = json.loads(
-        response.text
-    )  # multi array with pipes format
+    array_response: List[int] = response.json()  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
 
@@ -119,7 +113,7 @@ def test_strict_extra_query_param(strict_app):
     url = "/v1.0/test_parameter_validation?extra_parameter=true"
     resp = app_client.get(url, headers=headers)
     assert resp.status_code == 400
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["detail"] == "Extra query parameter(s) extra_parameter not in spec"
 
 
@@ -128,7 +122,7 @@ def test_strict_formdata_param(strict_app):
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     url = "/v1.0/test_array_csv_form_param"
     resp = app_client.post(url, headers=headers, data={"items": "mango"})
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == ["mango"]
     assert resp.status_code == 200
 
@@ -198,7 +192,7 @@ def test_default_param(strict_app):
     app_client = strict_app.test_client()
     resp = app_client.get("/v1.0/test-default-query-parameter")
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["app_name"] == "connexion"
 
 
@@ -206,12 +200,12 @@ def test_falsy_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-falsy-param", params={"falsy": 0})
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == 0
 
     resp = app_client.get("/v1.0/test-falsy-param")
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == 1
 
 
@@ -219,7 +213,7 @@ def test_formdata_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-param", data={"formData": "test"})
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == "test"
 
 
@@ -227,7 +221,7 @@ def test_formdata_bad_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-param")
     assert resp.status_code == 400
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["detail"] in [
         "Missing formdata parameter 'formData'",
         "'formData' is a required property",  # OAS3
@@ -256,9 +250,9 @@ def test_strict_formdata_extra_param(strict_app):
         "/v1.0/test-formData-param", data={"formData": "test", "extra_formData": "test"}
     )
     assert resp.status_code == 400
-    response = json.loads(resp.text)
     assert (
-        response["detail"] == "Extra formData parameter(s) extra_formData not in spec"
+        resp.json()["detail"]
+        == "Extra formData parameter(s) extra_formData not in spec"
     )
 
 
@@ -266,20 +260,17 @@ def test_formdata_file_upload(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post(
         "/v1.0/test-formData-file-upload",
-        data={"fileData": (BytesIO(b"file contents"), "filename.txt")},
-        headers={"content-type": "multipart/form-data"},
+        files={"fileData": ("filename.txt", BytesIO(b"file contents"))},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.text)
-    assert response == {"filename.txt": "file contents"}
+    assert resp.json() == {"filename.txt": "file contents"}
 
 
 def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-file-upload")
     assert resp.status_code == 400
-    response = json.loads(resp.text)
-    assert response["detail"] in [
+    assert resp.json()["detail"] in [
         "Missing formdata parameter 'fileData'",
         "'fileData' is a required property",  # OAS3
     ]
@@ -289,8 +280,7 @@ def test_formdata_file_upload_missing_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post(
         "/v1.0/test-formData-file-upload-missing-param",
-        data={"missing_fileData": (BytesIO(b"file contents"), "example.txt")},
-        headers={"content-type": "multipart/form-data"},
+        files={"missing_fileData": ("example.txt", BytesIO(b"file contents"))},
     )
     assert resp.status_code == 200, resp.text
 
@@ -305,7 +295,7 @@ def test_body_not_allowed_additional_properties(simple_app):
     )
     assert resp.status_code == 400
 
-    response = json.loads(resp.text)
+    response = resp.json()
     assert "Additional properties are not allowed" in response["detail"]
 
 
@@ -316,7 +306,7 @@ def test_bool_as_default_param(simple_app):
 
     resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": True})
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response is True
 
 
@@ -324,12 +314,12 @@ def test_bool_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": True})
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response is True
 
     resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": False})
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response is False
 
 
@@ -337,13 +327,13 @@ def test_bool_array_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-bool-array-param?thruthiness=true,true,true")
     assert resp.status_code == 200, resp.text
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response is True
 
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-bool-array-param?thruthiness=true,true,false")
     assert resp.status_code == 200, resp.text
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response is False
 
     app_client = simple_app.test_client()
@@ -368,7 +358,7 @@ def test_parameters_defined_in_path_level(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/parameters-in-root-path?title=nice-get")
     assert resp.status_code == 200
-    assert json.loads(resp.text) == ["nice-get"]
+    assert resp.json() == ["nice-get"]
 
     resp = app_client.get("/v1.0/parameters-in-root-path")
     assert resp.status_code == 400
@@ -377,10 +367,10 @@ def test_parameters_defined_in_path_level(simple_app):
 def test_array_in_path(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-array-in-path/one_item")
-    assert json.loads(resp.text) == ["one_item"]
+    assert resp.json() == ["one_item"]
 
     resp = app_client.get("/v1.0/test-array-in-path/one_item,another_item")
-    assert json.loads(resp.text) == [
+    assert resp.json() == [
         "one_item",
         "another_item",
     ]
@@ -389,43 +379,43 @@ def test_array_in_path(simple_app):
 def test_nullable_parameter(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/nullable-parameters?time_start=null")
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     resp = app_client.get("/v1.0/nullable-parameters?time_start=None")
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     time_start = 1010
     resp = app_client.get(f"/v1.0/nullable-parameters?time_start={time_start}")
-    assert json.loads(resp.text) == time_start
+    assert resp.json() == time_start
 
     resp = app_client.post("/v1.0/nullable-parameters", data={"post_param": "None"})
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     resp = app_client.post("/v1.0/nullable-parameters", data={"post_param": "null"})
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     headers = {"Content-Type": "application/json"}
     resp = app_client.put("/v1.0/nullable-parameters", data="null", headers=headers)
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     resp = app_client.put("/v1.0/nullable-parameters", data="None", headers=headers)
-    assert json.loads(resp.text) == "it was None"
+    assert resp.json() == "it was None"
 
     resp = app_client.put(
         "/v1.0/nullable-parameters-noargs", data="None", headers=headers
     )
-    assert json.loads(resp.text) == "hello"
+    assert resp.json() == "hello"
 
 
 def test_args_kwargs(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/query-params-as-kwargs")
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {}
+    assert resp.json() == {}
 
     resp = app_client.get("/v1.0/query-params-as-kwargs?foo=a&bar=b")
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {"foo": "a"}
+    assert resp.json() == {"foo": "a"}
 
     if simple_app._spec_file == "openapi.yaml":
         body = {"foo": "a", "bar": "b"}
@@ -436,7 +426,7 @@ def test_args_kwargs(simple_app):
         )
         assert resp.status_code == 200
         # having only kwargs, the handler would have been passed 'body'
-        assert json.loads(resp.text) == {
+        assert resp.json() == {
             "body": {"foo": "a", "bar": "b"},
         }
 
@@ -445,13 +435,13 @@ def test_param_sanitization(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/param-sanitization")
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {}
+    assert resp.json() == {}
 
     resp = app_client.post(
         "/v1.0/param-sanitization?$query=queryString", data={"$form": "formString"}
     )
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {
+    assert resp.json() == {
         "query": "queryString",
         "form": "formString",
     }
@@ -463,7 +453,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.text) == body
+    assert resp.json() == body
 
     body = {"body1": "bodyString", "body2": 12, "body3": {"a": "otherString"}}
     resp = app_client.post(
@@ -472,7 +462,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.text) == body
+    assert resp.json() == body
 
     body = {
         "body1": "bodyString",
@@ -485,7 +475,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.text) == body
+    assert resp.json() == body
 
 
 def test_no_sanitization_in_request_body(simple_app):
@@ -502,7 +492,7 @@ def test_no_sanitization_in_request_body(simple_app):
     response = app_client.post("/v1.0/forward", json=data)
 
     assert response.status_code == 200
-    assert json.loads(response.text) == data
+    assert response.json() == data
 
 
 def test_parameters_snake_case(snake_case_app):
@@ -546,22 +536,22 @@ def test_parameters_snake_case(snake_case_app):
         "/v1.0/test-get-camel-case-version?truthiness=true&orderBy=asc"
     )
     assert resp.status_code == 200, resp.text
-    assert json.loads(resp.text) == {"truthiness": True, "order_by": "asc"}
+    assert resp.json() == {"truthiness": True, "order_by": "asc"}
     resp = app_client.get("/v1.0/test-get-camel-case-version?truthiness=5")
     assert resp.status_code == 400
-    assert json.loads(resp.text)["detail"].startswith("'5' is not of type 'boolean'")
+    assert resp.json()["detail"].startswith("'5' is not of type 'boolean'")
     # Incorrectly cased params should be ignored
     resp = app_client.get(
         "/v1.0/test-get-camel-case-version?Truthiness=true&order_by=asc"
     )
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {
+    assert resp.json() == {
         "truthiness": False,
         "order_by": None,
     }  # default values
     resp = app_client.get("/v1.0/test-get-camel-case-version?Truthiness=5&order_by=4")
     assert resp.status_code == 200
-    assert json.loads(resp.text) == {
+    assert resp.json() == {
         "truthiness": False,
         "order_by": None,
     }  # default values
@@ -573,15 +563,11 @@ def test_get_unicode_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_unicode_request?price=%C2%A319.99")  # £19.99
     assert resp.status_code == 200
-    assert json.loads(resp.text)["price"] == "£19.99"
+    assert resp.json()["price"] == "£19.99"
 
 
 def test_cookie_param(simple_app):
-    try:
-        app_client = simple_app.test_client(cookies={"test_cookie": "hello"})
-    except TypeError:
-        app_client = simple_app.test_client()
-        app_client.set_cookie("localhost", "test_cookie", "hello")
+    app_client = simple_app.test_client(cookies={"test_cookie": "hello"})
     response = app_client.get("/v1.0/test-cookie-param")
     assert response.status_code == 200
-    assert response.json == {"cookie_value": "hello"}
+    assert response.json() == {"cookie_value": "hello"}

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -10,29 +10,21 @@ def test_parameter_validation(simple_app):
 
     url = "/v1.0/test_parameter_validation"
 
-    response = app_client.get(
-        url, query_string={"date": "2015-08-26"}
-    )  # type: flask.Response
+    response = app_client.get(url, params={"date": "2015-08-26"})
     assert response.status_code == 200
 
     for invalid_int in "", "foo", "0.1":
-        response = app_client.get(
-            url, query_string={"int": invalid_int}
-        )  # type: flask.Response
+        response = app_client.get(url, params={"int": invalid_int})
         assert response.status_code == 400
 
-    response = app_client.get(url, query_string={"int": "123"})  # type: flask.Response
+    response = app_client.get(url, params={"int": "123"})
     assert response.status_code == 200
 
     for invalid_bool in "", "foo", "yes":
-        response = app_client.get(
-            url, query_string={"bool": invalid_bool}
-        )  # type: flask.Response
+        response = app_client.get(url, params={"bool": invalid_bool})
         assert response.status_code == 400
 
-    response = app_client.get(
-        url, query_string={"bool": "true"}
-    )  # type: flask.Response
+    response = app_client.get(url, params={"bool": "true"})
     assert response.status_code == 200
 
 
@@ -43,7 +35,7 @@ def test_required_query_param(simple_app):
     response = app_client.get(url)
     assert response.status_code == 400
 
-    response = app_client.get(url, query_string={"n": "1.23"})
+    response = app_client.get(url, params={"n": "1.23"})
     assert response.status_code == 200
 
 
@@ -52,38 +44,34 @@ def test_array_query_param(simple_app):
     headers = {"Content-type": "application/json"}
     url = "/v1.0/test_array_csv_query_param"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[str] = json.loads(response.text)
     assert array_response == ["squash", "banana"]
     url = "/v1.0/test_array_csv_query_param?items=one,two,three"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[str] = json.loads(response.text)
     assert array_response == ["one", "two", "three"]
     url = "/v1.0/test_array_pipes_query_param?items=1|2|3"
     response = app_client.get(url, headers=headers)
-    array_response: List[int] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[int] = json.loads(response.text)
     assert array_response == [1, 2, 3]
     url = "/v1.0/test_array_unsupported_query_param?items=1;2;3"
     response = app_client.get(url, headers=headers)
     array_response: List[str] = json.loads(
-        response.data.decode("utf-8", "replace")
+        response.text
     )  # unsupported collectionFormat
     assert array_response == ["1;2;3"]
     url = "/v1.0/test_array_csv_query_param?items=A&items=B&items=C&items=D,E,F"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(
-        response.data.decode("utf-8", "replace")
-    )  # multi array with csv format
+    array_response: List[str] = json.loads(response.text)  # multi array with csv format
     assert array_response == ["D", "E", "F"]
     url = "/v1.0/test_array_multi_query_param?items=A&items=B&items=C&items=D,E,F"
     response = app_client.get(url, headers=headers)
-    array_response: List[str] = json.loads(
-        response.data.decode("utf-8", "replace")
-    )  # multi array with csv format
+    array_response: List[str] = json.loads(response.text)  # multi array with csv format
     assert array_response == ["A", "B", "C", "D", "E", "F"]
     url = "/v1.0/test_array_pipes_query_param?items=4&items=5&items=6&items=7|8|9"
     response = app_client.get(url, headers=headers)
     array_response: List[int] = json.loads(
-        response.data.decode("utf-8", "replace")
+        response.text
     )  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
@@ -93,28 +81,26 @@ def test_array_form_param(simple_app):
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     url = "/v1.0/test_array_csv_form_param"
     response = app_client.post(url, headers=headers)
-    array_response: List[str] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[str] = json.loads(response.text)
     assert array_response == ["squash", "banana"]
     url = "/v1.0/test_array_csv_form_param"
     response = app_client.post(url, headers=headers, data={"items": "one,two,three"})
-    array_response: List[str] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[str] = json.loads(response.text)
     assert array_response == ["one", "two", "three"]
     url = "/v1.0/test_array_pipes_form_param"
     response = app_client.post(url, headers=headers, data={"items": "1|2|3"})
-    array_response: List[int] = json.loads(response.data.decode("utf-8", "replace"))
+    array_response: List[int] = json.loads(response.text)
     assert array_response == [1, 2, 3]
     url = "/v1.0/test_array_csv_form_param"
     data = "items=A&items=B&items=C&items=D,E,F"
     response = app_client.post(url, headers=headers, data=data)
-    array_response: List[str] = json.loads(
-        response.data.decode("utf-8", "replace")
-    )  # multi array with csv format
+    array_response: List[str] = json.loads(response.text)  # multi array with csv format
     assert array_response == ["D", "E", "F"]
     url = "/v1.0/test_array_pipes_form_param"
     data = "items=4&items=5&items=6&items=7|8|9"
     response = app_client.post(url, headers=headers, data=data)
     array_response: List[int] = json.loads(
-        response.data.decode("utf-8", "replace")
+        response.text
     )  # multi array with pipes format
     assert array_response == [7, 8, 9]
 
@@ -133,7 +119,7 @@ def test_strict_extra_query_param(strict_app):
     url = "/v1.0/test_parameter_validation?extra_parameter=true"
     resp = app_client.get(url, headers=headers)
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["detail"] == "Extra query parameter(s) extra_parameter not in spec"
 
 
@@ -142,7 +128,7 @@ def test_strict_formdata_param(strict_app):
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     url = "/v1.0/test_array_csv_form_param"
     resp = app_client.post(url, headers=headers, data={"items": "mango"})
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == ["mango"]
     assert resp.status_code == 200
 
@@ -164,14 +150,14 @@ def test_strict_formdata_param(strict_app):
 def test_path_parameter_someint(simple_app, arg, result):
     assert isinstance(arg, str)  # sanity check
     app_client = simple_app.test_client()
-    resp = app_client.get(f"/v1.0/test-int-path/{arg}")  # type: flask.Response
-    assert resp.data.decode("utf-8", "replace") == f'"{result}"\n'
+    resp = app_client.get(f"/v1.0/test-int-path/{arg}")
+    assert resp.text == f'"{result}"\n'
 
 
 def test_path_parameter_someint__bad(simple_app):
     # non-integer values will not match Flask route
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-int-path/foo")  # type: flask.Response
+    resp = app_client.get("/v1.0/test-int-path/foo")
     assert resp.status_code == 404, resp.text
 
 
@@ -197,14 +183,14 @@ def test_path_parameter_someint__bad(simple_app):
 def test_path_parameter_somefloat(simple_app, arg, result):
     assert isinstance(arg, str)  # sanity check
     app_client = simple_app.test_client()
-    resp = app_client.get(f"/v1.0/test-float-path/{arg}")  # type: flask.Response
-    assert resp.data.decode("utf-8", "replace") == f'"{result}"\n'
+    resp = app_client.get(f"/v1.0/test-float-path/{arg}")
+    assert resp.text == f'"{result}"\n'
 
 
 def test_path_parameter_somefloat__bad(simple_app):
     # non-float values will not match Flask route
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-float-path/123,45")  # type: flask.Response
+    resp = app_client.get("/v1.0/test-float-path/123,45")
     assert resp.status_code == 404, resp.text
 
 
@@ -212,20 +198,20 @@ def test_default_param(strict_app):
     app_client = strict_app.test_client()
     resp = app_client.get("/v1.0/test-default-query-parameter")
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["app_name"] == "connexion"
 
 
 def test_falsy_param(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-falsy-param", query_string={"falsy": 0})
+    resp = app_client.get("/v1.0/test-falsy-param", params={"falsy": 0})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == 0
 
     resp = app_client.get("/v1.0/test-falsy-param")
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == 1
 
 
@@ -233,7 +219,7 @@ def test_formdata_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-param", data={"formData": "test"})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == "test"
 
 
@@ -241,7 +227,7 @@ def test_formdata_bad_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-param")
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["detail"] in [
         "Missing formdata parameter 'formData'",
         "'formData' is a required property",  # OAS3
@@ -270,7 +256,7 @@ def test_strict_formdata_extra_param(strict_app):
         "/v1.0/test-formData-param", data={"formData": "test", "extra_formData": "test"}
     )
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert (
         response["detail"] == "Extra formData parameter(s) extra_formData not in spec"
     )
@@ -281,9 +267,10 @@ def test_formdata_file_upload(simple_app):
     resp = app_client.post(
         "/v1.0/test-formData-file-upload",
         data={"fileData": (BytesIO(b"file contents"), "filename.txt")},
+        headers={"content-type": "multipart/form-data"},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == {"filename.txt": "file contents"}
 
 
@@ -291,7 +278,7 @@ def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-file-upload")
     assert resp.status_code == 400
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["detail"] in [
         "Missing formdata parameter 'fileData'",
         "'fileData' is a required property",  # OAS3
@@ -303,8 +290,9 @@ def test_formdata_file_upload_missing_param(simple_app):
     resp = app_client.post(
         "/v1.0/test-formData-file-upload-missing-param",
         data={"missing_fileData": (BytesIO(b"file contents"), "example.txt")},
+        headers={"content-type": "multipart/form-data"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
 
 
 def test_body_not_allowed_additional_properties(simple_app):
@@ -317,7 +305,7 @@ def test_body_not_allowed_additional_properties(simple_app):
     )
     assert resp.status_code == 400
 
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert "Additional properties are not allowed" in response["detail"]
 
 
@@ -326,22 +314,22 @@ def test_bool_as_default_param(simple_app):
     resp = app_client.get("/v1.0/test-bool-param")
     assert resp.status_code == 200
 
-    resp = app_client.get("/v1.0/test-bool-param", query_string={"thruthiness": True})
+    resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response is True
 
 
 def test_bool_param(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-bool-param", query_string={"thruthiness": True})
+    resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": True})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response is True
 
-    resp = app_client.get("/v1.0/test-bool-param", query_string={"thruthiness": False})
+    resp = app_client.get("/v1.0/test-bool-param", params={"thruthiness": False})
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response is False
 
 
@@ -349,13 +337,13 @@ def test_bool_array_param(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-bool-array-param?thruthiness=true,true,true")
     assert resp.status_code == 200, resp.text
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response is True
 
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-bool-array-param?thruthiness=true,true,false")
     assert resp.status_code == 200, resp.text
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response is False
 
     app_client = simple_app.test_client()
@@ -369,7 +357,7 @@ def test_required_param_miss_config(simple_app):
     resp = app_client.get("/v1.0/test-required-param")
     assert resp.status_code == 400
 
-    resp = app_client.get("/v1.0/test-required-param", query_string={"simple": "test"})
+    resp = app_client.get("/v1.0/test-required-param", params={"simple": "test"})
     assert resp.status_code == 200
 
     resp = app_client.get("/v1.0/test-required-param")
@@ -380,7 +368,7 @@ def test_parameters_defined_in_path_level(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/parameters-in-root-path?title=nice-get")
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == ["nice-get"]
+    assert json.loads(resp.text) == ["nice-get"]
 
     resp = app_client.get("/v1.0/parameters-in-root-path")
     assert resp.status_code == 400
@@ -389,10 +377,10 @@ def test_parameters_defined_in_path_level(simple_app):
 def test_array_in_path(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/test-array-in-path/one_item")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == ["one_item"]
+    assert json.loads(resp.text) == ["one_item"]
 
     resp = app_client.get("/v1.0/test-array-in-path/one_item,another_item")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == [
+    assert json.loads(resp.text) == [
         "one_item",
         "another_item",
     ]
@@ -401,43 +389,43 @@ def test_array_in_path(simple_app):
 def test_nullable_parameter(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/nullable-parameters?time_start=null")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     resp = app_client.get("/v1.0/nullable-parameters?time_start=None")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     time_start = 1010
     resp = app_client.get(f"/v1.0/nullable-parameters?time_start={time_start}")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == time_start
+    assert json.loads(resp.text) == time_start
 
     resp = app_client.post("/v1.0/nullable-parameters", data={"post_param": "None"})
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     resp = app_client.post("/v1.0/nullable-parameters", data={"post_param": "null"})
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     headers = {"Content-Type": "application/json"}
     resp = app_client.put("/v1.0/nullable-parameters", data="null", headers=headers)
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     resp = app_client.put("/v1.0/nullable-parameters", data="None", headers=headers)
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "it was None"
+    assert json.loads(resp.text) == "it was None"
 
     resp = app_client.put(
         "/v1.0/nullable-parameters-noargs", data="None", headers=headers
     )
-    assert json.loads(resp.data.decode("utf-8", "replace")) == "hello"
+    assert json.loads(resp.text) == "hello"
 
 
 def test_args_kwargs(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/query-params-as-kwargs")
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == {}
+    assert json.loads(resp.text) == {}
 
     resp = app_client.get("/v1.0/query-params-as-kwargs?foo=a&bar=b")
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == {"foo": "a"}
+    assert json.loads(resp.text) == {"foo": "a"}
 
     if simple_app._spec_file == "openapi.yaml":
         body = {"foo": "a", "bar": "b"}
@@ -448,7 +436,7 @@ def test_args_kwargs(simple_app):
         )
         assert resp.status_code == 200
         # having only kwargs, the handler would have been passed 'body'
-        assert json.loads(resp.data.decode("utf-8", "replace")) == {
+        assert json.loads(resp.text) == {
             "body": {"foo": "a", "bar": "b"},
         }
 
@@ -457,13 +445,13 @@ def test_param_sanitization(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/param-sanitization")
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == {}
+    assert json.loads(resp.text) == {}
 
     resp = app_client.post(
         "/v1.0/param-sanitization?$query=queryString", data={"$form": "formString"}
     )
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == {
+    assert json.loads(resp.text) == {
         "query": "queryString",
         "form": "formString",
     }
@@ -475,7 +463,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == body
+    assert json.loads(resp.text) == body
 
     body = {"body1": "bodyString", "body2": 12, "body3": {"a": "otherString"}}
     resp = app_client.post(
@@ -484,7 +472,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == body
+    assert json.loads(resp.text) == body
 
     body = {
         "body1": "bodyString",
@@ -497,7 +485,7 @@ def test_param_sanitization(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8", "replace")) == body
+    assert json.loads(resp.text) == body
 
 
 def test_no_sanitization_in_request_body(simple_app):
@@ -514,7 +502,7 @@ def test_no_sanitization_in_request_body(simple_app):
     response = app_client.post("/v1.0/forward", json=data)
 
     assert response.status_code == 200
-    assert response.json == data
+    assert json.loads(response.text) == data
 
 
 def test_parameters_snake_case(snake_case_app):
@@ -558,19 +546,25 @@ def test_parameters_snake_case(snake_case_app):
         "/v1.0/test-get-camel-case-version?truthiness=true&orderBy=asc"
     )
     assert resp.status_code == 200, resp.text
-    assert resp.get_json() == {"truthiness": True, "order_by": "asc"}
+    assert json.loads(resp.text) == {"truthiness": True, "order_by": "asc"}
     resp = app_client.get("/v1.0/test-get-camel-case-version?truthiness=5")
     assert resp.status_code == 400
-    assert resp.get_json()["detail"].startswith("'5' is not of type 'boolean'")
+    assert json.loads(resp.text)["detail"].startswith("'5' is not of type 'boolean'")
     # Incorrectly cased params should be ignored
     resp = app_client.get(
         "/v1.0/test-get-camel-case-version?Truthiness=true&order_by=asc"
     )
     assert resp.status_code == 200
-    assert resp.get_json() == {"truthiness": False, "order_by": None}  # default values
+    assert json.loads(resp.text) == {
+        "truthiness": False,
+        "order_by": None,
+    }  # default values
     resp = app_client.get("/v1.0/test-get-camel-case-version?Truthiness=5&order_by=4")
     assert resp.status_code == 200
-    assert resp.get_json() == {"truthiness": False, "order_by": None}  # default values
+    assert json.loads(resp.text) == {
+        "truthiness": False,
+        "order_by": None,
+    }  # default values
     # TODO: Add tests for body parameters
 
 
@@ -579,12 +573,15 @@ def test_get_unicode_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_unicode_request?price=%C2%A319.99")  # £19.99
     assert resp.status_code == 200
-    assert json.loads(resp.data.decode("utf-8"))["price"] == "£19.99"
+    assert json.loads(resp.text)["price"] == "£19.99"
 
 
 def test_cookie_param(simple_app):
-    app_client = simple_app.test_client()
-    app_client.set_cookie("localhost", "test_cookie", "hello")
+    try:
+        app_client = simple_app.test_client(cookies={"test_cookie": "hello"})
+    except TypeError:
+        app_client = simple_app.test_client()
+        app_client.set_cookie("localhost", "test_cookie", "hello")
     response = app_client.get("/v1.0/test-cookie-param")
     assert response.status_code == 200
     assert response.json == {"cookie_value": "hello"}

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -9,43 +9,39 @@ def test_app(simple_app):
     app_client = simple_app.test_client()
 
     # by default the Swagger UI is enabled
-    swagger_ui = app_client.get("/v1.0/ui/")  # type: flask.Response
+    swagger_ui = app_client.get("/v1.0/ui/")
     assert swagger_ui.status_code == 200
-    assert b"Swagger UI" in swagger_ui.data
+    assert "Swagger UI" in swagger_ui.text
 
     # test return Swagger UI static files
-    swagger_icon = app_client.get("/v1.0/ui/swagger-ui.js")  # type: flask.Response
+    swagger_icon = app_client.get("/v1.0/ui/swagger-ui.js")
     assert swagger_icon.status_code == 200
 
     post_greeting_url = app_client.post(
         "/v1.0/greeting/jsantos/the/third/of/his/name", data={}
-    )  # type: flask.Response
+    )
     assert post_greeting_url.status_code == 200
-    assert post_greeting_url.content_type == "application/json"
-    greeting_response_url = json.loads(post_greeting_url.data.decode("utf-8"))
+    assert post_greeting_url.headers.get("content-type") == "application/json"
+    greeting_response_url = json.loads(post_greeting_url.text)
     assert (
         greeting_response_url["greeting"]
         == "Hello jsantos thanks for the/third/of/his/name"
     )
 
-    post_greeting = app_client.post(
-        "/v1.0/greeting/jsantos", data={}
-    )  # type: flask.Response
+    post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
     assert post_greeting.status_code == 200
-    assert post_greeting.content_type == "application/json"
-    greeting_response = json.loads(post_greeting.data.decode("utf-8"))
+    assert post_greeting.headers.get("content-type") == "application/json"
+    greeting_response = json.loads(post_greeting.text)
     assert greeting_response["greeting"] == "Hello jsantos"
 
-    get_bye = app_client.get("/v1.0/bye/jsantos")  # type: flask.Response
+    get_bye = app_client.get("/v1.0/bye/jsantos")
     assert get_bye.status_code == 200
-    assert get_bye.data == b"Goodbye jsantos"
+    assert get_bye.text == "Goodbye jsantos"
 
-    post_greeting = app_client.post(
-        "/v1.0/greeting/jsantos", data={}
-    )  # type: flask.Response
+    post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
     assert post_greeting.status_code == 200
-    assert post_greeting.content_type == "application/json"
-    greeting_response = json.loads(post_greeting.data.decode("utf-8"))
+    assert post_greeting.headers.get("content-type") == "application/json"
+    greeting_response = json.loads(post_greeting.text)
     assert greeting_response["greeting"] == "Hello jsantos"
 
 
@@ -65,15 +61,15 @@ def test_openapi_yaml_behind_proxy(reverse_proxied_app):
     )
     assert openapi_yaml.status_code == 200
     assert openapi_yaml.headers.get("Content-Type").startswith("text/yaml")
-    spec = yaml.load(openapi_yaml.data.decode("utf-8"), Loader=yaml.BaseLoader)
+    spec = yaml.load(openapi_yaml.text, Loader=yaml.BaseLoader)
 
     if reverse_proxied_app._spec_file == "swagger.yaml":
-        assert b'url: "/behind/proxy/v1.0/swagger.json"' in swagger_ui.data
+        assert 'url: "/behind/proxy/v1.0/swagger.json"' in swagger_ui.text
         assert (
             spec.get("basePath") == "/behind/proxy/v1.0"
         ), "basePath should contains original URI"
     else:
-        assert b'url: "/behind/proxy/v1.0/openapi.json"' in swagger_ui.data
+        assert 'url: "/behind/proxy/v1.0/openapi.json"' in swagger_ui.text
         url = spec.get("servers", [{}])[0].get("url")
         assert url == "/behind/proxy/v1.0", "basePath should contains original URI"
 
@@ -81,47 +77,42 @@ def test_openapi_yaml_behind_proxy(reverse_proxied_app):
 def test_produce_decorator(simple_app):
     app_client = simple_app.test_client()
 
-    get_bye = app_client.get("/v1.0/bye/jsantos")  # type: flask.Response
-    assert get_bye.content_type == "text/plain; charset=utf-8"
+    get_bye = app_client.get("/v1.0/bye/jsantos")
+    assert get_bye.headers.get("content-type") == "text/plain; charset=utf-8"
 
 
+# TODO: make flask specific
 def test_returning_flask_response_tuple(simple_app):
     app_client = simple_app.test_client()
 
-    result = app_client.get("/v1.0/flask_response_tuple")  # type: flask.Response
+    result = app_client.get("/v1.0/flask_response_tuple")
     assert result.status_code == 201, result.text
-    assert result.content_type == "application/json"
-    result_data = json.loads(result.data.decode("utf-8", "replace"))
+    assert result.headers.get("content-type") == "application/json"
+    result_data = json.loads(result.text)
     assert result_data == {"foo": "bar"}
 
 
 def test_jsonifier(simple_app):
     app_client = simple_app.test_client()
 
-    post_greeting = app_client.post(
-        "/v1.0/greeting/jsantos", data={}
-    )  # type: flask.Response
+    post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
     assert post_greeting.status_code == 200
-    assert post_greeting.content_type == "application/json"
-    greeting_reponse = json.loads(post_greeting.data.decode("utf-8", "replace"))
+    assert post_greeting.headers.get("content-type") == "application/json"
+    greeting_reponse = json.loads(post_greeting.text)
     assert greeting_reponse["greeting"] == "Hello jsantos"
 
-    get_list_greeting = app_client.get(
-        "/v1.0/list/jsantos", data={}
-    )  # type: flask.Response
+    get_list_greeting = app_client.get("/v1.0/list/jsantos", data={})
     assert get_list_greeting.status_code == 200
-    assert get_list_greeting.content_type == "application/json"
-    greeting_reponse = json.loads(get_list_greeting.data.decode("utf-8", "replace"))
+    assert get_list_greeting.headers.get("content-type") == "application/json"
+    greeting_reponse = json.loads(get_list_greeting.text)
     assert len(greeting_reponse) == 2
     assert greeting_reponse[0] == "hello"
     assert greeting_reponse[1] == "jsantos"
 
-    get_greetings = app_client.get(
-        "/v1.0/greetings/jsantos", data={}
-    )  # type: flask.Response
+    get_greetings = app_client.get("/v1.0/greetings/jsantos", data={})
     assert get_greetings.status_code == 200
-    assert get_greetings.content_type == "application/x.connexion+json"
-    greetings_reponse = json.loads(get_greetings.data.decode("utf-8", "replace"))
+    assert get_greetings.headers.get("content-type") == "application/x.connexion+json"
+    greetings_reponse = json.loads(get_greetings.text)
     assert len(greetings_reponse) == 1
     assert greetings_reponse["greetings"] == "Hello jsantos"
 
@@ -131,16 +122,17 @@ def test_not_content_response(simple_app):
 
     get_no_content_response = app_client.get("/v1.0/test_no_content_response")
     assert get_no_content_response.status_code == 204
-    assert get_no_content_response.content_length is None
+    assert get_no_content_response.headers.get("content-length") is None
 
 
 def test_pass_through(simple_app):
     app_client = simple_app.test_client()
 
-    response = app_client.get("/v1.0/multimime", data={})  # type: flask.Response
+    response = app_client.get("/v1.0/multimime", data={})
     assert response.status_code == 500
+    detail = json.loads(response.text)["detail"]
     assert (
-        response.json["detail"] == "Multiple response content types are defined in the "
+        detail == "Multiple response content types are defined in the "
         "operation spec, but the handler response did not specify "
         "which one to return."
     )
@@ -149,19 +141,17 @@ def test_pass_through(simple_app):
 def test_empty(simple_app):
     app_client = simple_app.test_client()
 
-    response = app_client.get("/v1.0/empty")  # type: flask.Response
+    response = app_client.get("/v1.0/empty")
     assert response.status_code == 204
-    assert not response.data
+    assert not response.text
 
 
 def test_exploded_deep_object_param_endpoint_openapi_simple(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
 
-    response = app_client.get(
-        "/v1.0/exploded-deep-object-param?id[foo]=bar"
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/exploded-deep-object-param?id[foo]=bar")
     assert response.status_code == 200
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data == {"foo": "bar", "foo4": "blubb"}
 
 
@@ -172,9 +162,9 @@ def test_exploded_deep_object_param_endpoint_openapi_multiple_data_types(
 
     response = app_client.get(
         "/v1.0/exploded-deep-object-param?id[foo]=bar&id[fooint]=2&id[fooboo]=false"
-    )  # type: flask.Response
+    )
     assert response.status_code == 200, response.text
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data == {
         "foo": "bar",
         "fooint": 2,
@@ -190,9 +180,9 @@ def test_exploded_deep_object_param_endpoint_openapi_additional_properties(
 
     response = app_client.get(
         "/v1.0/exploded-deep-object-param-additional-properties?id[foo]=bar&id[fooint]=2"
-    )  # type: flask.Response
+    )
     assert response.status_code == 200
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data == {"foo": "bar", "fooint": "2"}
 
 
@@ -203,7 +193,7 @@ def test_exploded_deep_object_param_endpoint_openapi_additional_properties_false
 
     response = app_client.get(
         "/v1.0/exploded-deep-object-param?id[foo]=bar&id[foofoo]=barbar"
-    )  # type: flask.Response
+    )
     assert response.status_code == 400
 
 
@@ -212,9 +202,9 @@ def test_exploded_deep_object_param_endpoint_openapi_with_dots(simple_openapi_ap
 
     response = app_client.get(
         "/v1.0/exploded-deep-object-param-additional-properties?id[foo]=bar&id[foo.foo]=barbar"
-    )  # type: flask.Response
+    )
     assert response.status_code == 200
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data == {"foo": "bar", "foo.foo": "barbar"}
 
 
@@ -223,9 +213,9 @@ def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
 
     response = app_client.get(
         "/v1.0/nested-exploded-deep-object-param?id[foo][foo2]=bar&id[foofoo]=barbar"
-    )  # type: flask.Response
+    )
     assert response.status_code == 200
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data == {
         "foo": {"foo2": "bar", "foo3": "blubb"},
         "foofoo": "barbar",
@@ -248,12 +238,12 @@ def test_default_object_body(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-default-object-body")
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["stack"] == {"image_version": "default_image"}
 
     resp = app_client.post("/v1.0/test-default-integer-body")
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == 1
 
 
@@ -265,7 +255,7 @@ def test_empty_object_body(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["stack"] == {}
 
 
@@ -277,10 +267,11 @@ def test_nested_additional_properties(simple_openapi_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response == {"nested": {"object": True}}
 
 
+# TODO: make Flask specific
 def test_custom_provider(simple_app):
     class CustomProvider(FlaskJSONProvider):
         def default(self, o):
@@ -294,7 +285,7 @@ def test_custom_provider(simple_app):
 
     resp = app_client.get("/v1.0/custom-json-response")
     assert resp.status_code == 200
-    response = json.loads(resp.data.decode("utf-8", "replace"))
+    response = json.loads(resp.text)
     assert response["theResult"] == "cool result"
 
 
@@ -304,8 +295,15 @@ def test_content_type_not_json(simple_app):
     resp = app_client.get("/v1.0/blob-response")
     assert resp.status_code == 200
 
+    try:
+        # AsyncApp
+        content = resp.content
+    except AttributeError:
+        # FlaskApp
+        content = resp.data
+
     # validate binary content
-    text, number = unpack("!4sh", resp.data)
+    text, number = unpack("!4sh", content)
     assert text == b"cool"
     assert number == 8
 
@@ -315,9 +313,17 @@ def test_maybe_blob_or_json(simple_app):
 
     resp = app_client.get("/v1.0/binary-response")
     assert resp.status_code == 200
-    assert resp.content_type == "application/octet-stream"
+    assert resp.headers.get("content-type") == "application/octet-stream"
+
+    try:
+        # AsyncApp
+        content = resp.content
+    except AttributeError:
+        # FlaskApp
+        content = resp.data
+
     # validate binary content
-    text, number = unpack("!4sh", resp.data)
+    text, number = unpack("!4sh", content)
     assert text == b"cool"
     assert number == 8
 
@@ -353,21 +359,21 @@ def test_post_wrong_content_type(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
-        content_type="application/xml",
+        headers={"content-type": "application/xml"},
         data=json.dumps({"some": "data"}),
     )
     assert resp.status_code == 415
 
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
-        content_type="application/x-www-form-urlencoded",
+        headers={"content-type": "application/x-www-form-urlencoded"},
         data="a=1&b=2",
     )
     assert resp.status_code == 415
 
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
-        content_type="application/json",
+        headers={"content-type": "application/json"},
         data="not a valid json",
     )
     assert (
@@ -379,7 +385,7 @@ def test_get_unicode_response(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_unicode_response")
     actualJson = {"currency": "\xa3", "key": "leena"}
-    assert json.loads(resp.data.decode("utf-8", "replace")) == actualJson
+    assert json.loads(resp.text) == actualJson
 
 
 def test_get_enum_response(simple_app):
@@ -403,6 +409,7 @@ def test_get_bad_default_response(simple_app):
     assert resp.status_code == 500
 
 
+# TODO: split per app
 def test_streaming_response(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_streaming_response")
@@ -412,29 +419,31 @@ def test_streaming_response(simple_app):
 def test_oneof(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
 
-    post_greeting = app_client.post(  # type: flask.Response
+    headers = {"Content-type": "application/json"}
+
+    post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
         data=json.dumps({"name": 3}),
-        content_type="application/json",
+        headers=headers,
     )
     assert post_greeting.status_code == 200
-    assert post_greeting.content_type == "application/json"
-    greeting_reponse = json.loads(post_greeting.data.decode("utf-8", "replace"))
+    assert post_greeting.headers.get("content-type") == "application/json"
+    greeting_reponse = json.loads(post_greeting.text)
     assert greeting_reponse["greeting"] == "Hello 3"
 
-    post_greeting = app_client.post(  # type: flask.Response
+    post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
         data=json.dumps({"name": True}),
-        content_type="application/json",
+        headers=headers,
     )
     assert post_greeting.status_code == 200
-    assert post_greeting.content_type == "application/json"
-    greeting_reponse = json.loads(post_greeting.data.decode("utf-8", "replace"))
+    assert post_greeting.headers.get("content-type") == "application/json"
+    greeting_reponse = json.loads(post_greeting.text)
     assert greeting_reponse["greeting"] == "Hello True"
 
-    post_greeting = app_client.post(  # type: flask.Response
+    post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
         data=json.dumps({"name": "jsantos"}),
-        content_type="application/json",
+        headers=headers,
     )
     assert post_greeting.status_code == 400

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -240,12 +240,16 @@ def test_redirect_response_endpoint(simple_app):
 
 def test_default_object_body(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.post("/v1.0/test-default-object-body")
+    resp = app_client.post(
+        "/v1.0/test-default-object-body", headers={"content-type": "application/json"}
+    )
     assert resp.status_code == 200
     response = resp.json()
     assert response["stack"] == {"image_version": "default_image"}
 
-    resp = app_client.post("/v1.0/test-default-integer-body")
+    resp = app_client.post(
+        "/v1.0/test-default-integer-body", headers={"content-type": "application/json"}
+    )
     assert resp.status_code == 200
     response = resp.json()
     assert response == 1

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -259,8 +259,7 @@ def test_empty_object_body(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post(
         "/v1.0/test-empty-object-body",
-        data=json.dumps({}),
-        headers={"Content-Type": "application/json"},
+        json={},
     )
     assert resp.status_code == 200
     response = resp.json()
@@ -271,7 +270,7 @@ def test_nested_additional_properties(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
     resp = app_client.post(
         "/v1.0/test-nested-additional-properties",
-        data=json.dumps({"nested": {"object": True}}),
+        json={"nested": {"object": True}},
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
@@ -356,7 +355,7 @@ def test_bad_operations(bad_operations_app):
 def test_text_request(simple_app):
     app_client = simple_app.test_client()
 
-    resp = app_client.post("/v1.0/text-request", data="text")
+    resp = app_client.post("/v1.0/text-request", content="text")
     assert resp.status_code == 200
 
 
@@ -371,21 +370,21 @@ def test_post_wrong_content_type(simple_app):
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
         headers={"content-type": "application/xml"},
-        data=json.dumps({"some": "data"}),
+        json={"some": "data"},
     )
     assert resp.status_code == 415
 
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
         headers={"content-type": "application/x-www-form-urlencoded"},
-        data="a=1&b=2",
+        content="a=1&b=2",
     )
     assert resp.status_code == 415
 
     resp = app_client.post(
         "/v1.0/post_wrong_content_type",
         headers={"content-type": "application/json"},
-        data="not a valid json",
+        content="not a valid json",
     )
     assert (
         resp.status_code == 400
@@ -429,12 +428,9 @@ def test_streaming_response(simple_app):
 def test_oneof(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
 
-    headers = {"Content-type": "application/json"}
-
     post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
-        data=json.dumps({"name": 3}),
-        headers=headers,
+        json={"name": 3},
     )
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
@@ -443,8 +439,7 @@ def test_oneof(simple_openapi_app):
 
     post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
-        data=json.dumps({"name": True}),
-        headers=headers,
+        json={"name": True},
     )
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
@@ -453,7 +448,6 @@ def test_oneof(simple_openapi_app):
 
     post_greeting = app_client.post(
         "/v1.0/oneof_greeting",
-        data=json.dumps({"name": "jsantos"}),
-        headers=headers,
+        json={"name": "jsantos"},
     )
     assert post_greeting.status_code == 400

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -22,7 +22,7 @@ def test_app(simple_app):
     )
     assert post_greeting_url.status_code == 200
     assert post_greeting_url.headers.get("content-type") == "application/json"
-    greeting_response_url = json.loads(post_greeting_url.text)
+    greeting_response_url = post_greeting_url.json()
     assert (
         greeting_response_url["greeting"]
         == "Hello jsantos thanks for the/third/of/his/name"
@@ -31,7 +31,7 @@ def test_app(simple_app):
     post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
-    greeting_response = json.loads(post_greeting.text)
+    greeting_response = post_greeting.json()
     assert greeting_response["greeting"] == "Hello jsantos"
 
     get_bye = app_client.get("/v1.0/bye/jsantos")
@@ -41,7 +41,7 @@ def test_app(simple_app):
     post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
-    greeting_response = json.loads(post_greeting.text)
+    greeting_response = post_greeting.json()
     assert greeting_response["greeting"] == "Hello jsantos"
 
 
@@ -88,31 +88,31 @@ def test_returning_flask_response_tuple(simple_app):
     result = app_client.get("/v1.0/flask_response_tuple")
     assert result.status_code == 201, result.text
     assert result.headers.get("content-type") == "application/json"
-    result_data = json.loads(result.text)
+    result_data = result.json()
     assert result_data == {"foo": "bar"}
 
 
 def test_jsonifier(simple_app):
     app_client = simple_app.test_client()
 
-    post_greeting = app_client.post("/v1.0/greeting/jsantos", data={})
+    post_greeting = app_client.post("/v1.0/greeting/jsantos")
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
-    greeting_reponse = json.loads(post_greeting.text)
+    greeting_reponse = post_greeting.json()
     assert greeting_reponse["greeting"] == "Hello jsantos"
 
-    get_list_greeting = app_client.get("/v1.0/list/jsantos", data={})
+    get_list_greeting = app_client.get("/v1.0/list/jsantos")
     assert get_list_greeting.status_code == 200
     assert get_list_greeting.headers.get("content-type") == "application/json"
-    greeting_reponse = json.loads(get_list_greeting.text)
+    greeting_reponse = get_list_greeting.json()
     assert len(greeting_reponse) == 2
     assert greeting_reponse[0] == "hello"
     assert greeting_reponse[1] == "jsantos"
 
-    get_greetings = app_client.get("/v1.0/greetings/jsantos", data={})
+    get_greetings = app_client.get("/v1.0/greetings/jsantos")
     assert get_greetings.status_code == 200
     assert get_greetings.headers.get("content-type") == "application/x.connexion+json"
-    greetings_reponse = json.loads(get_greetings.text)
+    greetings_reponse = get_greetings.json()
     assert len(greetings_reponse) == 1
     assert greetings_reponse["greetings"] == "Hello jsantos"
 
@@ -128,9 +128,9 @@ def test_not_content_response(simple_app):
 def test_pass_through(simple_app):
     app_client = simple_app.test_client()
 
-    response = app_client.get("/v1.0/multimime", data={})
+    response = app_client.get("/v1.0/multimime")
     assert response.status_code == 500
-    detail = json.loads(response.text)["detail"]
+    detail = response.json()["detail"]
     assert (
         detail == "Multiple response content types are defined in the "
         "operation spec, but the handler response did not specify "
@@ -151,7 +151,7 @@ def test_exploded_deep_object_param_endpoint_openapi_simple(simple_openapi_app):
 
     response = app_client.get("/v1.0/exploded-deep-object-param?id[foo]=bar")
     assert response.status_code == 200
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data == {"foo": "bar", "foo4": "blubb"}
 
 
@@ -164,7 +164,7 @@ def test_exploded_deep_object_param_endpoint_openapi_multiple_data_types(
         "/v1.0/exploded-deep-object-param?id[foo]=bar&id[fooint]=2&id[fooboo]=false"
     )
     assert response.status_code == 200, response.text
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data == {
         "foo": "bar",
         "fooint": 2,
@@ -182,7 +182,7 @@ def test_exploded_deep_object_param_endpoint_openapi_additional_properties(
         "/v1.0/exploded-deep-object-param-additional-properties?id[foo]=bar&id[fooint]=2"
     )
     assert response.status_code == 200
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data == {"foo": "bar", "fooint": "2"}
 
 
@@ -204,7 +204,7 @@ def test_exploded_deep_object_param_endpoint_openapi_with_dots(simple_openapi_ap
         "/v1.0/exploded-deep-object-param-additional-properties?id[foo]=bar&id[foo.foo]=barbar"
     )
     assert response.status_code == 200
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data == {"foo": "bar", "foo.foo": "barbar"}
 
 
@@ -215,7 +215,7 @@ def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
         "/v1.0/nested-exploded-deep-object-param?id[foo][foo2]=bar&id[foofoo]=barbar"
     )
     assert response.status_code == 200
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data == {
         "foo": {"foo2": "bar", "foo3": "blubb"},
         "foofoo": "barbar",
@@ -224,13 +224,15 @@ def test_nested_exploded_deep_object_param_endpoint_openapi(simple_openapi_app):
 
 def test_redirect_endpoint(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-redirect-endpoint")
+    resp = app_client.get("/v1.0/test-redirect-endpoint", follow_redirects=False)
     assert resp.status_code == 302
 
 
 def test_redirect_response_endpoint(simple_app):
     app_client = simple_app.test_client()
-    resp = app_client.get("/v1.0/test-redirect-response-endpoint")
+    resp = app_client.get(
+        "/v1.0/test-redirect-response-endpoint", follow_redirects=False
+    )
     assert resp.status_code == 302
 
 
@@ -238,12 +240,12 @@ def test_default_object_body(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-default-object-body")
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["stack"] == {"image_version": "default_image"}
 
     resp = app_client.post("/v1.0/test-default-integer-body")
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == 1
 
 
@@ -255,7 +257,7 @@ def test_empty_object_body(simple_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["stack"] == {}
 
 
@@ -267,7 +269,7 @@ def test_nested_additional_properties(simple_openapi_app):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response == {"nested": {"object": True}}
 
 
@@ -281,11 +283,11 @@ def test_custom_provider(simple_app):
 
     flask_app = simple_app.app
     flask_app.json = CustomProvider(flask_app)
-    app_client = flask_app.test_client()
+    app_client = simple_app.test_client()
 
     resp = app_client.get("/v1.0/custom-json-response")
     assert resp.status_code == 200
-    response = json.loads(resp.text)
+    response = resp.json()
     assert response["theResult"] == "cool result"
 
 
@@ -385,7 +387,7 @@ def test_get_unicode_response(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_unicode_response")
     actualJson = {"currency": "\xa3", "key": "leena"}
-    assert json.loads(resp.text) == actualJson
+    assert resp.json() == actualJson
 
 
 def test_get_enum_response(simple_app):
@@ -428,7 +430,7 @@ def test_oneof(simple_openapi_app):
     )
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
-    greeting_reponse = json.loads(post_greeting.text)
+    greeting_reponse = post_greeting.json()
     assert greeting_reponse["greeting"] == "Hello 3"
 
     post_greeting = app_client.post(
@@ -438,7 +440,7 @@ def test_oneof(simple_openapi_app):
     )
     assert post_greeting.status_code == 200
     assert post_greeting.headers.get("content-type") == "application/json"
-    greeting_reponse = json.loads(post_greeting.text)
+    greeting_reponse = post_greeting.json()
     assert greeting_reponse["greeting"] == "Hello True"
 
     post_greeting = app_client.post(

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -7,12 +7,10 @@ def test_schema(schema_app):
 
     empty_request = app_client.post(
         "/v1.0/test_schema", headers=headers, data=json.dumps({})
-    )  # type: flask.Response
+    )
     assert empty_request.status_code == 400
-    assert empty_request.content_type == "application/problem+json"
-    empty_request_response = json.loads(
-        empty_request.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert empty_request.headers.get("content-type") == "application/problem+json"
+    empty_request_response = json.loads(empty_request.text)
     assert empty_request_response["title"] == "Bad Request"
     assert empty_request_response["detail"].startswith(
         "'image_version' is a required property"
@@ -20,23 +18,19 @@ def test_schema(schema_app):
 
     bad_type = app_client.post(
         "/v1.0/test_schema", headers=headers, data=json.dumps({"image_version": 22})
-    )  # type: flask.Response
+    )
     assert bad_type.status_code == 400
-    assert bad_type.content_type == "application/problem+json"
-    bad_type_response = json.loads(
-        bad_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert bad_type.headers.get("content-type") == "application/problem+json"
+    bad_type_response = json.loads(bad_type.text)
     assert bad_type_response["title"] == "Bad Request"
     assert bad_type_response["detail"].startswith("22 is not of type 'string'")
 
     bad_type_path = app_client.post(
         "/v1.0/test_schema", headers=headers, data=json.dumps({"image_version": 22})
-    )  # type: flask.Response
+    )
     assert bad_type_path.status_code == 400
-    assert bad_type_path.content_type == "application/problem+json"
-    bad_type_path_response = json.loads(
-        bad_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert bad_type_path.headers.get("content-type") == "application/problem+json"
+    bad_type_path_response = json.loads(bad_type.text)
     assert bad_type_path_response["title"] == "Bad Request"
     assert bad_type_path_response["detail"].endswith(" - 'image_version'")
 
@@ -44,32 +38,26 @@ def test_schema(schema_app):
         "/v1.0/test_schema",
         headers=headers,
         data=json.dumps({"image_version": "version"}),
-    )  # type: flask.Response
+    )
     assert good_request.status_code == 200
-    good_request_response = json.loads(
-        good_request.data.decode("utf-8", "replace")
-    )  # type: dict
+    good_request_response = json.loads(good_request.text)
     assert good_request_response["image_version"] == "version"
 
     good_request_extra = app_client.post(
         "/v1.0/test_schema",
         headers=headers,
         data=json.dumps({"image_version": "version", "extra": "stuff"}),
-    )  # type: flask.Response
+    )
     assert good_request_extra.status_code == 200
-    good_request_extra_response = json.loads(
-        good_request.data.decode("utf-8", "replace")
-    )  # type: dict
+    good_request_extra_response = json.loads(good_request.text)
     assert good_request_extra_response["image_version"] == "version"
 
     wrong_type = app_client.post(
         "/v1.0/test_schema", headers=headers, data=json.dumps(42)
-    )  # type: flask.Response
+    )
     assert wrong_type.status_code == 400
-    assert wrong_type.content_type == "application/problem+json"
-    wrong_type_response = json.loads(
-        wrong_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_type.headers.get("content-type") == "application/problem+json"
+    wrong_type_response = json.loads(wrong_type.text)
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
@@ -79,59 +67,59 @@ def test_schema_response(schema_app):
 
     request = app_client.get(
         "/v1.0/test_schema/response/object/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/object/invalid_type", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/object/invalid_requirements", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/string/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/string/invalid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/integer/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/integer/invalid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/number/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/number/invalid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/boolean/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/boolean/invalid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/array/valid", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 200, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/array/invalid_dict", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
     request = app_client.get(
         "/v1.0/test_schema/response/array/invalid_string", headers={}, data=None
-    )  # type: flask.Response
+    )
     assert request.status_code == 500, request.text
 
 
@@ -142,12 +130,10 @@ def test_schema_in_query(schema_app):
     good_request = app_client.post(
         "/v1.0/test_schema_in_query",
         headers=headers,
-        query_string={"image_version": "version", "not_required": "test"},
-    )  # type: flask.Response
+        params={"image_version": "version", "not_required": "test"},
+    )
     assert good_request.status_code == 200
-    good_request_response = json.loads(
-        good_request.data.decode("utf-8", "replace")
-    )  # type: dict
+    good_request_response = json.loads(good_request.text)
     assert good_request_response["image_version"] == "version"
 
 
@@ -157,23 +143,19 @@ def test_schema_list(schema_app):
 
     wrong_type = app_client.post(
         "/v1.0/test_schema_list", headers=headers, data=json.dumps(42)
-    )  # type: flask.Response
+    )
     assert wrong_type.status_code == 400
-    assert wrong_type.content_type == "application/problem+json"
-    wrong_type_response = json.loads(
-        wrong_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_type.headers.get("content-type") == "application/problem+json"
+    wrong_type_response = json.loads(wrong_type.text)
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'array'")
 
     wrong_items = app_client.post(
         "/v1.0/test_schema_list", headers=headers, data=json.dumps([42])
-    )  # type: flask.Response
+    )
     assert wrong_items.status_code == 400
-    assert wrong_items.content_type == "application/problem+json"
-    wrong_items_response = json.loads(
-        wrong_items.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_items.headers.get("content-type") == "application/problem+json"
+    wrong_items_response = json.loads(wrong_items.text)
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'string'")
 
@@ -191,29 +173,25 @@ def test_schema_map(schema_app):
 
     wrong_type = app_client.post(
         "/v1.0/test_schema_map", headers=headers, data=json.dumps(42)
-    )  # type: flask.Response
+    )
     assert wrong_type.status_code == 400
-    assert wrong_type.content_type == "application/problem+json"
-    wrong_type_response = json.loads(
-        wrong_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_type.headers.get("content-type") == "application/problem+json"
+    wrong_type_response = json.loads(wrong_type.text)
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
     wrong_items = app_client.post(
         "/v1.0/test_schema_map", headers=headers, data=json.dumps(invalid_object)
-    )  # type: flask.Response
+    )
     assert wrong_items.status_code == 400
-    assert wrong_items.content_type == "application/problem+json"
-    wrong_items_response = json.loads(
-        wrong_items.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_items.headers.get("content-type") == "application/problem+json"
+    wrong_items_response = json.loads(wrong_items.text)
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
     right_type = app_client.post(
         "/v1.0/test_schema_map", headers=headers, data=json.dumps(valid_object)
-    )  # type: flask.Response
+    )
     assert right_type.status_code == 200
 
 
@@ -237,25 +215,25 @@ def test_schema_recursive(schema_app):
 
     wrong_type = app_client.post(
         "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(42)
-    )  # type: flask.Response
+    )
     assert wrong_type.status_code == 400
-    assert wrong_type.content_type == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.data.decode("utf-8"))  # type: dict
+    assert wrong_type.headers.get("content-type") == "application/problem+json"
+    wrong_type_response = json.loads(wrong_type.text)
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
     wrong_items = app_client.post(
         "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(invalid_object)
-    )  # type: flask.Response
+    )
     assert wrong_items.status_code == 400
-    assert wrong_items.content_type == "application/problem+json"
-    wrong_items_response = json.loads(wrong_items.data.decode("utf-8"))  # type: dict
+    assert wrong_items.headers.get("content-type") == "application/problem+json"
+    wrong_items_response = json.loads(wrong_items.text)
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
     right_type = app_client.post(
         "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(valid_object)
-    )  # type: flask.Response
+    )
     assert right_type.status_code == 200
 
 
@@ -265,12 +243,10 @@ def test_schema_format(schema_app):
 
     wrong_type = app_client.post(
         "/v1.0/test_schema_format", headers=headers, data=json.dumps("xy")
-    )  # type: flask.Response
+    )
     assert wrong_type.status_code == 400
-    assert wrong_type.content_type == "application/problem+json"
-    wrong_type_response = json.loads(
-        wrong_type.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert wrong_type.headers.get("content-type") == "application/problem+json"
+    wrong_type_response = json.loads(wrong_type.text)
     assert wrong_type_response["title"] == "Bad Request"
     assert "'xy' is not a 'email'" in wrong_type_response["detail"]
 
@@ -281,12 +257,10 @@ def test_schema_array(schema_app):
 
     array_request = app_client.post(
         "/v1.0/schema_array", headers=headers, data=json.dumps(["list", "hello"])
-    )  # type: flask.Response
+    )
     assert array_request.status_code == 200
-    assert array_request.content_type == "application/json"
-    array_response = json.loads(
-        array_request.data.decode("utf-8", "replace")
-    )  # type: list
+    assert array_request.headers.get("content-type") == "application/json"
+    array_response = json.loads(array_request.text)
     assert array_response == ["list", "hello"]
 
 
@@ -296,19 +270,17 @@ def test_schema_int(schema_app):
 
     array_request = app_client.post(
         "/v1.0/schema_int", headers=headers, data=json.dumps(42)
-    )  # type: flask.Response
+    )
     assert array_request.status_code == 200
-    assert array_request.content_type == "application/json"
-    array_response = json.loads(
-        array_request.data.decode("utf-8", "replace")
-    )  # type: list
+    assert array_request.headers.get("content-type") == "application/json"
+    array_response = json.loads(array_request.text)  # type: list
     assert array_response == 42
 
 
 def test_global_response_definitions(schema_app):
     app_client = schema_app.test_client()
     resp = app_client.get("/v1.0/define_global_response")
-    assert json.loads(resp.data.decode("utf-8", "replace")) == ["general", "list"]
+    assert json.loads(resp.text) == ["general", "list"]
 
 
 def test_media_range(schema_app):

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -3,11 +3,8 @@ import json
 
 def test_schema(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
-    empty_request = app_client.post(
-        "/v1.0/test_schema", headers=headers, data=json.dumps({})
-    )
+    empty_request = app_client.post("/v1.0/test_schema", json={})
     assert empty_request.status_code == 400
     assert empty_request.headers.get("content-type") == "application/problem+json"
     empty_request_response = empty_request.json()
@@ -16,18 +13,14 @@ def test_schema(schema_app):
         "'image_version' is a required property"
     )
 
-    bad_type = app_client.post(
-        "/v1.0/test_schema", headers=headers, data=json.dumps({"image_version": 22})
-    )
+    bad_type = app_client.post("/v1.0/test_schema", json={"image_version": 22})
     assert bad_type.status_code == 400
     assert bad_type.headers.get("content-type") == "application/problem+json"
     bad_type_response = bad_type.json()
     assert bad_type_response["title"] == "Bad Request"
     assert bad_type_response["detail"].startswith("22 is not of type 'string'")
 
-    bad_type_path = app_client.post(
-        "/v1.0/test_schema", headers=headers, data=json.dumps({"image_version": 22})
-    )
+    bad_type_path = app_client.post("/v1.0/test_schema", json={"image_version": 22})
     assert bad_type_path.status_code == 400
     assert bad_type_path.headers.get("content-type") == "application/problem+json"
     bad_type_path_response = bad_type_path.json()
@@ -36,8 +29,7 @@ def test_schema(schema_app):
 
     good_request = app_client.post(
         "/v1.0/test_schema",
-        headers=headers,
-        data=json.dumps({"image_version": "version"}),
+        json={"image_version": "version"},
     )
     assert good_request.status_code == 200
     good_request_response = good_request.json()
@@ -45,16 +37,13 @@ def test_schema(schema_app):
 
     good_request_extra = app_client.post(
         "/v1.0/test_schema",
-        headers=headers,
-        data=json.dumps({"image_version": "version", "extra": "stuff"}),
+        json={"image_version": "version", "extra": "stuff"},
     )
     assert good_request_extra.status_code == 200
     good_request_extra_response = good_request.json()
     assert good_request_extra_response["image_version"] == "version"
 
-    wrong_type = app_client.post(
-        "/v1.0/test_schema", headers=headers, data=json.dumps(42)
-    )
+    wrong_type = app_client.post("/v1.0/test_schema", json=42)
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
     wrong_type_response = wrong_type.json()
@@ -139,20 +128,15 @@ def test_schema_in_query(schema_app):
 
 def test_schema_list(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
-    wrong_type = app_client.post(
-        "/v1.0/test_schema_list", headers=headers, data=json.dumps(42)
-    )
+    wrong_type = app_client.post("/v1.0/test_schema_list", json=42)
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
     wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'array'")
 
-    wrong_items = app_client.post(
-        "/v1.0/test_schema_list", headers=headers, data=json.dumps([42])
-    )
+    wrong_items = app_client.post("/v1.0/test_schema_list", json=[42])
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
     wrong_items_response = wrong_items.json()
@@ -162,7 +146,6 @@ def test_schema_list(schema_app):
 
 def test_schema_map(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
     valid_object = {
         "foo": {"image_version": "string"},
@@ -171,33 +154,26 @@ def test_schema_map(schema_app):
 
     invalid_object = {"foo": 42}
 
-    wrong_type = app_client.post(
-        "/v1.0/test_schema_map", headers=headers, data=json.dumps(42)
-    )
+    wrong_type = app_client.post("/v1.0/test_schema_map", json=42)
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
     wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
-    wrong_items = app_client.post(
-        "/v1.0/test_schema_map", headers=headers, data=json.dumps(invalid_object)
-    )
+    wrong_items = app_client.post("/v1.0/test_schema_map", json=invalid_object)
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
     wrong_items_response = wrong_items.json()
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
-    right_type = app_client.post(
-        "/v1.0/test_schema_map", headers=headers, data=json.dumps(valid_object)
-    )
+    right_type = app_client.post("/v1.0/test_schema_map", json=valid_object)
     assert right_type.status_code == 200
 
 
 def test_schema_recursive(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
     valid_object = {
         "children": [
@@ -213,37 +189,28 @@ def test_schema_recursive(schema_app):
 
     invalid_object = {"children": [42]}
 
-    wrong_type = app_client.post(
-        "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(42)
-    )
+    wrong_type = app_client.post("/v1.0/test_schema_recursive", json=42)
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
     wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
-    wrong_items = app_client.post(
-        "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(invalid_object)
-    )
+    wrong_items = app_client.post("/v1.0/test_schema_recursive", json=invalid_object)
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
     wrong_items_response = wrong_items.json()
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
-    right_type = app_client.post(
-        "/v1.0/test_schema_recursive", headers=headers, data=json.dumps(valid_object)
-    )
+    right_type = app_client.post("/v1.0/test_schema_recursive", json=valid_object)
     assert right_type.status_code == 200
 
 
 def test_schema_format(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
-    wrong_type = app_client.post(
-        "/v1.0/test_schema_format", headers=headers, data=json.dumps("xy")
-    )
+    wrong_type = app_client.post("/v1.0/test_schema_format", json="xy")
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
     wrong_type_response = wrong_type.json()
@@ -253,11 +220,8 @@ def test_schema_format(schema_app):
 
 def test_schema_array(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
-    array_request = app_client.post(
-        "/v1.0/schema_array", headers=headers, data=json.dumps(["list", "hello"])
-    )
+    array_request = app_client.post("/v1.0/schema_array", json=["list", "hello"])
     assert array_request.status_code == 200
     assert array_request.headers.get("content-type") == "application/json"
     array_response = array_request.json()
@@ -268,9 +232,7 @@ def test_schema_int(schema_app):
     app_client = schema_app.test_client()
     headers = {"Content-type": "application/json"}
 
-    array_request = app_client.post(
-        "/v1.0/schema_int", headers=headers, data=json.dumps(42)
-    )
+    array_request = app_client.post("/v1.0/schema_int", json=42)
     assert array_request.status_code == 200
     assert array_request.headers.get("content-type") == "application/json"
     array_response = array_request.json()  # type: list
@@ -285,9 +247,6 @@ def test_global_response_definitions(schema_app):
 
 def test_media_range(schema_app):
     app_client = schema_app.test_client()
-    headers = {"Content-type": "application/json"}
 
-    array_request = app_client.post(
-        "/v1.0/media_range", headers=headers, data=json.dumps({})
-    )
+    array_request = app_client.post("/v1.0/media_range", json={})
     assert array_request.status_code == 200, array_request.text

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -10,7 +10,7 @@ def test_schema(schema_app):
     )
     assert empty_request.status_code == 400
     assert empty_request.headers.get("content-type") == "application/problem+json"
-    empty_request_response = json.loads(empty_request.text)
+    empty_request_response = empty_request.json()
     assert empty_request_response["title"] == "Bad Request"
     assert empty_request_response["detail"].startswith(
         "'image_version' is a required property"
@@ -21,7 +21,7 @@ def test_schema(schema_app):
     )
     assert bad_type.status_code == 400
     assert bad_type.headers.get("content-type") == "application/problem+json"
-    bad_type_response = json.loads(bad_type.text)
+    bad_type_response = bad_type.json()
     assert bad_type_response["title"] == "Bad Request"
     assert bad_type_response["detail"].startswith("22 is not of type 'string'")
 
@@ -30,7 +30,7 @@ def test_schema(schema_app):
     )
     assert bad_type_path.status_code == 400
     assert bad_type_path.headers.get("content-type") == "application/problem+json"
-    bad_type_path_response = json.loads(bad_type.text)
+    bad_type_path_response = bad_type_path.json()
     assert bad_type_path_response["title"] == "Bad Request"
     assert bad_type_path_response["detail"].endswith(" - 'image_version'")
 
@@ -40,7 +40,7 @@ def test_schema(schema_app):
         data=json.dumps({"image_version": "version"}),
     )
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.text)
+    good_request_response = good_request.json()
     assert good_request_response["image_version"] == "version"
 
     good_request_extra = app_client.post(
@@ -49,7 +49,7 @@ def test_schema(schema_app):
         data=json.dumps({"image_version": "version", "extra": "stuff"}),
     )
     assert good_request_extra.status_code == 200
-    good_request_extra_response = json.loads(good_request.text)
+    good_request_extra_response = good_request.json()
     assert good_request_extra_response["image_version"] == "version"
 
     wrong_type = app_client.post(
@@ -57,7 +57,7 @@ def test_schema(schema_app):
     )
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.text)
+    wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
@@ -66,59 +66,59 @@ def test_schema_response(schema_app):
     app_client = schema_app.test_client()
 
     request = app_client.get(
-        "/v1.0/test_schema/response/object/valid", headers={}, data=None
+        "/v1.0/test_schema/response/object/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/object/invalid_type", headers={}, data=None
+        "/v1.0/test_schema/response/object/invalid_type",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/object/invalid_requirements", headers={}, data=None
+        "/v1.0/test_schema/response/object/invalid_requirements",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/string/valid", headers={}, data=None
+        "/v1.0/test_schema/response/string/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/string/invalid", headers={}, data=None
+        "/v1.0/test_schema/response/string/invalid",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/integer/valid", headers={}, data=None
+        "/v1.0/test_schema/response/integer/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/integer/invalid", headers={}, data=None
+        "/v1.0/test_schema/response/integer/invalid",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/number/valid", headers={}, data=None
+        "/v1.0/test_schema/response/number/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/number/invalid", headers={}, data=None
+        "/v1.0/test_schema/response/number/invalid",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/boolean/valid", headers={}, data=None
+        "/v1.0/test_schema/response/boolean/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/boolean/invalid", headers={}, data=None
+        "/v1.0/test_schema/response/boolean/invalid",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/array/valid", headers={}, data=None
+        "/v1.0/test_schema/response/array/valid",
     )
     assert request.status_code == 200, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/array/invalid_dict", headers={}, data=None
+        "/v1.0/test_schema/response/array/invalid_dict",
     )
     assert request.status_code == 500, request.text
     request = app_client.get(
-        "/v1.0/test_schema/response/array/invalid_string", headers={}, data=None
+        "/v1.0/test_schema/response/array/invalid_string",
     )
     assert request.status_code == 500, request.text
 
@@ -133,7 +133,7 @@ def test_schema_in_query(schema_app):
         params={"image_version": "version", "not_required": "test"},
     )
     assert good_request.status_code == 200
-    good_request_response = json.loads(good_request.text)
+    good_request_response = good_request.json()
     assert good_request_response["image_version"] == "version"
 
 
@@ -146,7 +146,7 @@ def test_schema_list(schema_app):
     )
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.text)
+    wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'array'")
 
@@ -155,7 +155,7 @@ def test_schema_list(schema_app):
     )
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
-    wrong_items_response = json.loads(wrong_items.text)
+    wrong_items_response = wrong_items.json()
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'string'")
 
@@ -176,7 +176,7 @@ def test_schema_map(schema_app):
     )
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.text)
+    wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
@@ -185,7 +185,7 @@ def test_schema_map(schema_app):
     )
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
-    wrong_items_response = json.loads(wrong_items.text)
+    wrong_items_response = wrong_items.json()
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
@@ -218,7 +218,7 @@ def test_schema_recursive(schema_app):
     )
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.text)
+    wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert wrong_type_response["detail"].startswith("42 is not of type 'object'")
 
@@ -227,7 +227,7 @@ def test_schema_recursive(schema_app):
     )
     assert wrong_items.status_code == 400
     assert wrong_items.headers.get("content-type") == "application/problem+json"
-    wrong_items_response = json.loads(wrong_items.text)
+    wrong_items_response = wrong_items.json()
     assert wrong_items_response["title"] == "Bad Request"
     assert wrong_items_response["detail"].startswith("42 is not of type 'object'")
 
@@ -246,7 +246,7 @@ def test_schema_format(schema_app):
     )
     assert wrong_type.status_code == 400
     assert wrong_type.headers.get("content-type") == "application/problem+json"
-    wrong_type_response = json.loads(wrong_type.text)
+    wrong_type_response = wrong_type.json()
     assert wrong_type_response["title"] == "Bad Request"
     assert "'xy' is not a 'email'" in wrong_type_response["detail"]
 
@@ -260,7 +260,7 @@ def test_schema_array(schema_app):
     )
     assert array_request.status_code == 200
     assert array_request.headers.get("content-type") == "application/json"
-    array_response = json.loads(array_request.text)
+    array_response = array_request.json()
     assert array_response == ["list", "hello"]
 
 
@@ -273,14 +273,14 @@ def test_schema_int(schema_app):
     )
     assert array_request.status_code == 200
     assert array_request.headers.get("content-type") == "application/json"
-    array_response = json.loads(array_request.text)  # type: list
+    array_response = array_request.json()  # type: list
     assert array_response == 42
 
 
 def test_global_response_definitions(schema_app):
     app_client = schema_app.test_client()
     resp = app_client.get("/v1.0/define_global_response")
-    assert json.loads(resp.text) == ["general", "list"]
+    assert resp.json() == ["general", "list"]
 
 
 def test_media_range(schema_app):

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -92,7 +92,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_no_auth = app_client.get("/v1.0/byesecure/jsantos")
     assert get_bye_no_auth.status_code == 401
     assert get_bye_no_auth.headers.get("content-type") == "application/problem+json"
-    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.text)
+    get_bye_no_auth_reponse = get_bye_no_auth.json()
     assert get_bye_no_auth_reponse["detail"] == "No authorization token provided"
 
     headers = {"Authorization": "Bearer 100"}
@@ -104,7 +104,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_wrong_scope = app_client.get("/v1.0/byesecure/jsantos", headers=headers)
     assert get_bye_wrong_scope.status_code == 403
     assert get_bye_wrong_scope.headers.get("content-type") == "application/problem+json"
-    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.text)
+    get_bye_wrong_scope_reponse = get_bye_wrong_scope.json()
     assert (
         get_bye_wrong_scope_reponse["detail"]
         == "Provided token doesn't have the required scope"
@@ -114,7 +114,7 @@ def test_security(oauth_requests, secure_endpoint_app):
     get_bye_bad_token = app_client.get("/v1.0/byesecure/jsantos", headers=headers)
     assert get_bye_bad_token.status_code == 401
     assert get_bye_bad_token.headers.get("content-type") == "application/problem+json"
-    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.text)
+    get_bye_bad_token_reponse = get_bye_bad_token.json()
     assert get_bye_bad_token_reponse["detail"] == "Provided token is not valid"
 
     response = app_client.get("/v1.0/more-than-one-security-definition")

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -58,129 +58,109 @@ def test_security_over_nonexistent_endpoints(oauth_requests, secure_api_app):
     headers = {"Authorization": "Bearer 300"}
     get_inexistent_endpoint = app_client.get(
         "/v1.0/does-not-exist-invalid-token", headers=headers
-    )  # type: flask.Response
+    )
     assert get_inexistent_endpoint.status_code == 401
-    assert get_inexistent_endpoint.content_type == "application/problem+json"
+    assert (
+        get_inexistent_endpoint.headers.get("content-type")
+        == "application/problem+json"
+    )
 
     headers = {"Authorization": "Bearer 100"}
     get_inexistent_endpoint = app_client.get(
         "/v1.0/does-not-exist-valid-token", headers=headers
-    )  # type: flask.Response
+    )
     assert get_inexistent_endpoint.status_code == 404
-    assert get_inexistent_endpoint.content_type == "application/problem+json"
+    assert (
+        get_inexistent_endpoint.headers.get("content-type")
+        == "application/problem+json"
+    )
 
-    get_inexistent_endpoint = app_client.get(
-        "/v1.0/does-not-exist-no-token"
-    )  # type: flask.Response
+    get_inexistent_endpoint = app_client.get("/v1.0/does-not-exist-no-token")
     assert get_inexistent_endpoint.status_code == 401
 
     headers = {"Authorization": "Bearer 100"}
-    post_greeting = app_client.post(
-        "/v1.0/greeting/rcaricio", data={}, headers=headers
-    )  # type: flask.Response
+    post_greeting = app_client.post("/v1.0/greeting/rcaricio", data={}, headers=headers)
     assert post_greeting.status_code == 200
 
-    post_greeting = app_client.post(
-        "/v1.0/greeting/rcaricio", data={}
-    )  # type: flask.Response
+    post_greeting = app_client.post("/v1.0/greeting/rcaricio", data={})
     assert post_greeting.status_code == 401
 
 
 def test_security(oauth_requests, secure_endpoint_app):
     app_client = secure_endpoint_app.test_client()
 
-    get_bye_no_auth = app_client.get("/v1.0/byesecure/jsantos")  # type: flask.Response
+    get_bye_no_auth = app_client.get("/v1.0/byesecure/jsantos")
     assert get_bye_no_auth.status_code == 401
-    assert get_bye_no_auth.content_type == "application/problem+json"
-    get_bye_no_auth_reponse = json.loads(
-        get_bye_no_auth.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert get_bye_no_auth.headers.get("content-type") == "application/problem+json"
+    get_bye_no_auth_reponse = json.loads(get_bye_no_auth.text)
     assert get_bye_no_auth_reponse["detail"] == "No authorization token provided"
 
     headers = {"Authorization": "Bearer 100"}
-    get_bye_good_auth = app_client.get(
-        "/v1.0/byesecure/jsantos", headers=headers
-    )  # type: flask.Response
+    get_bye_good_auth = app_client.get("/v1.0/byesecure/jsantos", headers=headers)
     assert get_bye_good_auth.status_code == 200
-    assert get_bye_good_auth.data == b"Goodbye jsantos (Secure: test-user)"
+    assert get_bye_good_auth.text == "Goodbye jsantos (Secure: test-user)"
 
     headers = {"Authorization": "Bearer 200"}
-    get_bye_wrong_scope = app_client.get(
-        "/v1.0/byesecure/jsantos", headers=headers
-    )  # type: flask.Response
+    get_bye_wrong_scope = app_client.get("/v1.0/byesecure/jsantos", headers=headers)
     assert get_bye_wrong_scope.status_code == 403
-    assert get_bye_wrong_scope.content_type == "application/problem+json"
-    get_bye_wrong_scope_reponse = json.loads(
-        get_bye_wrong_scope.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert get_bye_wrong_scope.headers.get("content-type") == "application/problem+json"
+    get_bye_wrong_scope_reponse = json.loads(get_bye_wrong_scope.text)
     assert (
         get_bye_wrong_scope_reponse["detail"]
         == "Provided token doesn't have the required scope"
     )
 
     headers = {"Authorization": "Bearer 300"}
-    get_bye_bad_token = app_client.get(
-        "/v1.0/byesecure/jsantos", headers=headers
-    )  # type: flask.Response
+    get_bye_bad_token = app_client.get("/v1.0/byesecure/jsantos", headers=headers)
     assert get_bye_bad_token.status_code == 401
-    assert get_bye_bad_token.content_type == "application/problem+json"
-    get_bye_bad_token_reponse = json.loads(
-        get_bye_bad_token.data.decode("utf-8", "replace")
-    )  # type: dict
+    assert get_bye_bad_token.headers.get("content-type") == "application/problem+json"
+    get_bye_bad_token_reponse = json.loads(get_bye_bad_token.text)
     assert get_bye_bad_token_reponse["detail"] == "Provided token is not valid"
 
-    response = app_client.get(
-        "/v1.0/more-than-one-security-definition"
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-security-definition")
     assert response.status_code == 401
 
     # also tests case-insensitivity
     headers = {"X-AUTH": "mykey"}
     response = app_client.get(
         "/v1.0/more-than-one-security-definition", headers=headers
-    )  # type: flask.Response
+    )
     assert response.status_code == 200
 
     headers = {"Authorization": "Bearer 100"}
     get_bye_good_auth = app_client.get(
         "/v1.0/byesecure-ignoring-context/hjacobs", headers=headers
-    )  # type: flask.Response
+    )
     assert get_bye_good_auth.status_code == 200
-    assert get_bye_good_auth.data == b"Goodbye hjacobs (Secure!)"
+    assert get_bye_good_auth.text == "Goodbye hjacobs (Secure!)"
 
     headers = {"Authorization": "Bearer 100"}
-    get_bye_from_flask = app_client.get(
-        "/v1.0/byesecure-from-flask", headers=headers
-    )  # type: flask.Response
-    assert get_bye_from_flask.data == b"Goodbye test-user (Secure!)"
+    get_bye_from_flask = app_client.get("/v1.0/byesecure-from-flask", headers=headers)
+    assert get_bye_from_flask.text == "Goodbye test-user (Secure!)"
 
     headers = {"Authorization": "Bearer 100"}
     get_bye_from_connexion = app_client.get(
         "/v1.0/byesecure-from-connexion", headers=headers
-    )  # type: flask.Response
-    assert get_bye_from_connexion.data == b"Goodbye test-user (Secure!)"
+    )
+    assert get_bye_from_connexion.text == "Goodbye test-user (Secure!)"
 
     headers = {"Authorization": "Bearer 100"}
     get_bye_from_connexion = app_client.get(
         "/v1.0/byesecure-jwt/test-user", headers=headers
-    )  # type: flask.Response
-    assert get_bye_from_connexion.data == b"Goodbye test-user (Secure: 100)"
+    )
+    assert get_bye_from_connexion.text == "Goodbye test-user (Secure: 100)"
 
     # has optional auth
-    response = app_client.get("/v1.0/optional-auth")  # type: flask.Response
+    response = app_client.get("/v1.0/optional-auth")
     assert response.status_code == 200
-    assert response.data == b'"Unauthenticated"\n'
+    assert response.text == '"Unauthenticated"\n'
     headers = {"X-AUTH": "mykey"}
-    response = app_client.get(
-        "/v1.0/optional-auth", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/optional-auth", headers=headers)
     assert response.status_code == 200
-    assert response.data == b'"Authenticated"\n'
+    assert response.text == '"Authenticated"\n'
     headers = {"X-AUTH": "wrong-key"}
-    response = app_client.get(
-        "/v1.0/optional-auth", headers=headers
-    )  # type: flask.Response
-    assert response.data == b'"Unauthenticated"\n'
+    response = app_client.get("/v1.0/optional-auth", headers=headers)
+    assert response.text == '"Unauthenticated"\n'
     assert response.status_code == 200
 
     # security function throws exception
@@ -195,35 +175,25 @@ def test_checking_that_client_token_has_all_necessary_scopes(
 
     # has only one of the required scopes
     headers = {"Authorization": "Bearer has_myscope"}
-    response = app_client.get(
-        "/v1.0/more-than-one-scope", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 403
 
     # has none of the necessary scopes
     headers = {"Authorization": "Bearer has_wrongscope"}
-    response = app_client.get(
-        "/v1.0/more-than-one-scope", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 403
 
     # is not auth
     headers = {"Authorization": "Bearer is_not_invalid"}
-    response = app_client.get(
-        "/v1.0/more-than-one-scope", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 401
 
     # has all necessary scopes
     headers = {"Authorization": "Bearer has_myscope_otherscope"}
-    response = app_client.get(
-        "/v1.0/more-than-one-scope", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 200
 
     # has all necessary scopes but under key 'scopes'
     headers = {"Authorization": "Bearer has_scopes_in_scopes_with_s"}
-    response = app_client.get(
-        "/v1.0/more-than-one-scope", headers=headers
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 200

--- a/tests/api/test_unordered_definition.py
+++ b/tests/api/test_unordered_definition.py
@@ -5,5 +5,5 @@ def test_app(unordered_definition_app):
     app_client = unordered_definition_app.test_client()
     response = app_client.get("/v1.0/unordered-params/1?first=first&second=2")
     assert response.status_code == 400
-    response_data = json.loads(response.text)
+    response_data = response.json()
     assert response_data["detail"].startswith("'first' is not of type 'integer'")

--- a/tests/api/test_unordered_definition.py
+++ b/tests/api/test_unordered_definition.py
@@ -3,9 +3,7 @@ import json
 
 def test_app(unordered_definition_app):
     app_client = unordered_definition_app.test_client()
-    response = app_client.get(
-        "/v1.0/unordered-params/1?first=first&second=2"
-    )  # type: flask.Response
+    response = app_client.get("/v1.0/unordered-params/1?first=first&second=2")
     assert response.status_code == 400
-    response_data = json.loads(response.data.decode("utf-8", "replace"))
+    response_data = json.loads(response.text)
     assert response_data["detail"].startswith("'first' is not of type 'integer'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ OPENAPI3_SPEC = "openapi.yaml"
 SPECS = [OPENAPI2_SPEC, OPENAPI3_SPEC]
 METHOD_VIEW_RESOLVERS = [MethodResolver, MethodViewResolver]
 APP_CLASSES = [FlaskApp, AsyncApp]
+# APP_CLASSES = [FlaskApp]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 
 import pytest
-from connexion import App
+from connexion import AsyncApp, FlaskApp
 from connexion.resolver import MethodResolver, MethodViewResolver
 
 logging.basicConfig(level=logging.INFO)
@@ -14,6 +14,7 @@ OPENAPI2_SPEC = "swagger.yaml"
 OPENAPI3_SPEC = "openapi.yaml"
 SPECS = [OPENAPI2_SPEC, OPENAPI3_SPEC]
 METHOD_VIEW_RESOLVERS = [MethodResolver, MethodViewResolver]
+APP_CLASSES = [FlaskApp, AsyncApp]
 
 
 @pytest.fixture
@@ -56,10 +57,15 @@ def method_view_resolver(request):
     return request.param
 
 
+@pytest.fixture(scope="session", params=APP_CLASSES)
+def app_class(request):
+    return request.param
+
+
 def build_app_from_fixture(
-    api_spec_folder, spec_file="openapi.yaml", middlewares=None, **kwargs
+    api_spec_folder, *, app_class, spec_file, middlewares=None, **kwargs
 ):
-    cnx_app = App(
+    cnx_app = app_class(
         __name__,
         specification_dir=FIXTURES_FOLDER / api_spec_folder,
         middlewares=middlewares,

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,5 +1,13 @@
-from unittest.mock import AsyncMock, MagicMock
+import sys
+from unittest.mock import MagicMock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # Python 3.7
+    AsyncMock = None
+
+import pytest
 from connexion.decorators.parameter import (
     AsyncParameterDecorator,
     SyncParameterDecorator,
@@ -27,6 +35,9 @@ def test_sync_injection():
     func.assert_called_with(p1="123")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="AsyncMock only available from 3.8."
+)
 async def test_async_injection():
     request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}
@@ -67,6 +78,9 @@ def test_sync_injection_with_context():
         func.assert_called_with(context, p1="123", test="success")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="AsyncMock only available from 3.8."
+)
 async def test_async_injection_with_context():
     request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from connexion.decorators.parameter import (
     AsyncParameterDecorator,
@@ -28,7 +28,7 @@ def test_sync_injection():
 
 
 async def test_async_injection():
-    request = MagicMock(name="request")
+    request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}
 
     func = MagicMock()
@@ -68,7 +68,7 @@ def test_sync_injection_with_context():
 
 
 async def test_async_injection_with_context():
-    request = MagicMock(name="request")
+    request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}
 
     func = MagicMock()

--- a/tests/fakeapi/example_method_class.py
+++ b/tests/fakeapi/example_method_class.py
@@ -1,0 +1,32 @@
+class PetsView:
+
+    mycontent = "demonstrate return from MethodView class"
+
+    def get(self, **kwargs):
+        if kwargs:
+            kwargs.update({"name": "get"})
+            return kwargs
+        else:
+            return [{"name": "get"}]
+
+    def search(self):
+        return [{"name": "search"}]
+
+    def post(self, **kwargs):
+        kwargs.update({"name": "post"})
+        return kwargs, 201
+
+    def put(self, *args, **kwargs):
+        kwargs.update({"name": "put"})
+        return kwargs, 201
+
+    def delete(self, **kwargs):
+        return 201
+
+    # Test that operation_id can still override resolver
+
+    def api_list(self):
+        return "api_list"
+
+    def post_greeting(self):
+        return "post_greeting"

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
 import datetime
 import uuid
 
 from connexion import NoContent, ProblemException, context, request
 from connexion.exceptions import OAuthProblem
 from flask import jsonify, redirect, send_file
+from starlette.responses import FileResponse
 
 
 class DummyClass:
@@ -75,8 +75,8 @@ def get_bye(name):
     return f"Goodbye {name}"
 
 
-def get_flask_response_tuple():
-    return jsonify({"foo": "bar"}), 201
+def get_response_tuple():
+    return {"foo": "bar"}, 201
 
 
 def get_bye_secure(name, user, token_info):
@@ -652,7 +652,11 @@ def nullable_default(test):
 
 
 def get_streaming_response():
-    return send_file(__file__)
+    try:
+        return send_file(__file__)
+    except RuntimeError:
+        # Not in Flask context
+        return FileResponse(__file__)
 
 
 async def async_route():

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -1,10 +1,12 @@
+import asyncio
 import datetime
 import uuid
 
+import flask
 from connexion import NoContent, ProblemException, context, request
 from connexion.exceptions import OAuthProblem
-from flask import jsonify, redirect, send_file
-from starlette.responses import FileResponse
+from flask import redirect, send_file
+from starlette.responses import FileResponse, RedirectResponse
 
 
 class DummyClass:
@@ -314,10 +316,16 @@ def test_formdata_missing_param():
     return ""
 
 
-def test_formdata_file_upload(fileData, **kwargs):
+async def test_formdata_file_upload(fileData, **kwargs):
     """In Swagger, form paramaeters and files are passed separately"""
-    filename = fileData.filename
-    contents = fileData.read()
+    file_ = fileData[0]
+    try:
+        filename = file_.filename
+    except AttributeError:
+        filename = file_.name
+    contents = file_.read()
+    if asyncio.iscoroutine(contents):
+        contents = await contents
     contents = contents.decode("utf-8", "replace")
     return {filename: contents}
 
@@ -362,7 +370,11 @@ def test_redirect_endpoint():
 
 
 def test_redirect_response_endpoint():
-    return redirect("http://www.google.com/")
+    url = "http://www.google.com/"
+    if flask.has_app_context():
+        return redirect(url)
+    else:
+        return RedirectResponse(url, status_code=302)
 
 
 def test_204_with_headers():

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -88,11 +88,11 @@ paths:
           required: true
           schema:
             type: string
-  /flask_response_tuple:
+  /response_tuple:
     get:
-      summary: Return flask response tuple
-      description: Test returning a flask response tuple
-      operationId: fakeapi.hello.get_flask_response_tuple
+      summary: Return response tuple
+      description: Test returning a response tuple
+      operationId: fakeapi.hello.get_response_tuple
       responses:
         '200':
           description: json response

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -85,11 +85,11 @@ paths:
           required: true
           type: string
 
-  /flask_response_tuple:
+  /response_tuple:
     get:
-      summary: Return flask response tuple
-      description: Test returning a flask response tuple
-      operationId: fakeapi.hello.get_flask_response_tuple
+      summary: Return response tuple
+      description: Test returning a response tuple
+      operationId: fakeapi.hello.get_response_tuple
       produces:
         - application/json
       responses:

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import math
 from decimal import Decimal
-from unittest import mock
 
 from connexion.frameworks.flask import FlaskJSONProvider
 
@@ -44,13 +43,15 @@ def test_json_encoder_datetime_with_timezone():
     assert s.endswith('+00:00"')
 
 
-def test_readonly(json_datetime_dir, spec):
-    app = build_app_from_fixture(json_datetime_dir, spec, validate_responses=True)
+def test_readonly(json_datetime_dir, spec, app_class):
+    app = build_app_from_fixture(
+        json_datetime_dir, app_class=app_class, spec_file=spec, validate_responses=True
+    )
     app_client = app.test_client()
 
     res = app_client.get("/v1.0/" + spec.replace("yaml", "json"))
     assert res.status_code == 200, f"Error is {res.data}"
-    spec_data = json.loads(res.data.decode())
+    spec_data = json.loads(res.text)
 
     if spec == "openapi.yaml":
         response_path = "responses.200.content.application/json.schema"
@@ -75,15 +76,15 @@ def test_readonly(json_datetime_dir, spec):
 
     res = app_client.get("/v1.0/datetime")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.data.decode())
+    data = json.loads(res.text)
     assert data == {"value": "2000-01-02T03:04:05.000006Z"}
 
     res = app_client.get("/v1.0/date")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.data.decode())
+    data = json.loads(res.text)
     assert data == {"value": "2000-01-02"}
 
     res = app_client.get("/v1.0/uuid")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.data.decode())
+    data = json.loads(res.text)
     assert data == {"value": "e7ff66d0-3ec2-4c4e-bed0-6e4723c24c51"}

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -51,7 +51,7 @@ def test_readonly(json_datetime_dir, spec, app_class):
 
     res = app_client.get("/v1.0/" + spec.replace("yaml", "json"))
     assert res.status_code == 200, f"Error is {res.data}"
-    spec_data = json.loads(res.text)
+    spec_data = res.json()
 
     if spec == "openapi.yaml":
         response_path = "responses.200.content.application/json.schema"
@@ -76,15 +76,15 @@ def test_readonly(json_datetime_dir, spec, app_class):
 
     res = app_client.get("/v1.0/datetime")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.text)
+    data = res.json()
     assert data == {"value": "2000-01-02T03:04:05.000006Z"}
 
     res = app_client.get("/v1.0/date")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.text)
+    data = res.json()
     assert data == {"value": "2000-01-02"}
 
     res = app_client.get("/v1.0/uuid")
     assert res.status_code == 200, f"Error is {res.data}"
-    data = json.loads(res.text)
+    data = res.json()
     assert data == {"value": "e7ff66d0-3ec2-4c4e-bed0-6e4723c24c51"}

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -39,15 +39,13 @@ def test_validator_map(json_validation_spec_dir, spec):
 
     res = app_client.post(
         "/v1.0/minlength",
-        data=json.dumps({"foo": "bar"}),
-        headers={"content-type": "application/json"},
+        json={"foo": "bar"},
     )
     assert res.status_code == 200
 
     res = app_client.post(
         "/v1.0/minlength",
-        data=json.dumps({"foo": ""}),
-        headers={"content-type": "application/json"},
+        json={"foo": ""},
     )
     assert res.status_code == 400
 
@@ -69,16 +67,14 @@ def test_readonly(json_validation_spec_dir, spec, app_class):
 
     res = app_client.post(
         "/v1.0/user",
-        data=json.dumps({"name": "max", "password": "1234"}),
-        headers=headers,
+        json={"name": "max", "password": "1234"},
     )
     assert res.status_code == 200
     assert res.json().get("user_id") == 8
 
     res = app_client.post(
         "/v1.0/user",
-        data=json.dumps({"user_id": 9, "name": "max"}),
-        headers=headers,
+        json={"user_id": 9, "name": "max"},
     )
     assert res.status_code == 400
 
@@ -94,8 +90,7 @@ def test_writeonly(json_validation_spec_dir, spec, app_class):
 
     res = app_client.post(
         "/v1.0/user",
-        data=json.dumps({"name": "max", "password": "1234"}),
-        headers={"content-type": "application/json"},
+        json={"name": "max", "password": "1234"},
     )
     assert res.status_code == 200
     assert "password" not in res.json()

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -40,12 +40,14 @@ def test_validator_map(json_validation_spec_dir, spec):
     res = app_client.post(
         "/v1.0/minlength",
         data=json.dumps({"foo": "bar"}),
-        content_type="application/json",
+        headers={"content-type": "application/json"},
     )
     assert res.status_code == 200
 
     res = app_client.post(
-        "/v1.0/minlength", data=json.dumps({"foo": ""}), content_type="application/json"
+        "/v1.0/minlength",
+        data=json.dumps({"foo": ""}),
+        headers={"content-type": "application/json"},
     )
     assert res.status_code == 400
 
@@ -63,7 +65,7 @@ def test_readonly(json_validation_spec_dir, spec, app_class):
 
     res = app_client.get("/v1.0/user")
     assert res.status_code == 200
-    assert json.loads(res.text).get("user_id") == 7
+    assert res.json().get("user_id") == 7
 
     res = app_client.post(
         "/v1.0/user",
@@ -71,7 +73,7 @@ def test_readonly(json_validation_spec_dir, spec, app_class):
         headers=headers,
     )
     assert res.status_code == 200
-    assert json.loads(res.text).get("user_id") == 8
+    assert res.json().get("user_id") == 8
 
     res = app_client.post(
         "/v1.0/user",
@@ -96,18 +98,15 @@ def test_writeonly(json_validation_spec_dir, spec, app_class):
         headers={"content-type": "application/json"},
     )
     assert res.status_code == 200
-    assert "password" not in json.loads(res.text)
+    assert "password" not in res.json()
 
     res = app_client.get("/v1.0/user")
     assert res.status_code == 200
-    assert "password" not in json.loads(res.text)
+    assert "password" not in res.json()
 
     res = app_client.get("/v1.0/user_with_password")
     assert res.status_code == 500
-    assert (
-        json.loads(res.text)["title"]
-        == "Response body does not conform to specification"
-    )
+    assert res.json()["title"] == "Response body does not conform to specification"
 
 
 def test_nullable_default(json_validation_spec_dir, spec):
@@ -127,9 +126,9 @@ def test_multipart_form_json(json_validation_spec_dir, spec, app_class):
 
     res = app_client.post(
         "/v1.0/multipart_form_json",
+        files={"file": b""},  # Force multipart/form-data content-type
         data={"x": json.dumps({"name": "joe", "age": 20})},
-        headers={"content-type": "multipart/form-data"},
     )
     assert res.status_code == 200
-    assert json.loads(res.text)["name"] == "joe-reply"
-    assert json.loads(res.text)["age"] == 30
+    assert res.json()["name"] == "joe-reply"
+    assert res.json()["age"] == 30

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -41,63 +41,71 @@ def test_validator_map(json_validation_spec_dir, spec):
         "/v1.0/minlength",
         data=json.dumps({"foo": "bar"}),
         content_type="application/json",
-    )  # type: flask.Response
+    )
     assert res.status_code == 200
 
     res = app_client.post(
         "/v1.0/minlength", data=json.dumps({"foo": ""}), content_type="application/json"
-    )  # type: flask.Response
+    )
     assert res.status_code == 400
 
 
-def test_readonly(json_validation_spec_dir, spec):
+def test_readonly(json_validation_spec_dir, spec, app_class):
     app = build_app_from_fixture(
-        json_validation_spec_dir, spec, validate_responses=True
+        json_validation_spec_dir,
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
     )
     app_client = app.test_client()
 
-    res = app_client.get("/v1.0/user")  # type: flask.Response
+    headers = {"content-type": "application/json"}
+
+    res = app_client.get("/v1.0/user")
     assert res.status_code == 200
-    assert json.loads(res.data.decode()).get("user_id") == 7
+    assert json.loads(res.text).get("user_id") == 7
 
     res = app_client.post(
         "/v1.0/user",
         data=json.dumps({"name": "max", "password": "1234"}),
-        content_type="application/json",
-    )  # type: flask.Response
+        headers=headers,
+    )
     assert res.status_code == 200
-    assert json.loads(res.data.decode()).get("user_id") == 8
+    assert json.loads(res.text).get("user_id") == 8
 
     res = app_client.post(
         "/v1.0/user",
         data=json.dumps({"user_id": 9, "name": "max"}),
-        content_type="application/json",
-    )  # type: flask.Response
+        headers=headers,
+    )
     assert res.status_code == 400
 
 
-def test_writeonly(json_validation_spec_dir, spec):
+def test_writeonly(json_validation_spec_dir, spec, app_class):
     app = build_app_from_fixture(
-        json_validation_spec_dir, spec, validate_responses=True
+        json_validation_spec_dir,
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
     )
     app_client = app.test_client()
 
     res = app_client.post(
         "/v1.0/user",
         data=json.dumps({"name": "max", "password": "1234"}),
-        content_type="application/json",
-    )  # type: flask.Response
+        headers={"content-type": "application/json"},
+    )
     assert res.status_code == 200
-    assert "password" not in json.loads(res.data.decode())
+    assert "password" not in json.loads(res.text)
 
-    res = app_client.get("/v1.0/user")  # type: flask.Response
+    res = app_client.get("/v1.0/user")
     assert res.status_code == 200
-    assert "password" not in json.loads(res.data.decode())
+    assert "password" not in json.loads(res.text)
 
-    res = app_client.get("/v1.0/user_with_password")  # type: flask.Response
+    res = app_client.get("/v1.0/user_with_password")
     assert res.status_code == 500
     assert (
-        json.loads(res.data.decode())["title"]
+        json.loads(res.text)["title"]
         == "Response body does not conform to specification"
     )
 
@@ -108,17 +116,20 @@ def test_nullable_default(json_validation_spec_dir, spec):
 
 
 @pytest.mark.parametrize("spec", ["openapi.yaml"])
-def test_multipart_form_json(json_validation_spec_dir, spec):
+def test_multipart_form_json(json_validation_spec_dir, spec, app_class):
     app = build_app_from_fixture(
-        json_validation_spec_dir, spec, validate_responses=True
+        json_validation_spec_dir,
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
     )
     app_client = app.test_client()
 
     res = app_client.post(
         "/v1.0/multipart_form_json",
         data={"x": json.dumps({"name": "joe", "age": 20})},
-        content_type="multipart/form-data",
+        headers={"content-type": "multipart/form-data"},
     )
     assert res.status_code == 200
-    assert json.loads(res.data.decode())["name"] == "joe-reply"
-    assert json.loads(res.data.decode())["age"] == 30
+    assert json.loads(res.text)["name"] == "joe-reply"
+    assert json.loads(res.text)["age"] == 30

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -31,9 +31,11 @@ class TestMiddleware:
 
 
 @pytest.fixture(scope="session")
-def middleware_app(spec):
+def middleware_app(spec, app_class):
     middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]
-    return build_app_from_fixture("simple", spec, middlewares=middlewares)
+    return build_app_from_fixture(
+        "simple", app_class=app_class, spec_file=spec, middlewares=middlewares
+    )
 
 
 def test_routing_middleware(middleware_app):

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -190,10 +190,11 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
     assert operation.operation_id == "fakeapi.PetsView.post"
 
 
-def test_method_view_resolver_integration(spec, method_view_resolver):
+def test_method_view_resolver_integration(spec, app_class, method_view_resolver):
     method_view_app = build_app_from_fixture(
         "method_view",
-        spec,
+        app_class=app_class,
+        spec_file=spec,
         resolver=MethodViewResolver("fakeapi.example_method_view"),
     )
 

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -201,13 +201,13 @@ def test_method_view_resolver_integration(spec, app_class, method_view_resolver)
     client = method_view_app.test_client()
 
     r = client.get("/v1.0/pets")
-    assert r.json == [{"name": "get"}]
+    assert r.json() == [{"name": "get"}]
 
     r = client.get("/v1.0/pets/1")
-    assert r.json == {"name": "get", "petId": 1}
+    assert r.json() == {"name": "get", "petId": 1}
 
     r = client.post("/v1.0/pets", json={"name": "Musti"})
-    assert r.json == {"name": "post", "body": {"name": "Musti"}}
+    assert r.json() == {"name": "post", "body": {"name": "Musti"}}
 
     r = client.put("/v1.0/pets/1", json={"name": "Igor"})
-    assert r.json == {"name": "put", "petId": 1, "body": {"name": "Igor"}}
+    assert r.json() == {"name": "put", "petId": 1, "body": {"name": "Igor"}}


### PR DESCRIPTION
Currently, our tests only run against the `FlaskApp`. This PR parametrizes the relevant tests to run against both the `AsyncApp` and `FlaskApp`. 

Unfortunately, the test clients provided by Flask and Starlette are not entirely aligned. This PR addresses this by refactoring the tests so they are framework agnostic.

This increased the number of tests from 483 to 709, of which 66 still fail due to issues with the `AsyncApp`. I will submit separate PRs targeting this branch to fix those.