### PR TITLE
Enable response mimetype validation for non-error responses

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -64,7 +64,7 @@ class BaseResponseDecorator:
             if not produces:
                 # Produces can be empty/ for empty responses
                 pass
-            if len(produces) == 1:
+            elif len(produces) == 1:
                 content_type = produces[0]
             elif isinstance(data, str) and "text/plain" in produces:
                 content_type = "text/plain"

--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -53,10 +53,13 @@ class RequestValidationOperation:
         return mime_type, encoding
 
     def validate_mime_type(self, mime_type: str) -> None:
-        """Validate the mime type against the spec.
+        """Validate the mime type against the spec if it defines which mime types are accepted.
 
         :param mime_type: mime type from content type header
         """
+        if not self._operation.consumes:
+            return
+
         # Convert to MediaTypeDict to handle media-ranges
         media_type_dict = MediaTypeDict(
             [(c.lower(), None) for c in self._operation.consumes]

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -128,7 +128,7 @@ class OpenAPIOperation(AbstractOperation):
     def consumes(self):
         if self._consumes is None:
             request_content = self.request_body.get("content", {})
-            self._consumes = list(request_content.keys()) or ["application/json"]
+            self._consumes = list(request_content.keys())
         return self._consumes
 
     @property

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -94,7 +94,7 @@ class OpenAPIOperation(AbstractOperation):
         response_content_types = []
         for _, defn in self._responses.items():
             response_content_types += defn.get("content", {}).keys()
-        self._produces = response_content_types or ["application/json"]
+        self._produces = response_content_types
         self._consumes = None
 
         logger.debug("consumes: %s" % self.consumes)

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -433,7 +433,7 @@ def test_get_bad_default_response(simple_app):
 def test_streaming_response(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/get_streaming_response")
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
 
 
 def test_oneof(simple_openapi_app):

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1269,7 +1269,7 @@ paths:
         '200':
           description: OK
           content:
-            application/octet-stream:
+            text/x-python:
               schema:
                 type: string
                 format: binary


### PR DESCRIPTION
Addresses a todo left in the code.

We only validate the mimetype if the spec defines which mime-types it produces, and only for non-error responses.