### PR TITLE
Add explicit asgiref dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ connexion = 'connexion.cli:main'
 
 [tool.poetry.dependencies]
 python = '^3.7'
+asgiref = "^3.4"
 clickclick = ">= 1.2, < 21"
 httpx = "^0.23"
 importlib_metadata = { version = "^6.0.0", python = "<3.8" }


### PR DESCRIPTION
We use `asgiref` as a direct dependency
https://github.com/spec-first/connexion/blob/ab94e2aaa67d30ab2bb97e4d8d27746a5ed43d20/connexion/decorators/main.py#L7

So should add it explicitly as well.

This issue is hidden in our tests since we install all extras. To prevent this, we need to address https://github.com/spec-first/connexion/issues/1389.