### PR TITLE
Fix examples links in security doc page

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -48,8 +48,8 @@ You can find a `minimal OAuth example application`_ showing the use of
 ``x-tokenInfoUrl``, and `another OAuth example`_ showing the use of
 ``x-tokenInfoFunc`` in Connexion's "examples" folder.
 
-.. _minimal OAuth example application: https://github.com/zalando/connexion/tree/main/examples/swagger2/oauth2
-.. _another OAuth example: https://github.com/zalando/connexion/tree/main/examples/swagger2/oauth2_local_tokeninfo
+.. _minimal OAuth example application: https://github.com/spec-first/connexion/tree/main/examples/oauth2
+.. _another OAuth example: https://github.com/spec-first/connexion/tree/main/examples/oauth2_local_tokeninfo
 
 Basic Authentication
 --------------------
@@ -62,7 +62,7 @@ parameters: username, password and required_scopes.
 You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
 
 .. _oauth scope: https://oauth.net/2/scope/
-.. _minimal Basic Auth example application: https://github.com/zalando/connexion/tree/main/examples/openapi3/basicauth
+.. _minimal Basic Auth example application: https://github.com/spec-first/connexion/tree/main/examples/basicauth
 
 ApiKey Authentication
 ---------------------
@@ -81,7 +81,7 @@ With Connexion, the API security definition **must** include a
 ``x-bearerInfoFunc`` or set ``BEARERINFO_FUNC`` env var. It uses the same
 semantics as for ``x-tokenInfoFunc``, but the function accepts one parameter: token.
 
-You can find a `minimal JWT example application`_ in Connexion's "examples/openapi3" folder.
+You can find a `minimal JWT example application`_ in Connexion's "examples" folder.
 
 Multiple Authentication Schemes
 -------------------------------
@@ -134,7 +134,7 @@ parameters to the underlying `werkzeug`_ server.
 .. _rfc6750: https://tools.ietf.org/html/rfc6750
 .. _rfc6749: https://tools.ietf.org/html/rfc6749
 .. _rfc7662: https://tools.ietf.org/html/rfc7662
-.. _minimal API Key example application: https://github.com/zalando/connexion/blob/main/examples/openapi3/apikey
-.. _minimal JWT example application: https://github.com/zalando/connexion/tree/main/examples/openapi3/jwt
+.. _minimal API Key example application: https://github.com/spec-first/connexion/tree/main/examples/apikey
+.. _minimal JWT example application: https://github.com/spec-first/connexion/tree/main/examples/jwt
 .. _enabling authentication passthrough in modwsgi: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIPassAuthorization.html
 .. _modwsgi documentation: https://modwsgi.readthedocs.io/en/develop/index.html


### PR DESCRIPTION
Contributes to #1531 

The links in security doc were pointing at an old repo and folders.
These links could be changed down the road to use relative paths since they point to the repo internally.

