### PR TITLE
Fix-bug: The JSON data of requests.post has been incorrectly discarded.

### DIFF
--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -277,6 +277,7 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         """
         ret = {}
         ret.update(self._get_path_arguments(path_params, sanitize))
+        ret.update(self._get_query_arguments(body, sanitize))
         ret.update(self._get_query_arguments(query_params, arguments,
                                              has_kwargs, sanitize))
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -277,8 +277,6 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         """
         ret = {}
         ret.update(self._get_path_arguments(path_params, sanitize))
-        ret.update(self._get_query_arguments(body, arguments,
-                                             has_kwargs, sanitize))
         ret.update(self._get_query_arguments(query_params, arguments,
                                              has_kwargs, sanitize))
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -277,7 +277,8 @@ class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
         """
         ret = {}
         ret.update(self._get_path_arguments(path_params, sanitize))
-        ret.update(self._get_query_arguments(body, sanitize))
+        ret.update(self._get_query_arguments(body, arguments,
+                                             has_kwargs, sanitize))
         ret.update(self._get_query_arguments(query_params, arguments,
                                              has_kwargs, sanitize))
 

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -284,6 +284,13 @@ class OpenAPIOperation(AbstractOperation):
             warnings.warn('x-body-name within the requestBody schema will be deprecated in the '
                           'next major version. It should be provided directly under '
                           'the requestBody instead.', DeprecationWarning)
+        else:
+            result = {}
+            for k in arguments:
+                if k not in body:
+                    continue
+                result[k] = body[k]
+            return result
 
         # prefer the x-body-name as an extension of requestBody, fallback to deprecated schema name, default 'body'
         x_body_name = sanitize(self.request_body.get('x-body-name', x_body_name or 'body'))

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -284,7 +284,7 @@ class OpenAPIOperation(AbstractOperation):
             warnings.warn('x-body-name within the requestBody schema will be deprecated in the '
                           'next major version. It should be provided directly under '
                           'the requestBody instead.', DeprecationWarning)
-        else:
+        else: # When x-body-name is not present in body_schema, consider that the body is used to pass POST parameters.
             result = {}
             for k in arguments:
                 if k not in body:


### PR DESCRIPTION
Fixes  #1726.


Changes proposed in this pull request:
In `_get_body_argument()` of openapi.py
 - When x-body-name is not present in body_schema, consider that the body is used to pass HTTP request parameters.

