### PR TITLE
Fix stream replay in validators

### DIFF
--- a/connexion/validators/abstract.py
+++ b/connexion/validators/abstract.py
@@ -99,11 +99,14 @@ class AbstractRequestBodyValidator:
         receive: Receive, *, messages: t.Iterable[t.MutableMapping[str, t.Any]]
     ) -> Receive:
         """Insert messages at the start of the `receive` channel."""
+        # Ensure that messages in an iterator
+        messages = iter(messages)
 
         async def receive_() -> t.MutableMapping[str, t.Any]:
-            for message in messages:
-                return message
-            return await receive()
+            try:
+                return next(iter(messages))
+            except StopIteration:
+                return await receive()
 
         return receive_
 


### PR DESCRIPTION
The current implementation of replaying the stream will always replay the first message. This PR fixes this by progressing through the messages with each call.