### PR TITLE
Unpack error handler when registering on middleware

### DIFF
--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -257,7 +257,7 @@ class ConnexionMiddleware:
 
             if isinstance(app, ExceptionMiddleware):
                 for error_handler in self.error_handlers:
-                    app.add_exception_handler(error_handler)
+                    app.add_exception_handler(*error_handler)
 
         return app, list(reversed(apps))
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -295,3 +295,16 @@ def test_async_route(simple_app):
     app_client = simple_app.test_client()
     resp = app_client.get("/v1.0/async-route")
     assert resp.status_code == 200
+
+
+def test_add_error_handler(app_class, simple_api_spec_dir):
+    app = app_class(__name__, specification_dir=simple_api_spec_dir)
+    app.add_api("openapi.yaml")
+
+    def custom_error_handler(_request, _exception):
+        pass
+
+    app.add_error_handler(Exception, custom_error_handler)
+    app.add_error_handler(500, custom_error_handler)
+
+    app.middleware._build_middleware_stack()


### PR DESCRIPTION
Registering error handlers on the async app leads to an error on 3.0.0a5 because the error handlers are not unpacked correctly when being registered internally.
