### PR TITLE
Update NumberConverter regex to match new Werkzeug behavior (v3)

### DIFF
--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -131,7 +131,7 @@ class FlaskJSONProvider(flask.json.provider.DefaultJSONProvider):
 class NumberConverter(werkzeug.routing.BaseConverter):
     """Flask converter for OpenAPI number type"""
 
-    regex = r"[+-]?[0-9]*(\.[0-9]*)?"
+    regex = r"[+-]?[0-9]*(?:\.[0-9]*)?"
 
     def to_python(self, value):
         return float(value)

--- a/examples/helloworld/spec/openapi.yaml
+++ b/examples/helloworld/spec/openapi.yaml
@@ -28,3 +28,8 @@ paths:
           schema:
             type: string
             example: "dave"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -181,6 +181,19 @@ def test_path_parameter_somefloat(simple_app, arg, result):
     assert resp.text == f'"{result}"\n'
 
 
+@pytest.mark.parametrize(
+    "arg, arg2, result",
+    [
+        ["-0.000000001", "0.3", "float -1e-09, 0.3"],
+    ],
+)
+def test_path_parameter_doublefloat(simple_app, arg, arg2, result):
+    assert isinstance(arg, str) and isinstance(arg2, str)  # sanity check
+    app_client = simple_app.test_client()
+    resp = app_client.get(f"/v1.0/test-float-path/{arg}/{arg2}")
+    assert resp.text == f'"{result}"\n'
+
+
 def test_path_parameter_somefloat__bad(simple_app):
     # non-float values will not match Flask route
     app_client = simple_app.test_client()

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -280,6 +280,10 @@ def test_get_somefloat(somefloat):
     return f"{type(somefloat).__name__} {somefloat:g}"
 
 
+def test_get_doublefloat(somefloat, someotherfloat):
+    return f"{type(somefloat).__name__} {somefloat:g}, {someotherfloat}"
+
+
 def test_default_param(name):
     return {"app_name": name}
 

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -526,6 +526,24 @@ paths:
       responses:
         '200':
           description: OK
+  '/test-float-path/{somefloat}/{someotherfloat}':
+    get:
+      summary: Test type casting of path parameter
+      operationId: fakeapi.hello.test_get_doublefloat
+      parameters:
+        - name: somefloat
+          in: path
+          required: true
+          schema:
+            type: number
+        - name: someotherfloat
+          in: path
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: OK
   /test-default-query-parameter:
     get:
       summary: Test if default parameter is passed to function

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -394,6 +394,23 @@ paths:
         200:
           description: OK
 
+  /test-float-path/{somefloat}/{someotherfloat}:
+    get:
+      summary: Test type casting of path parameter
+      operationId: fakeapi.hello.test_get_doublefloat
+      parameters:
+        - name: somefloat
+          in: path
+          type: number
+          required: true
+        - name: someotherfloat
+          in: path
+          type: number
+          required: true
+      responses:
+        200:
+          description: O
+
   /test-default-query-parameter:
     get:
       summary: Test if default parameter is passed to function


### PR DESCRIPTION
Fixes #1635

See https://github.com/pallets/werkzeug/issues/2518. 
Apparently, this is only an issue when you have more than 1 path parameter, so added a test for that.
