### PR TITLE
Don't return 400 when read-only property is provided

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -121,34 +121,6 @@ def allow_nullable(validation_fn: t.Callable) -> t.Callable:
     return nullable_validation_fn
 
 
-def validate_required(validator, required, instance, schema):
-    if not validator.is_type(instance, "object"):
-        return
-
-    for prop in required:
-        if prop not in instance:
-            properties = schema.get("properties")
-            if properties is not None:
-                subschema = properties.get(prop)
-                if subschema is not None:
-                    if "readOnly" in validator.VALIDATORS and subschema.get("readOnly"):
-                        continue
-                    if "writeOnly" in validator.VALIDATORS and subschema.get(
-                        "writeOnly"
-                    ):
-                        continue
-                    if (
-                        "x-writeOnly" in validator.VALIDATORS
-                        and subschema.get("x-writeOnly") is True
-                    ):
-                        continue
-            yield ValidationError("%r is a required property" % prop)
-
-
-def validate_readOnly(validator, ro, instance, schema):
-    yield ValidationError("Property is read-only")
-
-
 def validate_writeOnly(validator, wo, instance, schema):
     yield ValidationError("Property is write-only")
 
@@ -161,8 +133,6 @@ Draft4RequestValidator = extend(
     {
         "type": NullableTypeValidator,
         "enum": NullableEnumValidator,
-        "required": validate_required,
-        "readOnly": validate_readOnly,
     },
 )
 
@@ -171,7 +141,6 @@ Draft4ResponseValidator = extend(
     {
         "type": NullableTypeValidator,
         "enum": NullableEnumValidator,
-        "required": validate_required,
         "writeOnly": validate_writeOnly,
         "x-writeOnly": validate_writeOnly,
     },

--- a/tests/fixtures/json_validation/openapi.yaml
+++ b/tests/fixtures/json_validation/openapi.yaml
@@ -13,8 +13,6 @@ components:
       type: object
       required:
       - name
-      - user_id
-      - password
       properties:
         user_id:
           type: integer

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -59,8 +59,6 @@ def test_readonly(json_validation_spec_dir, spec, app_class):
     )
     app_client = app.test_client()
 
-    headers = {"content-type": "application/json"}
-
     res = app_client.get("/v1.0/user")
     assert res.status_code == 200
     assert res.json().get("user_id") == 7
@@ -76,7 +74,7 @@ def test_readonly(json_validation_spec_dir, spec, app_class):
         "/v1.0/user",
         json={"user_id": 9, "name": "max"},
     )
-    assert res.status_code == 400
+    assert res.status_code == 200
 
 
 def test_writeonly(json_validation_spec_dir, spec, app_class):


### PR DESCRIPTION
Fixes #942 

No longer return 400 if a read-only property is provided, as discussed in the issue. We still raise an error if write-only properties are included in the response and response validation is enabled.

I also changed how read-/write-only works in combination with `required`. Previously, `required` would not be overwritten by read-/write-only. Now we just follow the spec to the letter:
- required and read-only: must be included but must be ignored by the server
- required and write-only: impossible to achieve, but I also don't see how this combination could make sense
- read-only: may be included but must be ignored by server
- write-only: must not be included by server