### PR TITLE
Add jsonifier as argument to app / api

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -9,6 +9,7 @@ import typing as t
 from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
+from connexion.jsonifier import Jsonifier
 from connexion.middleware import ConnexionMiddleware, SpecMiddleware
 from connexion.resolver import Resolver
 from connexion.uri_parsing import AbstractURIParser
@@ -35,6 +36,7 @@ class AbstractApp:
         middlewares: t.Optional[list] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -56,6 +58,7 @@ class AbstractApp:
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
         :param resolver: Callable that maps operationId to a function or instance of
@@ -80,6 +83,7 @@ class AbstractApp:
             middlewares=middlewares,
             arguments=arguments,
             auth_all_paths=auth_all_paths,
+            jsonifier=jsonifier,
             swagger_ui_options=swagger_ui_options,
             pythonic_params=pythonic_params,
             resolver=resolver,
@@ -97,6 +101,7 @@ class AbstractApp:
         base_path: t.Optional[str] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -118,6 +123,7 @@ class AbstractApp:
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
         :param resolver: Callable that maps operationId to a function or instance of
@@ -145,6 +151,7 @@ class AbstractApp:
             base_path=base_path,
             arguments=arguments,
             auth_all_paths=auth_all_paths,
+            jsonifier=jsonifier,
             pythonic_params=pythonic_params,
             resolver=resolver,
             resolver_error=resolver_error,

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -71,12 +71,16 @@ class AsyncOperation:
 
 
 class AsyncApi(RoutedAPI[AsyncOperation]):
-
-    jsonifier = Jsonifier()
-
-    def __init__(self, *args, pythonic_params: bool, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        pythonic_params: bool,
+        jsonifier: t.Optional[Jsonifier] = None,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.pythonic_params = pythonic_params
+        self.jsonifier = jsonifier or Jsonifier()
         self.router = Router()
         self.add_paths()
 
@@ -124,6 +128,7 @@ class AsyncApp(AbstractApp):
         middlewares: t.Optional[list] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -145,6 +150,7 @@ class AsyncApp(AbstractApp):
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
         :param resolver: Callable that maps operationId to a function or instance of
@@ -170,11 +176,12 @@ class AsyncApp(AbstractApp):
             middlewares=middlewares,
             arguments=arguments,
             auth_all_paths=auth_all_paths,
-            swagger_ui_options=swagger_ui_options,
+            jsonifier=jsonifier,
             pythonic_params=pythonic_params,
             resolver=resolver,
             resolver_error=resolver_error,
             strict_validation=strict_validation,
+            swagger_ui_options=swagger_ui_options,
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -39,11 +39,15 @@ class FlaskOperation:
 
     @classmethod
     def from_operation(
-        cls, operation: AbstractOperation, pythonic_params: bool
+        cls,
+        operation: AbstractOperation,
+        *,
+        pythonic_params: bool,
+        jsonifier: Jsonifier,
     ) -> "FlaskOperation":
         return cls(
             fn=operation.function,
-            jsonifier=operation.api.jsonifier,
+            jsonifier=jsonifier,
             operation_id=operation.operation_id,
             pythonic_params=pythonic_params,
         )
@@ -81,7 +85,7 @@ class FlaskApi(AbstractRoutingAPI):
 
     def make_operation(self, operation):
         return FlaskOperation.from_operation(
-            operation, pythonic_params=self.pythonic_params
+            operation, pythonic_params=self.pythonic_params, jsonifier=self.jsonifier
         )
 
     @staticmethod

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -65,8 +65,11 @@ class FlaskOperation:
 
 
 class FlaskApi(AbstractRoutingAPI):
-
-    jsonifier = Jsonifier(flask.json, indent=2)
+    def __init__(
+        self, *args, jsonifier: t.Optional[Jsonifier] = None, **kwargs
+    ) -> None:
+        self.jsonifier = jsonifier or Jsonifier(flask.json, indent=2)
+        super().__init__(*args, **kwargs)
 
     def _set_base_path(self, base_path: t.Optional[str] = None) -> None:
         super()._set_base_path(base_path)
@@ -177,6 +180,7 @@ class FlaskApp(AbstractApp):
         middlewares: t.Optional[list] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -199,6 +203,7 @@ class FlaskApp(AbstractApp):
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param swagger_ui_options: A :class:`options.ConnexionOptions` instance with configuration
             options for the swagger ui.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
@@ -224,6 +229,7 @@ class FlaskApp(AbstractApp):
             middlewares=middlewares,
             arguments=arguments,
             auth_all_paths=auth_all_paths,
+            jsonifier=jsonifier,
             pythonic_params=pythonic_params,
             resolver=resolver,
             resolver_error=resolver_error,

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -7,7 +7,6 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.exceptions import MissingMiddleware, ResolverError
 from connexion.http_facts import METHODS
-from connexion.jsonifier import Jsonifier
 from connexion.operations import AbstractOperation
 from connexion.resolver import Resolver
 from connexion.spec import Specification
@@ -37,8 +36,6 @@ class SpecMiddleware(abc.ABC):
 
 class AbstractSpecAPI:
     """Base API class with only minimal behavior related to the specification."""
-
-    jsonifier = Jsonifier()
 
     def __init__(
         self,
@@ -126,10 +123,9 @@ class AbstractRoutingAPI(AbstractSpecAPI, t.Generic[OP]):
         spec_operation_cls = self.specification.operation_cls
         spec_operation = spec_operation_cls.from_spec(
             self.specification,
-            self,
-            path,
-            method,
-            self.resolver,
+            path=path,
+            method=method,
+            resolver=self.resolver,
             uri_parser_class=self.uri_parser_class,
         )
         operation = self.make_operation(spec_operation)
@@ -175,9 +171,6 @@ class AbstractRoutingAPI(AbstractSpecAPI, t.Generic[OP]):
         logger.error(error_msg)
         raise exc from None
 
-    def json_loads(self, data):
-        return self.jsonifier.loads(data)
-
 
 class RoutedAPI(AbstractSpecAPI, t.Generic[OP]):
     def __init__(
@@ -207,10 +200,9 @@ class RoutedAPI(AbstractSpecAPI, t.Generic[OP]):
         operation_spec_cls = self.specification.operation_cls
         operation = operation_spec_cls.from_spec(
             self.specification,
-            self,
-            path,
-            method,
-            self.resolver,
+            path=path,
+            method=method,
+            resolver=self.resolver,
             uri_parser_class=self.uri_parser_class,
         )
         routed_operation = self.make_operation(operation)

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -8,6 +8,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion import utils
 from connexion.handlers import ResolverErrorHandler
+from connexion.jsonifier import Jsonifier
 from connexion.middleware.abstract import SpecMiddleware
 from connexion.middleware.context import ContextMiddleware
 from connexion.middleware.exceptions import ExceptionMiddleware
@@ -39,6 +40,7 @@ class _Options:
 
     arguments: t.Optional[dict] = None
     auth_all_paths: t.Optional[bool] = False
+    jsonifier: t.Optional[Jsonifier] = None
     pythonic_params: t.Optional[bool] = False
     resolver: t.Optional[t.Union[Resolver, t.Callable]] = None
     resolver_error: t.Optional[int] = None
@@ -101,6 +103,7 @@ class ConnexionMiddleware:
         middlewares: t.Optional[list] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -122,6 +125,7 @@ class ConnexionMiddleware:
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
         :param resolver: Callable that maps operationId to a function or instance of
@@ -151,6 +155,7 @@ class ConnexionMiddleware:
         self.options = _Options(
             arguments=arguments,
             auth_all_paths=auth_all_paths,
+            jsonifier=jsonifier,
             pythonic_params=pythonic_params,
             resolver=resolver,
             resolver_error=resolver_error,
@@ -198,6 +203,7 @@ class ConnexionMiddleware:
         base_path: t.Optional[str] = None,
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
+        jsonifier: t.Optional[Jsonifier] = None,
         pythonic_params: t.Optional[bool] = None,
         resolver: t.Optional[t.Union[Resolver, t.Callable]] = None,
         resolver_error: t.Optional[int] = None,
@@ -219,6 +225,7 @@ class ConnexionMiddleware:
         :param arguments: Arguments to substitute the specification using Jinja.
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
+        :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
         :param resolver: Callable that maps operationId to a function or instance of
@@ -254,6 +261,7 @@ class ConnexionMiddleware:
         options = self.options.replace(
             arguments=arguments,
             auth_all_paths=auth_all_paths,
+            jsonifier=jsonifier,
             swagger_ui_options=swagger_ui_options,
             pythonic_params=pythonic_params,
             resolver=resolver,

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pathlib
 import re
@@ -12,6 +13,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from connexion.jsonifier import Jsonifier
 from connexion.middleware import SpecMiddleware
 from connexion.middleware.abstract import AbstractSpecAPI
 from connexion.options import SwaggerUIOptions
@@ -99,8 +101,11 @@ class SwaggerUIAPI(AbstractSpecAPI):
         )
 
     async def _get_openapi_json(self, request):
+        # Yaml parses datetime objects when loading the spec, so we need our custom jsonifier to dump it
+        jsonifier = Jsonifier()
+
         return StarletteResponse(
-            content=self.jsonifier.dumps(self._spec_for_prefix(request)),
+            content=jsonifier.dumps(self._spec_for_prefix(request)),
             status_code=200,
             media_type="application/json",
         )
@@ -170,7 +175,7 @@ class SwaggerUIAPI(AbstractSpecAPI):
         return StarletteResponse(
             status_code=200,
             media_type="application/json",
-            content=self.jsonifier.dumps(self.options.openapi_console_ui_config),
+            content=json.dumps(self.options.openapi_console_ui_config),
         )
 
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -34,7 +34,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        api,
         method,
         path,
         operation,
@@ -45,8 +44,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         uri_parser_class=None,
     ):
         """
-        :param api: api that this operation is attached to
-        :type api: apis.AbstractAPI
         :param method: HTTP method
         :type method: str
         :param path:
@@ -64,7 +61,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :param uri_parser_class: class to use for uri parsing
         :type uri_parser_class: AbstractURIParser
         """
-        self._api = api
         self._method = method
         self._path = path
         self._operation = operation
@@ -79,10 +75,6 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         self._operation_id = self._resolution.operation_id
 
         self._responses = self._operation.get("responses", {})
-
-    @property
-    def api(self):
-        return self._api
 
     @property
     def method(self):
@@ -246,12 +238,3 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         :rtype: types.FunctionType
         """
         return self._resolution.function
-
-    def json_loads(self, data):
-        """
-        A wrapper for calling the API specific JSON loader.
-
-        :param data: The JSON data in textual form.
-        :type data: bytes
-        """
-        return self.api.json_loads(data)

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -20,7 +20,6 @@ class OpenAPIOperation(AbstractOperation):
 
     def __init__(
         self,
-        api,
         method,
         path,
         operation,
@@ -71,7 +70,6 @@ class OpenAPIOperation(AbstractOperation):
         self._router_controller = operation.get("x-openapi-router-controller")
 
         super().__init__(
-            api=api,
             method=method,
             path=path,
             operation=operation,
@@ -101,9 +99,8 @@ class OpenAPIOperation(AbstractOperation):
         logger.debug("produces: %s" % self.produces)
 
     @classmethod
-    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+    def from_spec(cls, spec, *args, path, method, resolver, **kwargs):
         return cls(
-            api,
             method,
             path,
             spec.get_operation(path, method),

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -35,7 +35,6 @@ class Swagger2Operation(AbstractOperation):
 
     def __init__(
         self,
-        api,
         method,
         path,
         operation,
@@ -50,8 +49,6 @@ class Swagger2Operation(AbstractOperation):
         uri_parser_class=None,
     ):
         """
-        :param api: api that this operation is attached to
-        :type api: apis.AbstractAPI
         :param method: HTTP method
         :type method: str
         :param path: relative path to this operation
@@ -84,7 +81,6 @@ class Swagger2Operation(AbstractOperation):
         self._router_controller = operation.get("x-swagger-router-controller")
 
         super().__init__(
-            api=api,
             method=method,
             path=path,
             operation=operation,
@@ -107,9 +103,8 @@ class Swagger2Operation(AbstractOperation):
         self._responses = operation.get("responses", {})
 
     @classmethod
-    def from_spec(cls, spec, api, path, method, resolver, *args, **kwargs):
+    def from_spec(cls, spec, *args, path, method, resolver, **kwargs):
         return cls(
-            api,
             method,
             path,
             spec.get_operation(path, method),

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -50,7 +50,7 @@ def test_readonly(json_datetime_dir, spec, app_class):
     app_client = app.test_client()
 
     res = app_client.get("/v1.0/" + spec.replace("yaml", "json"))
-    assert res.status_code == 200, f"Error is {res.data}"
+    assert res.status_code == 200, f"Error is {res.text}"
     spec_data = res.json()
 
     if spec == "openapi.yaml":

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -8,7 +8,6 @@ def test_mock_resolver_default():
     responses = {"default": {"examples": {"application/json": {"foo": "bar"}}}}
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -31,7 +30,6 @@ def test_mock_resolver_numeric():
     responses = {"200": {"examples": {"application/json": {"foo": "bar"}}}}
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -62,7 +60,6 @@ def test_mock_resolver_example():
     }
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -92,7 +89,6 @@ def test_mock_resolver_example_nested_in_object():
     }
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -122,7 +118,6 @@ def test_mock_resolver_example_nested_in_list():
     }
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -156,7 +151,6 @@ def test_mock_resolver_example_nested_in_object_openapi():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -187,7 +181,6 @@ def test_mock_resolver_example_nested_in_list_openapi():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -218,7 +211,6 @@ def test_mock_resolver_no_example_nested_in_object():
     }
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -254,7 +246,6 @@ def test_mock_resolver_no_example_nested_in_list_openapi():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -274,7 +265,6 @@ def test_mock_resolver_no_examples():
     responses = {"418": {}}
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -298,7 +288,6 @@ def test_mock_resolver_notimplemented():
 
     # do not mock the existent functions
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -312,7 +301,6 @@ def test_mock_resolver_notimplemented():
 
     # mock only the nonexistent ones
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -16,7 +16,6 @@ def test_mock_resolver_default():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -44,7 +43,6 @@ def test_mock_resolver_numeric():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -76,7 +74,6 @@ def test_mock_resolver_inline_schema_example():
     }
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -96,7 +93,6 @@ def test_mock_resolver_no_examples():
     responses = {"418": {}}
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -117,7 +113,6 @@ def test_mock_resolver_notimplemented():
 
     # do not mock the existent functions
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -128,7 +123,6 @@ def test_mock_resolver_notimplemented():
 
     # mock only the nonexistent ones
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -398,7 +398,6 @@ def make_operation(op, definitions=True, parameters=True):
 def test_operation(api):
     op_spec = make_operation(OPERATION1)
     operation = Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -445,7 +444,6 @@ def test_operation_remote_token_info():
 def test_operation_array(api):
     op_spec = make_operation(OPERATION7)
     operation = Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -472,7 +470,6 @@ def test_operation_array(api):
 def test_operation_composed_definition(api):
     op_spec = make_operation(OPERATION8)
     operation = Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -533,7 +530,6 @@ def test_multi_body(api):
     with pytest.raises(InvalidSpecification) as exc_info:  # type: py.code.ExceptionInfo
         op_spec = make_operation(OPERATION2)
         operation = Swagger2Operation(
-            api=api,
             method="GET",
             path="endpoint",
             path_parameters=[],
@@ -620,7 +616,6 @@ def test_multiple_oauth_in_and(caplog):
 def test_parameter_reference(api):
     op_spec = make_operation(OPERATION3, definitions=False)
     operation = Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -637,7 +632,6 @@ def test_default(api):
     op_spec = make_operation(OPERATION4)
     op_spec["parameters"][1]["default"] = 1
     Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -655,7 +649,6 @@ def test_default(api):
         "new_traffic": 100,
     }
     Swagger2Operation(
-        api=api,
         method="POST",
         path="endpoint",
         path_parameters=[],
@@ -676,7 +669,6 @@ def test_get_path_parameter_types(api):
     ]
 
     operation = Swagger2Operation(
-        api=api,
         method="GET",
         path="endpoint",
         path_parameters=[],

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -54,7 +54,6 @@ def test_bad_operation_id():
 
 def test_standard_resolve_x_router_controller():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -72,7 +71,6 @@ def test_standard_resolve_x_router_controller():
 
 def test_relative_resolve_x_router_controller():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -90,7 +88,6 @@ def test_relative_resolve_x_router_controller():
 
 def test_relative_resolve_operation_id():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -109,7 +106,6 @@ def test_relative_resolve_operation_id_with_module():
     import fakeapi
 
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -126,7 +122,6 @@ def test_relative_resolve_operation_id_with_module():
 
 def test_resty_resolve_operation_id():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -143,7 +138,6 @@ def test_resty_resolve_operation_id():
 
 def test_resty_resolve_x_router_controller_with_operation_id():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -161,7 +155,6 @@ def test_resty_resolve_x_router_controller_with_operation_id():
 
 def test_resty_resolve_x_router_controller_without_operation_id():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello/{id}",
         path_parameters=[],
@@ -176,7 +169,6 @@ def test_resty_resolve_x_router_controller_without_operation_id():
 
 def test_resty_resolve_with_default_module_name():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello/{id}",
         path_parameters=[],
@@ -191,7 +183,6 @@ def test_resty_resolve_with_default_module_name():
 
 def test_resty_resolve_with_default_module_name_nested():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello/{id}/world",
         path_parameters=[],
@@ -206,7 +197,6 @@ def test_resty_resolve_with_default_module_name_nested():
 
 def test_resty_resolve_with_default_module_name_lowercase_verb():
     operation = Swagger2Operation(
-        api=None,
         method="get",
         path="/hello/{id}",
         path_parameters=[],
@@ -221,7 +211,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
 
 def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
     operation = Swagger2Operation(
-        api=None,
         method="get",
         path="/hello/world/{id}",
         path_parameters=[],
@@ -236,7 +225,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
 
 def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/foo-bar",
         path_parameters=[],
@@ -251,7 +239,6 @@ def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resourc
 
 def test_resty_resolve_with_default_module_name_can_resolve_api_root():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/",
         path_parameters=[],
@@ -266,7 +253,6 @@ def test_resty_resolve_with_default_module_name_can_resolve_api_root():
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -281,7 +267,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
 
 def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -298,7 +283,6 @@ def test_resty_resolve_with_default_module_name_and_x_router_controller_will_res
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
     operation = Swagger2Operation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -313,7 +297,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_co
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
     operation = Swagger2Operation(
-        api=None,
         method="POST",
         path="/hello",
         path_parameters=[],

--- a/tests/test_resolver3.py
+++ b/tests/test_resolver3.py
@@ -6,7 +6,6 @@ COMPONENTS = {"parameters": {"myparam": {"in": "path", "schema": {"type": "integ
 
 def test_standard_resolve_x_router_controller():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -22,7 +21,6 @@ def test_standard_resolve_x_router_controller():
 
 def test_relative_resolve_x_router_controller():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -38,7 +36,6 @@ def test_relative_resolve_x_router_controller():
 
 def test_relative_resolve_operation_id():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -55,7 +52,6 @@ def test_relative_resolve_operation_id_with_module():
     import fakeapi
 
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -70,7 +66,6 @@ def test_relative_resolve_operation_id_with_module():
 
 def test_resty_resolve_operation_id():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -85,7 +80,6 @@ def test_resty_resolve_operation_id():
 
 def test_resty_resolve_x_router_controller_with_operation_id():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -101,7 +95,6 @@ def test_resty_resolve_x_router_controller_with_operation_id():
 
 def test_resty_resolve_x_router_controller_without_operation_id():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello/{id}",
         path_parameters=[],
@@ -114,7 +107,6 @@ def test_resty_resolve_x_router_controller_without_operation_id():
 
 def test_resty_resolve_with_default_module_name():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello/{id}",
         path_parameters=[],
@@ -127,7 +119,6 @@ def test_resty_resolve_with_default_module_name():
 
 def test_resty_resolve_with_default_module_name():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello/{id}/world",
         path_parameters=[],
@@ -140,7 +131,6 @@ def test_resty_resolve_with_default_module_name():
 
 def test_resty_resolve_with_default_module_name_lowercase_verb():
     operation = OpenAPIOperation(
-        api=None,
         method="get",
         path="/hello/{id}",
         path_parameters=[],
@@ -153,7 +143,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb():
 
 def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
     operation = OpenAPIOperation(
-        api=None,
         method="get",
         path="/hello/world/{id}",
         path_parameters=[],
@@ -166,7 +155,6 @@ def test_resty_resolve_with_default_module_name_lowercase_verb_nested():
 
 def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resource_name():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/foo-bar",
         path_parameters=[],
@@ -179,7 +167,6 @@ def test_resty_resolve_with_default_module_name_will_translate_dashes_in_resourc
 
 def test_resty_resolve_with_default_module_name_can_resolve_api_root():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/",
         path_parameters=[],
@@ -192,7 +179,6 @@ def test_resty_resolve_with_default_module_name_can_resolve_api_root():
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_as_search():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -205,7 +191,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_get_a
 
 def test_resty_resolve_with_default_module_name_and_x_router_controller_will_resolve_resource_root_get_as_search():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -220,7 +205,6 @@ def test_resty_resolve_with_default_module_name_and_x_router_controller_will_res
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_configured():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -233,7 +217,6 @@ def test_resty_resolve_with_default_module_name_will_resolve_resource_root_as_co
 
 def test_resty_resolve_with_default_module_name_will_resolve_resource_root_post_as_post():
     operation = OpenAPIOperation(
-        api=None,
         method="POST",
         path="/hello",
         path_parameters=[],

--- a/tests/test_resolver_methodview.py
+++ b/tests/test_resolver_methodview.py
@@ -9,7 +9,6 @@ COMPONENTS = {"parameters": {"myparam": {"in": "path", "schema": {"type": "integ
 
 def test_standard_resolve_x_router_controller():
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -25,7 +24,6 @@ def test_standard_resolve_x_router_controller():
 
 def test_methodview_resolve_operation_id(method_view_resolver):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -40,7 +38,6 @@ def test_methodview_resolve_operation_id(method_view_resolver):
 
 def test_methodview_resolve_x_router_controller_with_operation_id(method_view_resolver):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="endpoint",
         path_parameters=[],
@@ -58,7 +55,6 @@ def test_methodview_resolve_x_router_controller_without_operation_id(
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello/{id}",
         path_parameters=[],
@@ -71,7 +67,6 @@ def test_methodview_resolve_x_router_controller_without_operation_id(
 
 def test_methodview_resolve_with_default_module_name(method_view_resolver):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/pets/{id}",
         path_parameters=[],
@@ -86,7 +81,6 @@ def test_methodview_resolve_with_default_module_name_lowercase_verb(
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="get",
         path="/pets/{id}",
         path_parameters=[],
@@ -101,7 +95,6 @@ def test_methodview_resolve_with_default_module_name_will_translate_dashes_in_re
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/pets",
         path_parameters=[],
@@ -116,7 +109,6 @@ def test_methodview_resolve_with_default_module_name_can_resolve_api_root(
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/",
         path_parameters=[],
@@ -133,7 +125,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/pets",
         path_parameters=[],
@@ -148,7 +139,6 @@ def test_methodview_resolve_with_default_module_name_and_x_router_controller_wil
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/hello",
         path_parameters=[],
@@ -165,7 +155,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="GET",
         path="/pets",
         path_parameters=[],
@@ -180,7 +169,6 @@ def test_methodview_resolve_with_default_module_name_will_resolve_resource_root_
     method_view_resolver,
 ):
     operation = OpenAPIOperation(
-        api=None,
         method="POST",
         path="/pets",
         path_parameters=[],


### PR DESCRIPTION
This PR adds a `jsonifier` argument to the app and api to align it with other customization options. We also no longer pass it via the operation object, which brings us closer to operations as data class only.
