### PR TITLE
Deepcopy only headers in validator

### DIFF
--- a/connexion/validators/abstract.py
+++ b/connexion/validators/abstract.py
@@ -76,7 +76,8 @@ class AbstractRequestBodyValidator:
         bytes_body = json.dumps(body).encode(self._encoding)
 
         # Update the content-length header
-        new_scope = copy.deepcopy(scope)
+        new_scope = scope.copy()
+        new_scope["headers"] = copy.deepcopy(scope["headers"])
         headers = MutableHeaders(scope=new_scope)
         headers["content-length"] = str(len(bytes_body))
 


### PR DESCRIPTION
Fixes the failing pipeline.

I don't understand the underlying issue completely, but It's related to [this code](https://github.com/encode/starlette/compare/0.27.0...0.28.0#diff-87bccafe494bc79680d9d8f57ea797733354b076aa411c0e2bd63f5b4039f71fR51-R54) added in starlette 0.28. This makes the scope unpicklable in some cases, leading to an error when trying to deepcopy it.

I replaced the deepcopy of the whole scope with just a deepcopy of the headers, since this is the only part we're chaning.