### PR TITLE
Make security pluggable

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -47,6 +47,7 @@ class AbstractApp:
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
     ) -> None:
         """
         :param import_name: The name of the package or module that this object belongs to. If you
@@ -77,6 +78,8 @@ class AbstractApp:
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`.
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`
         """
         self.middleware = ConnexionMiddleware(
             self.middleware_app,
@@ -95,6 +98,7 @@ class AbstractApp:
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
         )
 
     def add_api(
@@ -113,6 +117,7 @@ class AbstractApp:
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
         **kwargs,
     ) -> t.Any:
         """
@@ -143,6 +148,8 @@ class AbstractApp:
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`
         :param kwargs: Additional keyword arguments to pass to the `add_api` method of the managed
             middlewares. This can be used to pass arguments to middlewares added beyond the default
             ones.
@@ -163,6 +170,7 @@ class AbstractApp:
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
             **kwargs,
         )
 

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -135,6 +135,7 @@ class AsyncApp(AbstractApp):
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
     ) -> None:
         """
         :param import_name: The name of the package or module that this object belongs to. If you
@@ -165,6 +166,8 @@ class AsyncApp(AbstractApp):
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`.
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`
         """
         self.middleware_app: AsyncMiddlewareApp = AsyncMiddlewareApp()
 
@@ -184,6 +187,7 @@ class AsyncApp(AbstractApp):
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
         )
 
     def add_url_rule(

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -192,6 +192,7 @@ class FlaskApp(AbstractApp):
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
     ):
         """
         :param import_name: The name of the package or module that this object belongs to. If you
@@ -225,6 +226,8 @@ class FlaskApp(AbstractApp):
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`.
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`
         """
         self.middleware_app = FlaskMiddlewareApp(import_name, server_args or {})
         self.app = self.middleware_app.app
@@ -244,6 +247,7 @@ class FlaskApp(AbstractApp):
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
         )
 
     def add_url_rule(

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -51,6 +51,7 @@ class _Options:
     uri_parser_class: t.Optional[AbstractURIParser] = None
     validate_responses: t.Optional[bool] = False
     validator_map: t.Optional[dict] = None
+    security_map: t.Optional[dict] = None
 
     def __post_init__(self):
         self.resolver = (
@@ -115,6 +116,7 @@ class ConnexionMiddleware:
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
     ):
         """
         :param import_name: The name of the package or module that this object belongs to. If you
@@ -145,6 +147,8 @@ class ConnexionMiddleware:
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`.
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`.
         """
         import_name = import_name or str(pathlib.Path.cwd())
         self.root_path = utils.get_root_path(import_name)
@@ -169,6 +173,7 @@ class ConnexionMiddleware:
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
         )
 
         self.extra_files: t.List[str] = []
@@ -217,6 +222,7 @@ class ConnexionMiddleware:
         uri_parser_class: t.Optional[AbstractURIParser] = None,
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
+        security_map: t.Optional[dict] = None,
         **kwargs,
     ) -> t.Any:
         """
@@ -247,6 +253,8 @@ class ConnexionMiddleware:
             an impact on performance. Defaults to False.
         :param validator_map: A dictionary of validators to use. Defaults to
             :obj:`validators.VALIDATOR_MAP`
+        :param security_map: A dictionary of security handlers to use. Defaults to
+            :obj:`security.SECURITY_HANDLERS`
         :param kwargs: Additional keyword arguments to pass to the `add_api` method of the managed
             middlewares. This can be used to pass arguments to middlewares added beyond the default
             ones.
@@ -275,6 +283,7 @@ class ConnexionMiddleware:
             uri_parser_class=uri_parser_class,
             validate_responses=validate_responses,
             validator_map=validator_map,
+            security_map=security_map,
         )
 
         for app in self.apps:

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -97,7 +97,6 @@ class SecurityOperation:
 
         request = ASGIRequest(scope)
         await self.verification_fn(request)
-        # TODO: Adjust scope? Or adjust downstream validation to account for api keys in query?
         await self.next_app(scope, receive, send)
 
 

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -51,7 +51,7 @@ class SecurityOperation:
         auth_funcs = []
         for security_req in self.security:
             if not security_req:
-                auth_funcs.append(self.security_handler_factory.verify_none())
+                auth_funcs.append(self.security_handler_factory.verify_none)
                 continue
 
             sec_req_funcs = {}
@@ -67,123 +67,15 @@ class SecurityOperation:
                         )
                         break
                     oauth = True
-                    token_info_func = self.security_handler_factory.get_tokeninfo_func(
-                        security_scheme
-                    )
-                    scope_validate_func = (
-                        self.security_handler_factory.get_scope_validate_func(
-                            security_scheme
-                        )
-                    )
-                    if not token_info_func:
-                        logger.warning("... x-tokenInfoFunc missing", extra=vars(self))
-                        break
 
-                    sec_req_funcs[
-                        scheme_name
-                    ] = self.security_handler_factory.verify_oauth(
-                        token_info_func, scope_validate_func, required_scopes
-                    )
-
-                # Swagger 2.0
-                elif security_scheme["type"] == "basic":
-                    basic_info_func = self.security_handler_factory.get_basicinfo_func(
-                        security_scheme
-                    )
-                    if not basic_info_func:
-                        logger.warning("... x-basicInfoFunc missing", extra=vars(self))
-                        break
-
-                    sec_req_funcs[
-                        scheme_name
-                    ] = self.security_handler_factory.verify_basic(basic_info_func)
-
-                # OpenAPI 3.0.0
-                elif security_scheme["type"] == "http":
-                    scheme = security_scheme["scheme"].lower()
-                    if scheme == "basic":
-                        basic_info_func = (
-                            self.security_handler_factory.get_basicinfo_func(
-                                security_scheme
-                            )
-                        )
-                        if not basic_info_func:
-                            logger.warning(
-                                "... x-basicInfoFunc missing", extra=vars(self)
-                            )
-                            break
-
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self.security_handler_factory.verify_basic(basic_info_func)
-                    elif scheme == "bearer":
-                        bearer_info_func = (
-                            self.security_handler_factory.get_bearerinfo_func(
-                                security_scheme
-                            )
-                        )
-                        if not bearer_info_func:
-                            logger.warning(
-                                "... x-bearerInfoFunc missing", extra=vars(self)
-                            )
-                            break
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self.security_handler_factory.verify_bearer(
-                            bearer_info_func
-                        )
-                    else:
-                        logger.warning(
-                            "... Unsupported http authorization scheme %s" % scheme,
-                            extra=vars(self),
-                        )
-                        break
-
-                elif security_scheme["type"] == "apiKey":
-                    scheme = security_scheme.get("x-authentication-scheme", "").lower()
-                    if scheme == "bearer":
-                        bearer_info_func = (
-                            self.security_handler_factory.get_bearerinfo_func(
-                                security_scheme
-                            )
-                        )
-                        if not bearer_info_func:
-                            logger.warning(
-                                "... x-bearerInfoFunc missing", extra=vars(self)
-                            )
-                            break
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self.security_handler_factory.verify_bearer(
-                            bearer_info_func
-                        )
-                    else:
-                        apikey_info_func = (
-                            self.security_handler_factory.get_apikeyinfo_func(
-                                security_scheme
-                            )
-                        )
-                        if not apikey_info_func:
-                            logger.warning(
-                                "... x-apikeyInfoFunc missing", extra=vars(self)
-                            )
-                            break
-
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self.security_handler_factory.verify_api_key(
-                            apikey_info_func,
-                            security_scheme["in"],
-                            security_scheme["name"],
-                        )
-
-                else:
-                    logger.warning(
-                        "... Unsupported security scheme type %s"
-                        % security_scheme["type"],
-                        extra=vars(self),
-                    )
+                sec_req_func = self.security_handler_factory.parse_security_scheme(
+                    security_scheme, required_scopes
+                )
+                if sec_req_func is None:
                     break
+
+                sec_req_funcs[scheme_name] = sec_req_func
+
             else:
                 # No break encountered: no missing funcs
                 if len(sec_req_funcs) == 1:
@@ -199,16 +91,23 @@ class SecurityOperation:
         return self.security_handler_factory.verify_security(auth_funcs)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self.security:
+            await self.next_app(scope, receive, send)
+            return
+
         request = ASGIRequest(scope)
         await self.verification_fn(request)
+        # TODO: Adjust scope? Or adjust downstream validation to account for api keys in query?
         await self.next_app(scope, receive, send)
 
 
 class SecurityAPI(RoutedAPI[SecurityOperation]):
-    def __init__(self, *args, auth_all_paths: bool = False, **kwargs):
+    def __init__(
+        self, *args, auth_all_paths: bool = False, security_map: dict = None, **kwargs
+    ):
         super().__init__(*args, **kwargs)
 
-        self.security_handler_factory = SecurityHandlerFactory()
+        self.security_handler_factory = SecurityHandlerFactory(security_map)
 
         if auth_all_paths:
             self.add_auth_on_not_found()

--- a/connexion/security.py
+++ b/connexion/security.py
@@ -1,6 +1,46 @@
 """
-This module defines an abstract SecurityHandlerFactory which supports the creation of security
-handlers for operations.
+This module defines a SecurityHandlerFactory which supports the creation of
+SecurityHandler instances for different security schemes.
+
+It also exposes a `SECURITY_HANDLERS` dictionary which maps security scheme
+types to SecurityHandler classes. This dictionary can be used to register
+custom SecurityHandler classes for custom security schemes, or to overwrite
+existing SecurityHandler classes.
+This can be done by supplying a value for `security_map` argument of the
+SecurityHandlerFactory.
+
+Swagger 2.0 lets you define the following authentication types for an API:
+
+- Basic authentication
+- API key (as a header or a query string parameter)
+- OAuth 2 common flows (authorization code, implicit, resource owner password credentials, client credentials)
+
+
+Changes from OpenAPI 2.0 to OpenAPI 3.0
+If you used OpenAPI 2.0 before, here is a summary of changes to help you get started with OpenAPI 3.0:
+- securityDefinitions were renamed to securitySchemes and moved inside components.
+- type: basic was replaced with type: http and scheme: basic.
+- The new type: http is an umbrella type for all HTTP security schemes, including Basic, Bearer and other,
+and the scheme keyword indicates the scheme type.
+- API keys can now be sent in: cookie.
+- Added support for OpenID Connect Discovery (type: openIdConnect).
+- OAuth 2 security schemes can now define multiple flows.
+- OAuth 2 flows were renamed to match the OAuth 2 Specification: accessCode is now authorizationCode,
+and application is now clientCredentials.
+
+
+OpenAPI uses the term security scheme for authentication and authorization schemes.
+OpenAPI 3.0 lets you describe APIs protected using the following security schemes:
+
+- HTTP authentication schemes (they use the Authorization header):
+    - Basic
+    - Bearer
+    - other HTTP schemes as defined by RFC 7235 and HTTP Authentication Scheme Registry
+- API keys in headers, query string or cookies
+    - Cookie authentication
+- OAuth 2
+- OpenID Connect Discovery
+
 """
 
 import asyncio
@@ -8,181 +48,89 @@ import base64
 import http.cookies
 import logging
 import os
-import textwrap
 import typing as t
 
 import httpx
 
 from connexion.decorators.parameter import inspect_function_arguments
-from connexion.exceptions import (
-    ConnexionException,
-    OAuthProblem,
-    OAuthResponseProblem,
-    OAuthScopeProblem,
-)
+from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeProblem
 from connexion.utils import get_function_from_name
 
-logger = logging.getLogger("connexion.api.security")
+logger = logging.getLogger(__name__)
 
 
-class SecurityHandlerFactory:
-    """
-    get_*_func -> _get_function -> get_function_from_name (name=security function defined in spec)
-        (if url defined instead of a function -> get_token_info_remote)
+NO_VALUE = object()
+"""Sentinel value to indicate that no security credentials were found."""
 
-    std security functions: security_{passthrough,deny}
 
-    verify_* -> returns a security wrapper around the security function
-        check_* -> returns a function tasked with doing auth for use inside the verify wrapper
-            check helpers (used outside wrappers): _need_to_add_context_or_scopes
-            the security function
+class AbstractSecurityHandler:
 
-        verify helpers (used inside wrappers): get_auth_header_value, get_cookie_value
-    """
-
-    no_value = object()
     required_scopes_kw = "required_scopes"
     context_kw = "context_"
     client = None
+    security_definition_key: str
+    """The key which contains the value for the function name to resolve."""
+    environ_key: str
+    """The name of the environment variable that can be used alternatively for the function name."""
 
-    @staticmethod
+    def get_fn(self, security_scheme, required_scopes):
+        """Returns the handler function"""
+        security_func = self._resolve_func(security_scheme)
+        if not security_func:
+            logger.warning("... %s missing", self.security_definition_key)
+            return None
+
+        return self._get_verify_func(security_func)
+
+    @classmethod
     def _get_function(
-        security_definition, security_definition_key, environ_key, default=None
+        cls,
+        security_definition: dict,
+        security_definition_key: str,
+        environ_key: str,
+        default: t.Optional[t.Callable] = None,
     ):
         """
         Return function by getting its name from security_definition or environment variable
+
+        :param security_definition: Security Definition (scheme) from the spec.
+        :param security_definition_key: The key which contains the value for the function name to resolve.
+        :param environ_key: The name of the environment variable that can be used alternatively for the function name.
+        :param default: The default to use in case the function cannot be found based on the security_definition_key or the environ_key
         """
-        func = security_definition.get(security_definition_key) or os.environ.get(
+        func_name = security_definition.get(security_definition_key) or os.environ.get(
             environ_key
         )
-        if func:
-            return get_function_from_name(func)
+        if func_name:
+            return get_function_from_name(func_name)
         return default
 
-    def get_tokeninfo_func(self, security_definition: dict) -> t.Optional[t.Callable]:
-        """
-        :type security_definition: dict
+    def _generic_check(self, func, exception_msg):
+        (
+            need_to_add_context,
+            need_to_add_required_scopes,
+        ) = self._need_to_add_context_or_scopes(func)
 
-        >>> get_tokeninfo_url({'x-tokenInfoFunc': 'foo.bar'})
-        '<function foo.bar>'
-        """
-        token_info_func = self._get_function(
-            security_definition, "x-tokenInfoFunc", "TOKENINFO_FUNC"
-        )
-        if token_info_func:
-            return token_info_func
+        async def wrapper(request, *args, required_scopes=None):
+            kwargs = {}
+            if need_to_add_context:
+                kwargs[self.context_kw] = request.context
+            if need_to_add_required_scopes:
+                kwargs[self.required_scopes_kw] = required_scopes
+            token_info = func(*args, **kwargs)
+            while asyncio.iscoroutine(token_info):
+                token_info = await token_info
+            if token_info is NO_VALUE:
+                return NO_VALUE
+            if token_info is None:
+                raise OAuthResponseProblem(detail=exception_msg)
+            return token_info
 
-        token_info_url = security_definition.get("x-tokenInfoUrl") or os.environ.get(
-            "TOKENINFO_URL"
-        )
-        if token_info_url:
-            return self.get_token_info_remote(token_info_url)
-
-        return None
-
-    @classmethod
-    def get_scope_validate_func(cls, security_definition):
-        """
-        :type security_definition: dict
-        :rtype: function
-
-        >>> get_scope_validate_func({'x-scopeValidateFunc': 'foo.bar'})
-        '<function foo.bar>'
-        """
-        return cls._get_function(
-            security_definition,
-            "x-scopeValidateFunc",
-            "SCOPEVALIDATE_FUNC",
-            cls.validate_scope,
-        )
-
-    @classmethod
-    def get_basicinfo_func(cls, security_definition):
-        """
-        :type security_definition: dict
-        :rtype: function
-
-        >>> get_basicinfo_func({'x-basicInfoFunc': 'foo.bar'})
-        '<function foo.bar>'
-        """
-        return cls._get_function(
-            security_definition, "x-basicInfoFunc", "BASICINFO_FUNC"
-        )
-
-    @classmethod
-    def get_apikeyinfo_func(cls, security_definition):
-        """
-        :type security_definition: dict
-        :rtype: function
-
-        >>> get_apikeyinfo_func({'x-apikeyInfoFunc': 'foo.bar'})
-        '<function foo.bar>'
-        """
-        return cls._get_function(
-            security_definition, "x-apikeyInfoFunc", "APIKEYINFO_FUNC"
-        )
-
-    @classmethod
-    def get_bearerinfo_func(cls, security_definition):
-        """
-        :type security_definition: dict
-        :rtype: function
-
-        >>> get_bearerinfo_func({'x-bearerInfoFunc': 'foo.bar'})
-        '<function foo.bar>'
-        """
-        return cls._get_function(
-            security_definition, "x-bearerInfoFunc", "BEARERINFO_FUNC"
-        )
-
-    @staticmethod
-    async def security_passthrough(request):
-        return request
-
-    @staticmethod
-    def security_deny(function):
-        """
-        :type function: types.FunctionType
-        :rtype: types.FunctionType
-        """
-
-        def deny(*args, **kwargs):
-            raise ConnexionException("Error in security definitions")
-
-        return deny
-
-    @staticmethod
-    def validate_scope(required_scopes, token_scopes):
-        """
-        :param required_scopes: Scopes required to access operation
-        :param token_scopes: Scopes granted by authorization server
-        :rtype: bool
-        """
-        required_scopes = set(required_scopes)
-        if isinstance(token_scopes, list):
-            token_scopes = set(token_scopes)
-        else:
-            token_scopes = set(token_scopes.split())
-        logger.debug("... Scopes required: %s", required_scopes)
-        logger.debug("... Token scopes: %s", token_scopes)
-        if not required_scopes <= token_scopes:
-            logger.info(
-                textwrap.dedent(
-                    """
-                        ... Token scopes (%s) do not match the scopes necessary to call endpoint (%s).
-                         Aborting with 403."""
-                ).replace("\n", ""),
-                token_scopes,
-                required_scopes,
-            )
-            return False
-        return True
+        return wrapper
 
     @staticmethod
     def get_auth_header_value(request):
         """
-        Called inside security wrapper functions
-
         Return Authorization type and value if any.
         If not Authorization, return (None, None)
         Raise OAuthProblem for invalid Authorization header
@@ -192,30 +140,52 @@ class SecurityHandlerFactory:
             return None, None
 
         try:
-            auth_type, value = authorization.split(None, 1)
+            auth_type, value = authorization.split(maxsplit=1)
         except ValueError:
             raise OAuthProblem(detail="Invalid authorization header")
         return auth_type.lower(), value
 
-    def verify_oauth(self, token_info_func, scope_validate_func, required_scopes):
-        check_oauth_func = self.check_oauth_func(token_info_func, scope_validate_func)
+    def _need_to_add_context_or_scopes(self, func):
+        arguments, has_kwargs = inspect_function_arguments(func)
+        need_context = self.context_kw in arguments
+        need_required_scopes = has_kwargs or self.required_scopes_kw in arguments
+        return need_context, need_required_scopes
 
-        def wrapper(request):
-            auth_type, token = self.get_auth_header_value(request)
-            if auth_type != "bearer":
-                return self.no_value
+    def _resolve_func(self, security_scheme):
+        """
+        Get the user function object based on the security scheme or the environment variable.
 
-            return check_oauth_func(request, token, required_scopes=required_scopes)
+        :param security_scheme: Security Definition (scheme) from the spec.
+        """
+        return self._get_function(
+            security_scheme, self.security_definition_key, self.environ_key
+        )
 
-        return wrapper
+    def _get_verify_func(self, function):
+        """
+        Wraps the user security function in a function that checks the request for the correct
+        security credentials and calls the user function with the correct arguments.
+        """
+        return self._generic_check(function, "Provided authorization is not valid")
 
-    def verify_basic(self, basic_info_func):
+
+class BasicSecurityHandler(AbstractSecurityHandler):
+    """
+    Security Handler for
+    - `type: basic` (Swagger 2), and
+    - `type: http` and `scheme: basic` (OpenAPI 3)
+    """
+
+    security_definition_key = "x-basicInfoFunc"
+    environ_key = "BASICINFO_FUNC"
+
+    def _get_verify_func(self, basic_info_func):
         check_basic_info_func = self.check_basic_auth(basic_info_func)
 
         def wrapper(request):
             auth_type, user_pass = self.get_auth_header_value(request)
             if auth_type != "basic":
-                return self.no_value
+                return NO_VALUE
 
             try:
                 username, password = (
@@ -228,23 +198,60 @@ class SecurityHandlerFactory:
 
         return wrapper
 
-    @staticmethod
-    def get_cookie_value(cookies, name):
-        """
-        Called inside security wrapper functions
+    def check_basic_auth(self, basic_info_func):
+        return self._generic_check(
+            basic_info_func, "Provided authorization is not valid"
+        )
 
-        Returns cookie value by its name. None if no such value.
-        :param cookies: str: cookies raw data
-        :param name: str: cookies key
+
+class BearerSecurityHandler(AbstractSecurityHandler):
+    """
+    Security Handler for HTTP Bearer authentication.
+    """
+
+    security_definition_key = "x-bearerInfoFunc"
+    environ_key = "BEARERINFO_FUNC"
+
+    def check_bearer_token(self, token_info_func):
+        return self._generic_check(token_info_func, "Provided token is not valid")
+
+    def _get_verify_func(self, token_info_func):
         """
-        cookie_parser = http.cookies.SimpleCookie()
-        cookie_parser.load(str(cookies))
-        try:
-            return cookie_parser[name].value
-        except KeyError:
+        :param token_info_func: types.FunctionType
+        :rtype: types.FunctionType
+        """
+        check_bearer_func = self.check_bearer_token(token_info_func)
+
+        def wrapper(request):
+            auth_type, token = self.get_auth_header_value(request)
+            if auth_type != "bearer":
+                return NO_VALUE
+            return check_bearer_func(request, token)
+
+        return wrapper
+
+
+class ApiKeySecurityHandler(AbstractSecurityHandler):
+    """
+    Security Handler for API Keys.
+    """
+
+    security_definition_key = "x-apikeyInfoFunc"
+    environ_key = "APIKEYINFO_FUNC"
+
+    def get_fn(self, security_scheme, required_scopes):
+        apikey_info_func = self._resolve_func(security_scheme)
+        if not apikey_info_func:
+            logger.warning("... %s missing", self.security_definition_key)
             return None
 
-    def verify_api_key(self, api_key_info_func, loc, name):
+        return self._get_verify_func(
+            apikey_info_func,
+            security_scheme["in"],
+            security_scheme["name"],
+        )
+
+    def _get_verify_func(self, api_key_info_func, loc, name):
         check_api_key_func = self.check_api_key(api_key_info_func)
 
         def wrapper(request):
@@ -272,104 +279,148 @@ class SecurityHandlerFactory:
                 cookie_list = request.headers.get("Cookie")
                 api_key = self.get_cookie_value(cookie_list, name)
             else:
-                return self.no_value
+                return NO_VALUE
 
             if api_key is None:
-                return self.no_value
+                return NO_VALUE
 
             return check_api_key_func(request, api_key)
 
         return wrapper
 
-    def verify_bearer(self, token_info_func):
+    def check_api_key(self, api_key_info_func):
+        return self._generic_check(api_key_info_func, "Provided apikey is not valid")
+
+    @staticmethod
+    def get_cookie_value(cookies, name):
         """
-        :param token_info_func: types.FunctionType
-        :rtype: types.FunctionType
+        Returns cookie value by its name. `None` if no such value.
+
+        :param cookies: str: cookies raw data
+        :param name: str: cookies key
         """
-        check_bearer_func = self.check_bearer_token(token_info_func)
+        cookie_parser = http.cookies.SimpleCookie()
+        cookie_parser.load(str(cookies))
+        try:
+            return cookie_parser[name].value
+        except KeyError:
+            return None
+
+
+class OAuthSecurityHandler(AbstractSecurityHandler):
+    """
+    Security Handler for the OAuth security scheme.
+    """
+
+    def get_fn(self, security_scheme, required_scopes):
+        token_info_func = self.get_tokeninfo_func(security_scheme)
+        scope_validate_func = self.get_scope_validate_func(security_scheme)
+        if not token_info_func:
+            logger.warning("... x-tokenInfoFunc missing")
+            return None
+
+        return self._get_verify_func(
+            token_info_func, scope_validate_func, required_scopes
+        )
+
+    def get_tokeninfo_func(self, security_definition: dict) -> t.Optional[t.Callable]:
+        """
+        Gets the function for retrieving the token info.
+        It is possible to specify a function or a URL. The function variant is
+        preferred. If it is not found, the URL variant is used with the
+        `get_token_info_remote` function.
+
+        >>> get_tokeninfo_func({'x-tokenInfoFunc': 'foo.bar'})
+        '<function foo.bar>'
+        """
+        token_info_func = self._get_function(
+            security_definition, "x-tokenInfoFunc", "TOKENINFO_FUNC"
+        )
+        if token_info_func:
+            return token_info_func
+
+        token_info_url = security_definition.get("x-tokenInfoUrl") or os.environ.get(
+            "TOKENINFO_URL"
+        )
+        if token_info_url:
+            return self.get_token_info_remote(token_info_url)
+
+        return None
+
+    @classmethod
+    def get_scope_validate_func(cls, security_definition):
+        """
+        Gets the function for validating the token scopes.
+        If it is not found, the default `validate_scope` function is used.
+
+        >>> get_scope_validate_func({'x-scopeValidateFunc': 'foo.bar'})
+        '<function foo.bar>'
+        """
+        return cls._get_function(
+            security_definition,
+            "x-scopeValidateFunc",
+            "SCOPEVALIDATE_FUNC",
+            cls.validate_scope,
+        )
+
+    @staticmethod
+    def validate_scope(required_scopes, token_scopes):
+        """
+        :param required_scopes: Scopes required to access operation
+        :param token_scopes: Scopes granted by authorization server
+        :rtype: bool
+        """
+        required_scopes = set(required_scopes)
+        if isinstance(token_scopes, list):
+            token_scopes = set(token_scopes)
+        else:
+            token_scopes = set(token_scopes.split())
+        logger.debug("... Scopes required: %s", required_scopes)
+        logger.debug("... Token scopes: %s", token_scopes)
+        if not required_scopes <= token_scopes:
+            logger.info(
+                "... Token scopes (%s) do not match the scopes necessary to call endpoint (%s)."
+                " Aborting with 403.",
+                token_scopes,
+                required_scopes,
+            )
+            return False
+        return True
+
+    def get_token_info_remote(self, token_info_url: str) -> t.Callable:
+        """
+        Return a function which will call `token_info_url` to retrieve token info.
+
+        Returned function must accept oauth token in parameter.
+        It must return a token_info dict in case of success, None otherwise.
+
+        :param token_info_url: URL to get information about the token
+        """
+
+        async def wrapper(token):
+            if self.client is None:
+                self.client = httpx.AsyncClient()
+            headers = {"Authorization": f"Bearer {token}"}
+            token_request = await self.client.get(
+                token_info_url, headers=headers, timeout=5
+            )
+            if token_request.status_code != 200:
+                return
+            return token_request.json()
+
+        return wrapper
+
+    def _get_verify_func(self, token_info_func, scope_validate_func, required_scopes):
+        check_oauth_func = self.check_oauth_func(token_info_func, scope_validate_func)
 
         def wrapper(request):
             auth_type, token = self.get_auth_header_value(request)
             if auth_type != "bearer":
-                return self.no_value
-            return check_bearer_func(request, token)
+                return NO_VALUE
+
+            return check_oauth_func(request, token, required_scopes=required_scopes)
 
         return wrapper
-
-    def verify_multiple_schemes(self, schemes):
-        """
-        Verifies multiple authentication schemes in AND fashion.
-        If any scheme fails, the entire authentication fails.
-
-        :param schemes: mapping scheme_name to auth function
-        :type schemes: dict
-        :rtype: types.FunctionType
-        """
-
-        async def wrapper(request):
-            token_info = {}
-            for scheme_name, func in schemes.items():
-                result = func(request)
-                while asyncio.iscoroutine(result):
-                    result = await result
-                if result is self.no_value:
-                    return self.no_value
-                token_info[scheme_name] = result
-
-            return token_info
-
-        return wrapper
-
-    @staticmethod
-    def verify_none():
-        """
-        :rtype: types.FunctionType
-        """
-
-        def wrapper(request):
-            return {}
-
-        return wrapper
-
-    def _need_to_add_context_or_scopes(self, func):
-        arguments, has_kwargs = inspect_function_arguments(func)
-        need_context = self.context_kw in arguments
-        need_required_scopes = has_kwargs or self.required_scopes_kw in arguments
-        return need_context, need_required_scopes
-
-    def _generic_check(self, func, exception_msg):
-        (
-            need_to_add_context,
-            need_to_add_required_scopes,
-        ) = self._need_to_add_context_or_scopes(func)
-
-        async def wrapper(request, *args, required_scopes=None):
-            kwargs = {}
-            if need_to_add_context:
-                kwargs[self.context_kw] = request.context
-            if need_to_add_required_scopes:
-                kwargs[self.required_scopes_kw] = required_scopes
-            token_info = func(*args, **kwargs)
-            while asyncio.iscoroutine(token_info):
-                token_info = await token_info
-            if token_info is self.no_value:
-                return self.no_value
-            if token_info is None:
-                raise OAuthResponseProblem(detail=exception_msg)
-            return token_info
-
-        return wrapper
-
-    def check_bearer_token(self, token_info_func):
-        return self._generic_check(token_info_func, "Provided token is not valid")
-
-    def check_basic_auth(self, basic_info_func):
-        return self._generic_check(
-            basic_info_func, "Provided authorization is not valid"
-        )
-
-    def check_api_key(self, api_key_info_func):
-        return self._generic_check(api_key_info_func, "Provided apikey is not valid")
 
     def check_oauth_func(self, token_info_func, scope_validate_func):
         get_token_info = self._generic_check(
@@ -403,17 +454,141 @@ class SecurityHandlerFactory:
 
         return wrapper
 
+
+SECURITY_HANDLERS = {
+    # Swagger 2: `type: basic`
+    # OpenAPI 3: `type: http` and `scheme: basic`
+    "basic": BasicSecurityHandler,
+    # Swagger 2 and OpenAPI 3
+    "apiKey": ApiKeySecurityHandler,
+    "oauth2": OAuthSecurityHandler,
+    # OpenAPI 3: http schemes
+    "bearer": BearerSecurityHandler,
+}
+
+
+class SecurityHandlerFactory:
+    """
+    A factory class for parsing security schemes and returning the appropriate
+    security handler.
+
+    By default, it will use the built-in security handlers specified in the
+    SECURITY_HANDLERS dict, but you can also pass in your own security handlers
+    to override the built-in ones.
+    """
+
+    def __init__(
+        self,
+        security_handlers: t.Optional[dict] = None,
+    ) -> None:
+        self.security_handlers = SECURITY_HANDLERS.copy()
+        if security_handlers is not None:
+            self.security_handlers.update(security_handlers)
+
+    def parse_security_scheme(
+        self,
+        security_scheme: dict,
+        required_scopes: t.List[str],
+    ) -> t.Optional[t.Callable]:
+        """Parses the security scheme and returns the function for verifying it.
+
+        :param security_scheme: The security scheme from the spec.
+        :param required_scopes: List of scopes for this security scheme.
+        """
+        security_type = security_scheme["type"]
+        if security_type in ("basic", "oauth2"):
+            security_handler = self.security_handlers[security_type]
+            return security_handler().get_fn(security_scheme, required_scopes)
+
+        # OpenAPI 3.0.0
+        elif security_type == "http":
+            scheme = security_scheme["scheme"].lower()
+            if scheme in self.security_handlers:
+                security_handler = self.security_handlers[scheme]
+                return security_handler().get_fn(security_scheme, required_scopes)
+            else:
+                logger.warning("... Unsupported http authorization scheme %s", scheme)
+                return None
+
+        elif security_type == "apiKey":
+            scheme = security_scheme.get("x-authentication-scheme", "").lower()
+            if scheme == "bearer":
+                return BearerSecurityHandler().get_fn(security_scheme, required_scopes)
+            else:
+                security_handler = self.security_handlers["apiKey"]
+                return security_handler().get_fn(security_scheme, required_scopes)
+
+        else:
+            logger.warning(
+                "... Unsupported security scheme type %s",
+                security_type,
+            )
+            return None
+
+    @staticmethod
+    async def security_passthrough(request):
+        """Used when no security is required for the operation.
+
+        Equivalent OpenAPI snippet:
+
+        .. code-block:: yaml
+
+            /helloworld
+              get:
+                security: []   # No security
+                ...
+        """
+        return request
+
+    @staticmethod
+    def verify_none(request):
+        """Used for optional security.
+
+        Equivalent OpenAPI snippet:
+
+        .. code-block:: yaml
+
+            security:
+              - {}  # <--
+              - myapikey: []
+        """
+        return {}
+
+    def verify_multiple_schemes(self, schemes):
+        """
+        Verifies multiple authentication schemes in AND fashion.
+        If any scheme fails, the entire authentication fails.
+
+        :param schemes: mapping scheme_name to auth function
+        :type schemes: dict
+        :rtype: types.FunctionType
+        """
+
+        async def wrapper(request):
+            token_info = {}
+            for scheme_name, func in schemes.items():
+                result = func(request)
+                while asyncio.iscoroutine(result):
+                    result = await result
+                if result is NO_VALUE:
+                    return NO_VALUE
+                token_info[scheme_name] = result
+
+            return token_info
+
+        return wrapper
+
     @classmethod
     def verify_security(cls, auth_funcs):
         async def verify_fn(request):
-            token_info = cls.no_value
+            token_info = NO_VALUE
             errors = []
             for func in auth_funcs:
                 try:
                     token_info = func(request)
                     while asyncio.iscoroutine(token_info):
                         token_info = await token_info
-                    if token_info is not cls.no_value:
+                    if token_info is not NO_VALUE:
                         break
                 except Exception as err:
                     errors.append(err)
@@ -465,28 +640,3 @@ class SecurityHandlerFactory:
         else:
             lowest_status_code = min(status_to_exc)
             raise status_to_exc[lowest_status_code]
-
-    def get_token_info_remote(self, token_info_url):
-        """
-        Return a function which will call `token_info_url` to retrieve token info.
-
-        Returned function must accept oauth token in parameter.
-        It must return a token_info dict in case of success, None otherwise.
-
-        :param token_info_url: Url to get information about the token
-        :type token_info_url: str
-        :rtype: types.FunctionType
-        """
-
-        async def wrapper(token):
-            if self.client is None:
-                self.client = httpx.AsyncClient()
-            headers = {"Authorization": f"Bearer {token}"}
-            token_request = await self.client.get(
-                token_info_url, headers=headers, timeout=5
-            )
-            if token_request.status_code != 200:
-                return
-            return token_request.json()
-
-        return wrapper

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from connexion.security import SecurityHandlerFactory
+from connexion.security import OAuthSecurityHandler
 
 
 class FakeResponse:
@@ -50,7 +50,7 @@ def oauth_requests(monkeypatch):
                     )
             return url
 
-    monkeypatch.setattr(SecurityHandlerFactory, "client", FakeClient())
+    monkeypatch.setattr(OAuthSecurityHandler, "client", FakeClient())
 
 
 def test_security_over_nonexistent_endpoints(oauth_requests, secure_api_app):


### PR DESCRIPTION
Make security pluggable

- [x] Solution for standard security handlers: `security_deny`, `security_passthrough`, `verify_none` 
- [x] HTTP security handlers & overlap with basic from swagger 2
- [x] Do we need a separate handler for each `oauth2` flow?