### PR TITLE
Update quickstart.rst to include example of passing server arguments

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -96,6 +96,15 @@ to ``tornado`` or ``gevent``:
     app = connexion.FlaskApp(__name__, port = 8080, specification_dir='openapi/', server='tornado')
 
 
+Additoinally you can pass the parameters for the corresponding server as a dictionary using the `server_args` parameter. Hence in scenarios like serving static content, you can pass the parameters as given here:
+
+.. code-block:: python
+
+    import connexion
+
+    app = connexion.FlaskApp(__name__, port = 8080, specification_dir='openapi/', server='flask', server_args={'static_url_path':"/", 'static_folder':"whereever/your/static/files/are"})
+
+
 .. _Jinja2: http://jinja.pocoo.org/
 .. _Tornado: http://www.tornadoweb.org/en/stable/
 .. _gevent: http://www.gevent.org/

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -96,13 +96,19 @@ to ``tornado`` or ``gevent``:
     app = connexion.FlaskApp(__name__, port = 8080, specification_dir='openapi/', server='tornado')
 
 
-Additoinally you can pass the parameters for the corresponding server as a dictionary using the `server_args` parameter. Hence in scenarios like serving static content, you can pass the parameters as given here:
+Additionally, you can pass the parameters for the corresponding server as a dictionary using the `server_args` parameter. For example, in a scenario where you're serving static content, you can pass the parameters as follows:
 
 .. code-block:: python
 
     import connexion
 
-    app = connexion.FlaskApp(__name__, port = 8080, specification_dir='openapi/', server='flask', server_args={'static_url_path':"/", 'static_folder':"whereever/your/static/files/are"})
+    app = connexion.FlaskApp(
+        __name__,
+        port=8080,
+        specification_dir='openapi/',
+        server='flask',
+        server_args={'static_url_path': '/', 'static_folder': 'wherever/your/static/files/are'}
+    )
 
 
 .. _Jinja2: http://jinja.pocoo.org/


### PR DESCRIPTION
Changes proposed in this pull request:
 - Updated the docs such that it comes with an example for passing server arguments and serving static files
