### PR TITLE
Inspect middleware parameters before passing in lifespan

### DIFF
--- a/connexion/decorators/parameter.py
+++ b/connexion/decorators/parameter.py
@@ -5,7 +5,6 @@ import abc
 import asyncio
 import builtins
 import functools
-import inspect
 import keyword
 import logging
 import re
@@ -19,7 +18,13 @@ from connexion.frameworks.abstract import Framework
 from connexion.http_facts import FORM_CONTENT_TYPES
 from connexion.lifecycle import ASGIRequest, WSGIRequest
 from connexion.operations import AbstractOperation, Swagger2Operation
-from connexion.utils import deep_merge, is_null, is_nullable, make_type
+from connexion.utils import (
+    deep_merge,
+    inspect_function_arguments,
+    is_null,
+    is_nullable,
+    make_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,21 +159,6 @@ def unwrap_decorators(function: t.Callable) -> t.Callable:
     while hasattr(function, "__wrapped__"):
         function = function.__wrapped__  # type: ignore
     return function
-
-
-def inspect_function_arguments(function: t.Callable) -> t.Tuple[t.List[str], bool]:
-    """
-    Returns the list of variables names of a function and if it
-    accepts keyword arguments.
-    """
-    parameters = inspect.signature(function).parameters
-    bound_arguments = [
-        name
-        for name, p in parameters.items()
-        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
-    ]
-    has_kwargs = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
-    return list(bound_arguments), has_kwargs
 
 
 def snake_and_shadow(name: str) -> str:

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -230,7 +230,7 @@ class RoutedMiddleware(SpecMiddleware, t.Generic[API]):
     api_cls: t.Type[API]
     """The subclass of RoutedAPI this middleware uses."""
 
-    def __init__(self, app: ASGIApp, **kwargs) -> None:
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
         self.apis: t.Dict[str, API] = {}
 

--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -15,7 +15,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
     """Subclass of starlette ExceptionMiddleware to change handling of HTTP exceptions to
     existing connexion behavior."""
 
-    def __init__(self, next_app: ASGIApp, *args, **kwargs):
+    def __init__(self, next_app: ASGIApp):
         super().__init__(next_app)
         self.add_exception_handler(ProblemException, self.problem_handler)
         self.add_exception_handler(Exception, self.common_error_handler)

--- a/connexion/middleware/lifespan.py
+++ b/connexion/middleware/lifespan.py
@@ -12,9 +12,7 @@ class LifespanMiddleware:
     (https://www.starlette.io/lifespan/).
     """
 
-    def __init__(
-        self, next_app: ASGIApp, *, lifespan: t.Optional[Lifespan], **kwargs
-    ) -> None:
+    def __init__(self, next_app: ASGIApp, *, lifespan: t.Optional[Lifespan]) -> None:
         self.next_app = next_app
         self._lifespan = lifespan
         # Leverage a Starlette Router for lifespan handling only

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -239,7 +239,7 @@ class ConnexionMiddleware:
         app = self.app
         apps = [app]
         for middleware in reversed(self.middlewares):
-            arguments, has_kwargs = inspect_function_arguments(middleware)
+            arguments, _ = inspect_function_arguments(middleware)
             if "lifespan" in arguments:
                 app = middleware(app, lifespan=self.lifespan)  # type: ignore
             else:

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -22,6 +22,7 @@ from connexion.middleware.security import SecurityMiddleware
 from connexion.middleware.swagger_ui import SwaggerUIMiddleware
 from connexion.resolver import Resolver
 from connexion.uri_parsing import AbstractURIParser
+from connexion.utils import inspect_function_arguments
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +239,11 @@ class ConnexionMiddleware:
         app = self.app
         apps = [app]
         for middleware in reversed(self.middlewares):
-            app = middleware(app, lifespan=self.lifespan)  # type: ignore
+            arguments, has_kwargs = inspect_function_arguments(middleware)
+            if "lifespan" in arguments:
+                app = middleware(app, lifespan=self.lifespan)  # type: ignore
+            else:
+                app = middleware(app)  # type: ignore
             apps.append(app)
 
         for app in apps:

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -92,7 +92,7 @@ class RoutingAPI(AbstractRoutingAPI):
 
 
 class RoutingMiddleware(SpecMiddleware):
-    def __init__(self, app: ASGIApp, **kwargs) -> None:
+    def __init__(self, app: ASGIApp) -> None:
         """Middleware that resolves the Operation for an incoming request and attaches it to the
         scope.
 

--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -180,7 +180,7 @@ class SwaggerUIAPI(AbstractSpecAPI):
 
 
 class SwaggerUIMiddleware(SpecMiddleware):
-    def __init__(self, app: ASGIApp, **kwargs) -> None:
+    def __init__(self, app: ASGIApp) -> None:
         """Middleware that hosts a swagger UI.
 
         :param app: app to wrap in middleware.

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -5,6 +5,7 @@ This module provides general utility functions used within Connexion.
 import asyncio
 import functools
 import importlib
+import inspect
 import os
 import pkgutil
 import sys
@@ -407,3 +408,18 @@ def get_root_path(import_name: str) -> str:
 
     # filepath is import_name.py for a module, or __init__.py for a package.
     return os.path.dirname(os.path.abspath(filepath))
+
+
+def inspect_function_arguments(function: t.Callable) -> t.Tuple[t.List[str], bool]:
+    """
+    Returns the list of variables names of a function and if it
+    accepts keyword arguments.
+    """
+    parameters = inspect.signature(function).parameters
+    bound_arguments = [
+        name
+        for name, p in parameters.items()
+        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    ]
+    has_kwargs = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
+    return list(bound_arguments), has_kwargs

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,7 +13,7 @@ class TestMiddleware:
 
     __test__ = False
 
-    def __init__(self, app, **kwargs):
+    def __init__(self, app):
         self.app = app
 
     async def __call__(self, scope, receive, send):


### PR DESCRIPTION
Fixes #1682 

This PR inspects the parameters of a Middleware class before passing in the `lifespan` keyword argument. I was doubting to check the class instead (`isinstance(LifespanMiddleware)`), but that's less flexible if users want to write custom middleware to handle the lifespan.
