### PR TITLE
Pass through lifespan events

### DIFF
--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -212,6 +212,10 @@ class SwaggerUIMiddleware(SpecMiddleware):
         self.router.mount(api.base_path, app=api.router)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
         _original_scope.set(scope.copy())  # type: ignore
         await self.router(scope, receive, send)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from connexion.middleware import ConnexionMiddleware
 from starlette.datastructures import MutableHeaders
@@ -46,3 +48,13 @@ def test_routing_middleware(middleware_app):
     assert (
         response.headers.get("operation_id") == "fakeapi.hello.post_greeting"
     ), response.status_code
+
+
+async def test_lifecycle():
+    """Test that lifecycle events are passed correctly."""
+
+    async def check_lifecycle(scope, receive, send):
+        assert scope["type"] == "lifecycle"
+
+    test_app = ConnexionMiddleware(check_lifecycle)
+    await test_app({"type": "lifecycle"}, mock.AsyncMock, mock.AsyncMock)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -50,11 +51,17 @@ def test_routing_middleware(middleware_app):
     ), response.status_code
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="AsyncMock only available from 3.8."
+)
 async def test_lifecycle():
     """Test that lifecycle events are passed correctly."""
+    lifecycle_handler = mock.Mock()
 
     async def check_lifecycle(scope, receive, send):
-        assert scope["type"] == "lifecycle"
+        if scope["type"] == "lifecycle":
+            lifecycle_handler.handle()
 
     test_app = ConnexionMiddleware(check_lifecycle)
     await test_app({"type": "lifecycle"}, mock.AsyncMock, mock.AsyncMock)
+    lifecycle_handler.handle.assert_called()


### PR DESCRIPTION
Fixes #1672

Lifespan events were being intercepted by the swagger UI middleware. We should let them pass through.