### PR TITLE
Add support for relative refs in spec

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,11 @@ def json_datetime_dir():
     return FIXTURES_FOLDER / "datetime_support"
 
 
+@pytest.fixture(scope="session")
+def relative_refs():
+    return FIXTURES_FOLDER / "relative_refs"
+
+
 @pytest.fixture(scope="session", params=SPECS)
 def spec(request):
     return request.param

--- a/tests/fixtures/relative_refs/components.yaml
+++ b/tests/fixtures/relative_refs/components.yaml
@@ -1,0 +1,37 @@
+components:
+  schemas:
+    Pet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: fluffy
+        tag:
+          type: string
+          example: red
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+          example: 1
+        last_updated:
+          type: string
+          readOnly: true
+          example: 2019-01-16T23:52:54.309102Z
+
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+
+    Error:
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/tests/fixtures/relative_refs/definitions.yaml
+++ b/tests/fixtures/relative_refs/definitions.yaml
@@ -1,0 +1,29 @@
+definitions:
+  Pet:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      registered:
+        type: string
+        format: date-time
+
+  Pets:
+    type: array
+    items:
+      $ref: "#/definitions/Pet"
+
+  Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+    required:
+      - code
+      - message

--- a/tests/fixtures/relative_refs/openapi.yaml
+++ b/tests/fixtures/relative_refs/openapi.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+
+servers:
+  - url: /openapi
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/Pets"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/Error"
+
+  '/pets/{petId}':
+    get:
+      summary: Info for a specific pet
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/Pet"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/Error"

--- a/tests/fixtures/relative_refs/swagger.yaml
+++ b/tests/fixtures/relative_refs/swagger.yaml
@@ -1,0 +1,36 @@
+swagger: "2.0"
+
+info:
+  title: "{{title}}"
+  version: "1.0"
+
+basePath: /swagger
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      responses:
+        '200':
+          description: A paged array of pets
+          schema:
+            type: array
+            items:
+              $ref: 'definitions.yaml#/definitions/Pets'
+        default:
+          description: Unexpected Error
+          schema:
+            $ref:  'definitions.yaml#/definitions/Error'
+
+  '/pets/{id}':
+    get:
+      summary: Info for a specific pet
+      responses:
+        '200':
+          description: Expected response to a valid request
+          schema:
+            $ref: 'definitions.yaml#/definitions/Pet'
+        default:
+          description: Unexpected Error
+          schema:
+            $ref:  'definitions.yaml#/definitions/Error'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from connexion import FlaskApi
 from connexion.exceptions import InvalidSpecification
-from connexion.spec import canonical_base_path
+from connexion.spec import Specification, canonical_base_path
 from yaml import YAMLError
 
 TEST_FOLDER = pathlib.Path(__file__).parent
@@ -136,6 +136,12 @@ def test_validation_error_on_completely_invalid_swagger_spec():
     with pytest.raises(InvalidSpecification):
         FlaskApi(pathlib.Path(f.name), base_path="/api/v1.0")
     os.unlink(f.name)
+
+
+def test_relative_refs(relative_refs, spec):
+    spec_path = relative_refs / spec
+    specification = Specification.load(spec_path)
+    assert "$ref" not in specification.raw
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #254 
Fixes #967 

This PR fixes the very long-standing issue of being able to handle relative references, which allows users to split their specification into multiple files.