### PR TITLE
Delay import error for optional flask depencendy

### DIFF
--- a/connexion/__init__.py
+++ b/connexion/__init__.py
@@ -18,7 +18,9 @@ from .utils import not_installed_error  # NOQA
 try:
     from connexion.apps.flask import FlaskApi, FlaskApp
 except ImportError as e:  # pragma: no cover
-    _flask_not_installed_error = not_installed_error(e)
+    _flask_not_installed_error = not_installed_error(
+        e, msg="Please install connexion using the 'flask' extra"
+    )
     FlaskApi = _flask_not_installed_error  # type: ignore
     FlaskApp = _flask_not_installed_error  # type: ignore
 

--- a/connexion/decorators/main.py
+++ b/connexion/decorators/main.py
@@ -19,9 +19,17 @@ from connexion.decorators.response import (
     SyncResponseDecorator,
 )
 from connexion.frameworks.abstract import Framework
-from connexion.frameworks.flask import Flask as FlaskFramework
 from connexion.frameworks.starlette import Starlette as StarletteFramework
 from connexion.uri_parsing import AbstractURIParser
+from connexion.utils import not_installed_error
+
+try:
+    from connexion.frameworks.flask import Flask as FlaskFramework
+except ImportError as e:
+    _flask_not_installed_error = not_installed_error(
+        e, msg="Please install connexion using the 'flask' extra"
+    )
+    FlaskFramework = _flask_not_installed_error  # type: ignore
 
 
 class BaseDecorator:
@@ -68,6 +76,7 @@ class BaseDecorator:
         function = self._sync_async_decorator(function)
 
         parameter_decorator = self._parameter_decorator_cls(
+            framework=self.framework,
             pythonic_params=self.pythonic_params,
         )
         function = parameter_decorator(function)

--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -15,8 +15,7 @@ from copy import copy, deepcopy
 import inflection
 
 from connexion.context import context, operation
-from connexion.frameworks.flask import Flask as FlaskFramework
-from connexion.frameworks.starlette import Starlette as StarletteFramework
+from connexion.frameworks.abstract import Framework
 from connexion.http_facts import FORM_CONTENT_TYPES
 from connexion.lifecycle import ASGIRequest, WSGIRequest
 from connexion.operations import AbstractOperation, Swagger2Operation
@@ -31,8 +30,10 @@ class BaseParameterDecorator:
     def __init__(
         self,
         *,
+        framework: t.Type[Framework],
         pythonic_params: bool = False,
     ) -> None:
+        self.framework = framework
         self.sanitize_fn = pythonic if pythonic_params else sanitized
 
     def _maybe_get_body(
@@ -59,9 +60,6 @@ class BaseParameterDecorator:
 
 
 class SyncParameterDecorator(BaseParameterDecorator):
-
-    framework = FlaskFramework
-
     def __call__(self, function: t.Callable) -> t.Callable:
         unwrapped_function = unwrap_decorators(function)
         arguments, has_kwargs = inspect_function_arguments(unwrapped_function)
@@ -87,9 +85,6 @@ class SyncParameterDecorator(BaseParameterDecorator):
 
 
 class AsyncParameterDecorator(BaseParameterDecorator):
-
-    framework = StarletteFramework
-
     def __call__(self, function: t.Callable) -> t.Callable:
         unwrapped_function = unwrap_decorators(function)
         arguments, has_kwargs = inspect_function_arguments(unwrapped_function)

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -271,13 +271,15 @@ def yamldumper(openapi):
     return yaml.dump(openapi, allow_unicode=True, Dumper=NoAnchorDumper)
 
 
-def not_installed_error(exc):  # pragma: no cover
-    """Raises the ImportError when the module/object is actually called."""
+def not_installed_error(exc, *, msg=None):  # pragma: no cover
+    """Raises the ImportError when the module/object is actually called with a custom message."""
 
-    def _required_lib(exc, *args, **kwargs):
+    def _delayed_error(*args, **kwargs):
+        if msg is not None:
+            raise type(exc)(msg).with_traceback(exc.__traceback__)
         raise exc
 
-    return functools.partial(_required_lib, exc)
+    return _delayed_error
 
 
 def extract_content_type(

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -13,6 +13,8 @@ from connexion.decorators.parameter import (
     SyncParameterDecorator,
     pythonic,
 )
+from connexion.frameworks.flask import Flask as FlaskFramework
+from connexion.frameworks.starlette import Starlette as StarletteFramework
 from connexion.testing import TestContext
 
 
@@ -29,7 +31,7 @@ def test_sync_injection():
     operation.body_name = lambda _: "body"
 
     with TestContext(operation=operation):
-        parameter_decorator = SyncParameterDecorator()
+        parameter_decorator = SyncParameterDecorator(framework=FlaskFramework)
         decorated_handler = parameter_decorator(handler)
         decorated_handler(request)
     func.assert_called_with(p1="123")
@@ -51,7 +53,7 @@ async def test_async_injection():
     operation.body_name = lambda _: "body"
 
     with TestContext(operation=operation):
-        parameter_decorator = AsyncParameterDecorator()
+        parameter_decorator = AsyncParameterDecorator(framework=StarletteFramework)
         decorated_handler = parameter_decorator(handler)
         await decorated_handler(request)
     func.assert_called_with(p1="123")
@@ -72,7 +74,7 @@ def test_sync_injection_with_context():
     operation.body_name = lambda _: "body"
 
     with TestContext(context=context, operation=operation):
-        parameter_decorator = SyncParameterDecorator()
+        parameter_decorator = SyncParameterDecorator(framework=FlaskFramework)
         decorated_handler = parameter_decorator(handler)
         decorated_handler(request)
         func.assert_called_with(context, p1="123", test="success")
@@ -96,7 +98,7 @@ async def test_async_injection_with_context():
     operation.body_name = lambda _: "body"
 
     with TestContext(context=context, operation=operation):
-        parameter_decorator = AsyncParameterDecorator()
+        parameter_decorator = AsyncParameterDecorator(framework=StarletteFramework)
         decorated_handler = parameter_decorator(handler)
         await decorated_handler(request)
         func.assert_called_with(context, p1="123", test="success")


### PR DESCRIPTION
This PR delays import errors for the optional Flask dependency, so you can use the AsyncApp without Flask installed.

This issue is hidden in our tests since we install all extras. To prevent this, we need to address https://github.com/spec-first/connexion/issues/1389.