### PR TITLE
Add traceback info to common error handler

### DIFF
--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -52,7 +52,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
 
     @staticmethod
     def common_error_handler(_request: StarletteRequest, exc: Exception) -> Response:
-        logger.error(exc)
+        logger.error(exc, exc_info=exc)
 
         response = InternalServerError().to_problem()
 


### PR DESCRIPTION
Still up for discussion: right now, when an internal server error occurs, the logged error is not really useful for the user.
For example, a `KeyError` will only print the missing key instead of the full stacktrace and error.

Adding it to the common error handler as that one is meant to catch all remaining errors, `HTTPException`s are handled by another error handler.

Another option would be to do like `Flask` and `Starlette` by adding a `debug` option, but that seems a lot of work while this current solution doesn't really have big downsides (?)
