### PR TITLE
Update Operations to act as wrapper of wrapped view function

### DIFF
--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -2,6 +2,7 @@
 This module defines a native connexion asynchronous application.
 """
 
+import functools
 import logging
 import pathlib
 import typing as t
@@ -24,19 +25,16 @@ logger = logging.getLogger(__name__)
 class AsyncOperation:
     def __init__(
         self,
-        operation: AbstractOperation,
         fn: t.Callable,
-        uri_parser: AbstractURIParser,
         jsonifier: Jsonifier,
         operation_id: str,
         pythonic_params: bool,
     ) -> None:
-        self._operation = operation
         self._fn = fn
-        self.uri_parser = uri_parser
         self.jsonifier = jsonifier
         self.operation_id = operation_id
         self.pythonic_params = pythonic_params
+        functools.update_wrapper(self, fn)
 
     @classmethod
     def from_operation(
@@ -47,9 +45,7 @@ class AsyncOperation:
         jsonifier: Jsonifier,
     ) -> "AsyncOperation":
         return cls(
-            operation,
-            fn=operation.function,
-            uri_parser=operation.uri_parser_class,
+            operation.function,
             jsonifier=jsonifier,
             operation_id=operation.operation_id,
             pythonic_params=pythonic_params,

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -1,7 +1,7 @@
 """
 This module defines a FlaskApp, a Connexion application to wrap a Flask application.
 """
-
+import functools
 import pathlib
 import typing as t
 
@@ -36,6 +36,7 @@ class FlaskOperation:
         self.jsonifier = jsonifier
         self.operation_id = operation_id
         self.pythonic_params = pythonic_params
+        functools.update_wrapper(self, fn)
 
     @classmethod
     def from_operation(
@@ -104,7 +105,7 @@ class FlaskApi(AbstractRoutingAPI):
         return flask_path, endpoint_name
 
     def _add_operation_internal(
-        self, method: str, path: str, operation: FlaskOperation, name: str = None
+        self, method: str, path: str, operation: t.Callable, name: str = None
     ) -> None:
         self.blueprint.add_url_rule(path, name, operation, methods=[method])
 


### PR DESCRIPTION
Fixes #1666 

The `FlaskOperation` and `AsyncOperation` classes act as decorators for their wrapped view functions, so their metadata should reflect this, similar to what `functools.wraps` does.