### PR TITLE
Re-add tests for multiple and mixed file uploads

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -135,7 +135,7 @@ def prep_kwargs(
         arguments=arguments,
         has_kwargs=has_kwargs,
         sanitize=sanitize,
-        content_type=request.content_type,
+        content_type=request.mimetype,
     )
 
     # optionally convert parameter variable names to un-shadowed, snake_case form

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -266,6 +266,39 @@ def test_formdata_file_upload(simple_app):
     assert resp.json() == {"filename.txt": "file contents"}
 
 
+def test_formdata_multiple_file_upload(simple_app):
+    app_client = simple_app.test_client()
+    resp = app_client.post(
+        "/v1.0/test-formData-file-upload",
+        files=[
+            ("fileData", ("filename.txt", BytesIO(b"file contents"))),
+            ("fileData", ("filename2.txt", BytesIO(b"file2 contents"))),
+        ],
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "filename.txt": "file contents",
+        "filename2.txt": "file2 contents",
+    }
+
+
+def test_mixed_formdata(simple_app):
+    app_client = simple_app.test_client()
+    resp = app_client.post(
+        "/v1.0/test-mixed-formData",
+        data={"formData": "test"},
+        files={"fileData": ("filename.txt", BytesIO(b"file contents"))},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": {"formData": "test"},
+        "files": {
+            "filename.txt": "file contents",
+        },
+    }
+
+
 def test_formdata_file_upload_bad_request(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.post("/v1.0/test-formData-file-upload")

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -318,16 +318,45 @@ def test_formdata_missing_param():
 
 async def test_formdata_file_upload(fileData, **kwargs):
     """In Swagger, form paramaeters and files are passed separately"""
-    file_ = fileData[0]
-    try:
+    files = {}
+    for file_ in fileData:
         filename = file_.filename
-    except AttributeError:
-        filename = file_.name
-    contents = file_.read()
-    if asyncio.iscoroutine(contents):
-        contents = await contents
-    contents = contents.decode("utf-8", "replace")
-    return {filename: contents}
+        content = file_.read()
+        if asyncio.iscoroutine(content):
+            # AsyncApp
+            content = await content
+
+        files[filename] = content.decode()
+
+    return files
+
+
+async def test_mixed_formdata(fileData, formData):
+    files = {}
+    for file_ in fileData:
+        filename = file_.filename
+        content = file_.read()
+        if asyncio.iscoroutine(content):
+            # AsyncApp
+            content = await content
+
+        files[filename] = content.decode()
+
+    return {"data": {"formData": formData}, "files": files}
+
+
+async def test_mixed_formdata3(fileData, formData):
+    files = {}
+    for file_ in fileData:
+        filename = file_.filename
+        content = file_.read()
+        if asyncio.iscoroutine(content):
+            # AsyncApp
+            content = await content
+
+        files[filename] = content.decode()
+
+    return {"data": formData, "files": files}
 
 
 def test_formdata_file_upload_missing_param():

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -605,6 +605,28 @@ paths:
                   format: binary
               required:
                 - fileData
+  /test-mixed-formData:
+    post:
+      summary: 'Test formData with file type, for file upload'
+      operationId: fakeapi.hello.test_mixed_formdata3
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        x-body-name: formData
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                formData:
+                  type: string
+                fileData:
+                  type: string
+                  format: binary
+              required:
+                - formData
+                - fileData
   /test-formData-file-upload-missing-param:
     post:
       summary: 'Test formData with file type, missing parameter in handler'

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -465,6 +465,25 @@ paths:
         200:
           description: OK
 
+  /test-mixed-formData:
+    post:
+      summary: 'Test formData with file type, for file upload'
+      operationId: fakeapi.hello.test_mixed_formdata
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: fileData
+          type: file
+          in: formData
+          required: true
+        - name: formData
+          type: string
+          in: formData
+          required: true
+      responses:
+        200:
+          description: OK
+
   /test-formData-file-upload-missing-param:
     post:
       summary: Test formData with file type, missing parameter in handler


### PR DESCRIPTION
Fixes #992

This PR re-adds tests that were removed when dropping aiohttp, as raised in https://github.com/spec-first/connexion/issues/1395#issuecomment-1175591898.
