### PR TITLE
Add `add_middleware` interface

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -7,10 +7,10 @@ import pathlib
 import typing as t
 
 from starlette.testclient import TestClient
-from starlette.types import Receive, Scope, Send
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.jsonifier import Jsonifier
-from connexion.middleware import ConnexionMiddleware, SpecMiddleware
+from connexion.middleware import ConnexionMiddleware, MiddlewarePosition, SpecMiddleware
 from connexion.middleware.lifespan import Lifespan
 from connexion.resolver import Resolver
 from connexion.uri_parsing import AbstractURIParser
@@ -96,6 +96,20 @@ class AbstractApp:
             validate_responses=validate_responses,
             validator_map=validator_map,
         )
+
+    def add_middleware(
+        self,
+        middleware_class: t.Type[ASGIApp],
+        position: MiddlewarePosition = MiddlewarePosition.BEFORE_CONTEXT,
+        **options: t.Any,
+    ) -> None:
+        """Add a middleware to the stack on the specified position.
+
+        :param middleware_class: Middleware class to add
+        :param position: Position to add the middleware, one of the MiddlewarePosition Enum
+        :param options: Options to pass to the middleware_class on initialization
+        """
+        self.middleware.add_middleware(middleware_class, position=position, **options)
 
     def add_api(
         self,

--- a/connexion/middleware/__init__.py
+++ b/connexion/middleware/__init__.py
@@ -1,2 +1,2 @@
 from .abstract import SpecMiddleware  # NOQA
-from .main import ConnexionMiddleware  # NOQA
+from .main import ConnexionMiddleware, MiddlewarePosition  # NOQA

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -149,7 +149,10 @@ class ConnexionMiddleware:
         import_name = import_name or str(pathlib.Path.cwd())
         self.root_path = utils.get_root_path(import_name)
 
-        self.specification_dir = self.ensure_absolute(specification_dir)
+        spec_dir = pathlib.Path(specification_dir)
+        self.specification_dir = (
+            spec_dir if spec_dir.absolute() else self.root_path / spec_dir
+        )
 
         if middlewares is None:
             middlewares = self.default_middlewares
@@ -172,15 +175,6 @@ class ConnexionMiddleware:
         )
 
         self.extra_files: t.List[str] = []
-
-    def ensure_absolute(self, path: t.Union[str, pathlib.Path]) -> pathlib.Path:
-        """Ensure that a path is absolute. If the path is not absolute, it is assumed to relative
-        to the application root path and made absolute."""
-        path = pathlib.Path(path)
-        if path.is_absolute():
-            return path
-        else:
-            return self.root_path / path
 
     def _apply_middlewares(
         self, app: ASGIApp, middlewares: t.List[t.Type[ASGIApp]], **kwargs

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -1,8 +1,10 @@
 import dataclasses
+import enum
 import logging
 import pathlib
 import typing as t
 from dataclasses import dataclass, field
+from functools import partial
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -81,6 +83,22 @@ class _Options:
         return dataclasses.replace(self, **changes)
 
 
+class MiddlewarePosition(enum.Enum):
+
+    BEFORE_SWAGGER = SwaggerUIMiddleware
+    BEFORE_ROUTING = RoutingMiddleware
+    BEFORE_SECURITY = SecurityMiddleware
+    BEFORE_VALIDATION = RequestValidationMiddleware
+    BEFORE_CONTEXT = ContextMiddleware
+
+
+class API:
+    def __init__(self, specification, *, base_path, **kwargs) -> None:
+        self.specification = specification
+        self.base_path = base_path
+        self.kwargs = kwargs
+
+
 class ConnexionMiddleware:
     """The main Connexion middleware, which wraps a list of specialized middlewares around the
     provided application."""
@@ -92,8 +110,8 @@ class ConnexionMiddleware:
         SecurityMiddleware,
         RequestValidationMiddleware,
         ResponseValidationMiddleware,
-        ContextMiddleware,
         LifespanMiddleware,
+        ContextMiddleware,
     ]
 
     def __init__(
@@ -102,7 +120,7 @@ class ConnexionMiddleware:
         *,
         import_name: t.Optional[str] = None,
         lifespan: t.Optional[Lifespan] = None,
-        middlewares: t.Optional[list] = None,
+        middlewares: t.Optional[t.List[ASGIApp]] = None,
         specification_dir: t.Union[pathlib.Path, str] = "",
         arguments: t.Optional[dict] = None,
         auth_all_paths: t.Optional[bool] = None,
@@ -151,14 +169,17 @@ class ConnexionMiddleware:
 
         spec_dir = pathlib.Path(specification_dir)
         self.specification_dir = (
-            spec_dir if spec_dir.absolute() else self.root_path / spec_dir
+            spec_dir if spec_dir.is_absolute() else self.root_path / spec_dir
         )
 
-        if middlewares is None:
-            middlewares = self.default_middlewares
-        self.app, self.apps = self._apply_middlewares(
-            app, middlewares, lifespan=lifespan
+        self.app = app
+        self.lifespan = lifespan
+        self.middlewares = (
+            middlewares if middlewares is not None else self.default_middlewares
         )
+        self.middleware_stack: t.Optional[t.Iterable[ASGIApp]] = None
+        self.apis: t.List[API] = []
+        self.error_handlers: t.List[tuple] = []
 
         self.options = _Options(
             arguments=arguments,
@@ -176,23 +197,58 @@ class ConnexionMiddleware:
 
         self.extra_files: t.List[str] = []
 
-    def _apply_middlewares(
-        self, app: ASGIApp, middlewares: t.List[t.Type[ASGIApp]], **kwargs
-    ) -> t.Tuple[ASGIApp, t.Iterable[ASGIApp]]:
-        """Apply all middlewares to the provided app.
+    def add_middleware(
+        self,
+        middleware_class: t.Type[ASGIApp],
+        *,
+        position: MiddlewarePosition = MiddlewarePosition.BEFORE_CONTEXT,
+        **options: t.Any,
+    ) -> None:
+        """Add a middleware to the stack on the specified position.
 
-        :param app: App to wrap in middlewares.
-        :param middlewares: List of middlewares to wrap around app. The list should be ordered
-                            from outer to inner middleware.
+        :param middleware_class: Middleware class to add
+        :param position: Position to add the middleware, one of the MiddlewarePosition Enum
+        :param options: Options to pass to the middleware_class on initialization
+        """
+        if self.middleware_stack is not None:
+            raise RuntimeError("Cannot add middleware after an application has started")
+
+        for m, middleware in enumerate(self.middlewares):
+            if isinstance(middleware, partial):
+                middleware = middleware.func
+
+            if middleware == position:
+                self.middlewares.insert(
+                    m, t.cast(ASGIApp, partial(middleware_class, **options))
+                )
+                break
+
+    def _build_middleware_stack(self) -> t.Tuple[ASGIApp, t.Iterable[ASGIApp]]:
+        """Apply all middlewares to the provided app.
 
         :return: Tuple of the outer middleware wrapping the application and a list of the wrapped
             middlewares, including the wrapped application.
         """
         # Include the wrapped application in the returned list.
+        app = self.app
         apps = [app]
-        for middleware in reversed(middlewares):
-            app = middleware(app, **kwargs)  # type: ignore
+        for middleware in reversed(self.middlewares):
+            app = middleware(app, lifespan=self.lifespan)  # type: ignore
             apps.append(app)
+
+        for app in apps:
+            if isinstance(app, SpecMiddleware):
+                for api in self.apis:
+                    app.add_api(
+                        api.specification,
+                        base_path=api.base_path,
+                        **api.kwargs,
+                    )
+
+            if isinstance(app, ExceptionMiddleware):
+                for error_handler in self.error_handlers:
+                    app.add_exception_handler(error_handler)
+
         return app, list(reversed(apps))
 
     def add_api(
@@ -212,7 +268,7 @@ class ConnexionMiddleware:
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
         **kwargs,
-    ) -> t.Any:
+    ) -> None:
         """
         Register een API represented by a single OpenAPI specification on this middleware.
         Multiple APIs can be registered on a single middleware.
@@ -247,6 +303,9 @@ class ConnexionMiddleware:
 
         :return: The Api registered on the wrapped application.
         """
+        if self.middleware_stack is not None:
+            raise RuntimeError("Cannot add api after an application has started")
+
         if isinstance(specification, dict):
             specification = specification
         else:
@@ -271,24 +330,19 @@ class ConnexionMiddleware:
             validator_map=validator_map,
         )
 
-        for app in self.apps:
-            if isinstance(app, SpecMiddleware):
-                api = app.add_api(
-                    specification,
-                    base_path=base_path,
-                    **options.__dict__,
-                    **kwargs,
-                )
-
-        # Api registered on the inner application.
-        return api
+        api = API(specification, base_path=base_path, **options.__dict__, **kwargs)
+        self.apis.append(api)
 
     def add_error_handler(
         self, code_or_exception: t.Union[int, t.Type[Exception]], function: t.Callable
     ) -> None:
-        for app in self.apps:
-            if isinstance(app, ExceptionMiddleware):
-                app.add_exception_handler(code_or_exception, function)
+        if self.middleware_stack is not None:
+            raise RuntimeError(
+                "Cannot add error handler after an application has started"
+            )
+
+        error_handler = (code_or_exception, function)
+        self.error_handlers.append(error_handler)
 
     def run(self, import_string: str = None, **kwargs):
         """Run the application using uvicorn.
@@ -323,4 +377,6 @@ class ConnexionMiddleware:
         uvicorn.run(app, **kwargs)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.middleware_stack is None:
+            self.app, self.middleware_stack = self._build_middleware_stack()
         await self.app(scope, receive, send)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ OPENAPI3_SPEC = "openapi.yaml"
 SPECS = [OPENAPI2_SPEC, OPENAPI3_SPEC]
 METHOD_VIEW_RESOLVERS = [MethodResolver, MethodViewResolver]
 APP_CLASSES = [FlaskApp, AsyncApp]
-# APP_CLASSES = [FlaskApp]
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import logging
 from unittest.mock import MagicMock
 
-import connexion
 import importlib_metadata
 import pytest
 from click.testing import CliRunner
@@ -11,13 +10,27 @@ from connexion.exceptions import ResolverError
 from conftest import FIXTURES_FOLDER
 
 
-@pytest.fixture()
-def mock_app_run(mock_get_function_from_name):
-    test_server = MagicMock(wraps=connexion.FlaskApp(__name__))
-    test_server.run = MagicMock(return_value=True)
-    test_app = MagicMock(return_value=test_server)
-    mock_get_function_from_name.return_value = test_app
-    return test_app
+@pytest.fixture(scope="function")
+def mock_app_run(app_class, monkeypatch):
+    mocked_app = MagicMock(name="mocked_app", wraps=app_class(__name__))
+
+    def mocked_run(*args, **kwargs):
+        mocked_app.middleware._build_middleware_stack()
+
+    mocked_app.run = MagicMock(name="mocked_app.run", side_effect=mocked_run)
+
+    def get_mocked_app(*args, **kwargs):
+        return mocked_app
+
+    mocked_app_class = MagicMock(name="mocked_app_class", side_effect=get_mocked_app)
+
+    def get_mocked_app_class(*args, **kwargs):
+        return mocked_app_class
+
+    monkeypatch.setattr(
+        "connexion.cli.connexion.utils.get_function_from_name", get_mocked_app_class
+    )
+    return mocked_app_class
 
 
 @pytest.fixture()
@@ -170,23 +183,34 @@ def test_run_using_option_base_path(mock_app_run, expected_arguments, spec_file)
         validate_responses=False,
         strict_validation=False,
     )
-    mock_app_run().add_api.assert_called_with(spec_file, **expected_arguments)
+    app_instance = mock_app_run()
+    app_instance.add_api.assert_called_with(spec_file, **expected_arguments)
 
 
-def test_run_unimplemented_operations_and_stub(mock_app_run):
+def test_run_unimplemented_operations(mock_app_run):
     runner = CliRunner()
 
     spec_file = str(FIXTURES_FOLDER / "missing_implementation/swagger.yaml")
     with pytest.raises(ResolverError):
         runner.invoke(main, ["run", spec_file], catch_exceptions=False)
-    # yet can be run with --stub option
-    result = runner.invoke(main, ["run", spec_file, "--stub"], catch_exceptions=False)
-    assert result.exit_code == 0
 
     spec_file = str(FIXTURES_FOLDER / "module_does_not_exist/swagger.yaml")
     with pytest.raises(ResolverError):
         runner.invoke(main, ["run", spec_file], catch_exceptions=False)
-    # yet can be run with --stub option
+
+
+def test_run_unimplemented_operations_with_stub1(mock_app_run):
+    runner = CliRunner()
+
+    spec_file = str(FIXTURES_FOLDER / "missing_implementation/swagger.yaml")
+    result = runner.invoke(main, ["run", spec_file, "--stub"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+
+def test_run_unimplemented_operations_with_stub2(mock_app_run):
+    runner = CliRunner()
+
+    spec_file = str(FIXTURES_FOLDER / "module_does_not_exist/swagger.yaml")
     result = runner.invoke(main, ["run", spec_file, "--stub"], catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -195,9 +219,6 @@ def test_run_unimplemented_operations_and_mock(mock_app_run):
     runner = CliRunner()
 
     spec_file = str(FIXTURES_FOLDER / "missing_implementation/swagger.yaml")
-    with pytest.raises(ResolverError):
-        runner.invoke(main, ["run", spec_file], catch_exceptions=False)
-    # yet can be run with --mock option
     result = runner.invoke(
         main, ["run", spec_file, "--mock=all"], catch_exceptions=False
     )


### PR DESCRIPTION
This PR adds an `add_middleware` method to the apps and `ConnexionMiddleware` to easily add middleware to the stack. Before, the only way to do this was to pass in a complete middleware stack.

The default position to add the new middleware is right before the `ContextMiddleware`, which is the final middleware in the stack. Another position can be selected by passing in a `MiddlewarePosition` enum, which defines some positions which make sense.

Since we can no longer assume that the whole middleware stack is defined when initializing the `ConnexionMiddleware`, we need to delay building the middleware stack until the `ConnexionMiddleware` is actually called. This also means we need to delay registering the APIs and error handlers. This is now all done in the `_build_middleware_stack` method.