### PR TITLE
Add tests for strict validation in combination with api key in query

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -115,6 +115,17 @@ def secure_endpoint_app(spec, app_class):
 
 
 @pytest.fixture(scope="session")
+def secure_endpoint_strict_app(spec, app_class):
+    return build_app_from_fixture(
+        "secure_endpoint",
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
+        strict_validation=True,
+    )
+
+
+@pytest.fixture(scope="session")
 def secure_api_app(spec, app_class):
     options = {"swagger_ui": False}
     return build_app_from_fixture(

--- a/tests/api/test_secure_api.py
+++ b/tests/api/test_secure_api.py
@@ -196,3 +196,29 @@ def test_checking_that_client_token_has_all_necessary_scopes(
     headers = {"Authorization": "Bearer has_scopes_in_scopes_with_s"}
     response = app_client.get("/v1.0/more-than-one-scope", headers=headers)
     assert response.status_code == 200
+
+
+def test_security_with_strict_validation(secure_endpoint_strict_app):
+    app_client = secure_endpoint_strict_app.test_client()
+
+    res = app_client.get("/v1.0/test_apikey_query_parameter_validation")
+    assert res.status_code == 401
+
+    res = app_client.get(
+        "/v1.0/test_apikey_query_parameter_validation",
+        params={"name": "foo"},
+    )
+    assert res.status_code == 401
+
+    res = app_client.get(
+        "/v1.0/test_apikey_query_parameter_validation",
+        params={"apikey": "mykey", "name": "foo"},
+    )
+    assert res.status_code == 200
+
+    res = app_client.get(
+        "/v1.0/test_apikey_query_parameter_validation",
+        params={"apikey": "mykey", "name": "foo", "extra_param": "bar"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Extra query parameter(s) extra_param not in spec"

--- a/tests/fixtures/secure_endpoint/openapi.yaml
+++ b/tests/fixtures/secure_endpoint/openapi.yaml
@@ -148,6 +148,19 @@ paths:
       responses:
         '200':
           description: some response
+  /test_apikey_query_parameter_validation:
+    get:
+      operationId: fakeapi.hello.test_apikey_query_parameter_validation
+      parameters:
+        - name: name
+          in: query
+          schema:
+            type: string
+      security:
+        - api_key_query: []
+      responses:
+        '200':
+          description: OK
 
 servers:
   - url: /v1.0
@@ -177,3 +190,8 @@ components:
       name: X-Api-Key
       in: header
       x-apikeyInfoFunc: fakeapi.hello.apikey_exception
+    api_key_query:
+      type: apiKey
+      name: apikey
+      in: query
+      x-apikeyInfoFunc: fakeapi.hello.apikey_info

--- a/tests/fixtures/secure_endpoint/swagger.yaml
+++ b/tests/fixtures/secure_endpoint/swagger.yaml
@@ -35,6 +35,12 @@ securityDefinitions:
       in: header
       x-apikeyInfoFunc: fakeapi.hello.apikey_exception
 
+    api_key_query:
+      type: apiKey
+      name: apikey
+      in: query
+      x-apikeyInfoFunc: fakeapi.hello.apikey_info
+
 paths:
   /byesecure/{name}:
     get:
@@ -188,3 +194,16 @@ paths:
       responses:
         '200':
           description: some response
+
+  /test_apikey_query_parameter_validation:
+    get:
+      operationId: fakeapi.hello.test_apikey_query_parameter_validation
+      parameters:
+        - name: name
+          in: query
+          type: string
+      security:
+        - api_key_query: []
+      responses:
+        200:
+          description: OK

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -372,19 +372,6 @@ paths:
       responses:
         '200':
           description: OK
-  /test_apikey_query_parameter_validation:
-    get:
-      operationId: fakeapi.hello.test_apikey_query_parameter_validation
-      parameters:
-        - name: name
-          in: query
-          schema:
-            type: string
-      security:
-        - api_key: []
-      responses:
-        '200':
-          description: OK
   /test_required_query_param:
     get:
       operationId: fakeapi.hello.test_required_query_param
@@ -1347,9 +1334,3 @@ components:
       required: true
       schema:
         type: string
-  securitySchemes:
-    api_key:
-      type: apiKey
-      name: apikey
-      in: query
-      x-apikeyInfoFunc: fakeapi.hello.apikey_info

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -259,19 +259,6 @@ paths:
         200:
           description: OK
 
-  /test_apikey_query_parameter_validation:
-    get:
-      operationId: fakeapi.hello.test_apikey_query_parameter_validation
-      parameters:
-        - name: name
-          in: query
-          type: string
-      security:
-        - api_key: []
-      responses:
-        200:
-          description: OK
-
   /test_required_query_param:
     get:
       operationId: fakeapi.hello.test_required_query_param
@@ -1112,10 +1099,3 @@ definitions:
         description: Docker image version to deploy
     required:
       - image_version
-
-securityDefinitions:
-    api_key:
-      type: apiKey
-      name: apikey
-      in: query
-      x-apikeyInfoFunc: fakeapi.hello.apikey_info


### PR DESCRIPTION
Continues on the work of #1077 by moving the test fixtures into the `secure_endpoint` fixture and adding a test for it in `test_secure_api.py`.

The test will check whether an api key in the query will not lead to an error when `strict_validation` is enabled.
