### PR TITLE
Use repr for error logging

### DIFF
--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -24,7 +24,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
 
     @staticmethod
     def problem_handler(_request: StarletteRequest, exc: ProblemException):
-        logger.error(exc)
+        logger.error("%r", exc)
 
         response = exc.to_problem()
 
@@ -37,7 +37,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
 
     @staticmethod
     def http_exception(_request: StarletteRequest, exc: HTTPException) -> Response:
-        logger.error(exc)
+        logger.error("%r", exc)
 
         headers = exc.headers
 
@@ -54,7 +54,7 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
 
     @staticmethod
     def common_error_handler(_request: StarletteRequest, exc: Exception) -> Response:
-        logger.error(exc, exc_info=exc)
+        logger.error("%r", exc, exc_info=exc)
 
         response = InternalServerError().to_problem()
 


### PR DESCRIPTION
Follow-up on #1708 ([comment](https://github.com/spec-first/connexion/pull/1708#issuecomment-1581196226))

As mentioned there, there is a `__repr__` but not a `__str__`, leading to an empty log message (for HTTPExceptions).

An example when running the dev server (previously the first line would just be an empty line):
```
HTTPException(status_code=404, detail='Not Found')
INFO:     127.0.0.1:33538 - "GET /swaggers/ui/ HTTP/1.1" 404 Not Found
```

However, I would also be fine with just removing the logging here as `HTTPException`s can be part of the normal flow, without indicating an actual application error (case in point: raising a `Not Found` exception)