### PR TITLE
Feature/request context

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -18,8 +18,6 @@ from .resolver import Resolution, Resolver, RestyResolver  # NOQA
 from .utils import not_installed_error  # NOQA
 
 try:
-    from flask import request  # NOQA
-
     from connexion.apps.flask import FlaskApi, FlaskApp
 except ImportError as e:  # pragma: no cover
     _flask_not_installed_error = not_installed_error(e)
@@ -27,6 +25,7 @@ except ImportError as e:  # pragma: no cover
     FlaskApp = _flask_not_installed_error  # type: ignore
 
 from connexion.apps.asynchronous import AsyncApi, AsyncApp
+from connexion.context import request
 from connexion.middleware import ConnexionMiddleware
 
 App = FlaskApp

--- a/connexion/context.py
+++ b/connexion/context.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 from starlette.types import Receive, Scope
 from werkzeug.local import LocalProxy
 
+from connexion.lifecycle import ASGIRequest
 from connexion.operations import AbstractOperation
 
 UNBOUND_MESSAGE = (
@@ -22,3 +23,7 @@ receive = LocalProxy(_receive, unbound_message=UNBOUND_MESSAGE)
 
 _scope: ContextVar[Scope] = ContextVar("SCOPE")
 scope = LocalProxy(_scope, unbound_message=UNBOUND_MESSAGE)
+
+request = LocalProxy(
+    lambda: ASGIRequest(scope, receive), unbound_message=UNBOUND_MESSAGE
+)

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -10,7 +10,7 @@ from connexion.context import operation
 from connexion.datastructures import NoContent
 from connexion.exceptions import NonConformingResponseHeaders
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import ConnexionResponse, MiddlewareResponse
+from connexion.lifecycle import ConnexionResponse
 from connexion.utils import is_json_mimetype
 
 logger = logging.getLogger(__name__)
@@ -160,7 +160,7 @@ class SyncResponseDecorator(BaseResponseDecorator):
             handler_response = function(*args, **kwargs)
             if self.framework.is_framework_response(handler_response):
                 return handler_response
-            elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):
+            elif isinstance(handler_response, ConnexionResponse):
                 return self.framework.connexion_to_framework_response(handler_response)
             else:
                 return self.build_framework_response(handler_response)
@@ -180,7 +180,7 @@ class AsyncResponseDecorator(BaseResponseDecorator):
             handler_response = await function(*args, **kwargs)
             if self.framework.is_framework_response(handler_response):
                 return handler_response
-            elif isinstance(handler_response, (ConnexionResponse, MiddlewareResponse)):
+            elif isinstance(handler_response, ConnexionResponse):
                 return self.framework.connexion_to_framework_response(handler_response)
             else:
                 return self.build_framework_response(handler_response)

--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -12,7 +12,7 @@ import werkzeug.routing
 
 from connexion import jsonifier
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import ConnexionRequest
+from connexion.lifecycle import WSGIRequest
 from connexion.uri_parsing import AbstractURIParser
 
 
@@ -54,8 +54,10 @@ class Flask(Framework):
         return flask.current_app.response_class(**kwargs)
 
     @staticmethod
-    def get_request(*, uri_parser: AbstractURIParser, **kwargs) -> ConnexionRequest:  # type: ignore
-        return ConnexionRequest(flask.request, uri_parser=uri_parser)
+    def get_request(*, uri_parser: AbstractURIParser, **kwargs) -> WSGIRequest:  # type: ignore
+        return WSGIRequest(
+            flask.request, uri_parser=uri_parser, view_args=flask.request.view_args
+        )
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/frameworks/starlette.py
+++ b/connexion/frameworks/starlette.py
@@ -8,15 +8,14 @@ from starlette.responses import Response as StarletteResponse
 from starlette.types import Receive, Scope
 
 from connexion.frameworks.abstract import Framework
-from connexion.lifecycle import MiddlewareRequest, MiddlewareResponse
+from connexion.lifecycle import ASGIRequest
+from connexion.uri_parsing import AbstractURIParser
 
 
 class Starlette(Framework):
     @staticmethod
     def is_framework_response(response: t.Any) -> bool:
-        return isinstance(response, StarletteResponse) and not isinstance(
-            response, MiddlewareResponse
-        )
+        return isinstance(response, StarletteResponse)
 
     @classmethod
     def connexion_to_framework_response(cls, response):
@@ -49,8 +48,8 @@ class Starlette(Framework):
         )
 
     @staticmethod
-    def get_request(*, scope: Scope, receive: Receive, **kwargs) -> MiddlewareRequest:  # type: ignore
-        return MiddlewareRequest(scope, receive)
+    def get_request(*, scope: Scope, receive: Receive, uri_parser: AbstractURIParser, **kwargs) -> ASGIRequest:  # type: ignore
+        return ASGIRequest(scope, receive, uri_parser=uri_parser)
 
 
 PATH_PARAMETER = re.compile(r"\{([^}]*)\}")

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.exceptions import ProblemException
-from connexion.lifecycle import MiddlewareRequest
+from connexion.lifecycle import ASGIRequest
 from connexion.middleware.abstract import RoutedAPI, RoutedMiddleware
 from connexion.operations import AbstractOperation
 from connexion.security import SecurityHandlerFactory
@@ -199,7 +199,7 @@ class SecurityOperation:
         return self.security_handler_factory.verify_security(auth_funcs)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        request = MiddlewareRequest(scope)
+        request = ASGIRequest(scope)
         await self.verification_fn(request)
         await self.next_app(scope, receive, send)
 

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from connexion.decorators.parameter import (
     AsyncParameterDecorator,
@@ -28,7 +28,7 @@ def test_sync_injection():
 
 
 async def test_async_injection():
-    request = MagicMock(name="request")
+    request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}
 
     func = MagicMock()
@@ -68,7 +68,7 @@ def test_sync_injection_with_context():
 
 
 async def test_async_injection_with_context():
-    request = MagicMock(name="request")
+    request = AsyncMock(name="request")
     request.path_params = {"p1": "123"}
 
     func = MagicMock()

--- a/tests/fakeapi/example_method_class.py
+++ b/tests/fakeapi/example_method_class.py
@@ -1,0 +1,32 @@
+class PetsView:
+
+    mycontent = "demonstrate return from MethodView class"
+
+    def get(self, **kwargs):
+        if kwargs:
+            kwargs.update({"name": "get"})
+            return kwargs
+        else:
+            return [{"name": "get"}]
+
+    def search(self):
+        return [{"name": "search"}]
+
+    def post(self, **kwargs):
+        kwargs.update({"name": "post"})
+        return kwargs, 201
+
+    def put(self, *args, **kwargs):
+        kwargs.update({"name": "put"})
+        return kwargs, 201
+
+    def delete(self, **kwargs):
+        return 201
+
+    # Test that operation_id can still override resolver
+
+    def api_list(self):
+        return "api_list"
+
+    def post_greeting(self):
+        return "post_greeting"

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
 import datetime
 import uuid
 
 from connexion import NoContent, ProblemException, context, request
 from connexion.exceptions import OAuthProblem
 from flask import jsonify, redirect, send_file
+from starlette.responses import FileResponse
 
 
 class DummyClass:
@@ -75,8 +75,8 @@ def get_bye(name):
     return f"Goodbye {name}"
 
 
-def get_flask_response_tuple():
-    return jsonify({"foo": "bar"}), 201
+def get_response_tuple():
+    return {"foo": "bar"}, 201
 
 
 def get_bye_secure(name, user, token_info):
@@ -652,7 +652,11 @@ def nullable_default(test):
 
 
 def get_streaming_response():
-    return send_file(__file__)
+    try:
+        return send_file(__file__)
+    except RuntimeError:
+        # Not in Flask context
+        return FileResponse(__file__)
 
 
 async def async_route():

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -88,11 +88,11 @@ paths:
           required: true
           schema:
             type: string
-  /flask_response_tuple:
+  /response_tuple:
     get:
-      summary: Return flask response tuple
-      description: Test returning a flask response tuple
-      operationId: fakeapi.hello.get_flask_response_tuple
+      summary: Return response tuple
+      description: Test returning a response tuple
+      operationId: fakeapi.hello.get_response_tuple
       responses:
         '200':
           description: json response

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -85,11 +85,11 @@ paths:
           required: true
           type: string
 
-  /flask_response_tuple:
+  /response_tuple:
     get:
-      summary: Return flask response tuple
-      description: Test returning a flask response tuple
-      operationId: fakeapi.hello.get_flask_response_tuple
+      summary: Return response tuple
+      description: Test returning a response tuple
+      operationId: fakeapi.hello.get_response_tuple
       produces:
         - application/json
       responses:


### PR DESCRIPTION
This PR fixes 'outside of Flask context' errors in our test suite and contains the following changes:

- `Connexion.request` is now a Connexion `ASGIRequest` instead of a Flask `request`
- All other tests with a Flask dependency have been updated or split

Failing tests are down to 11.
