### PR TITLE
Modifications to work with Flask 3.0.0

### DIFF
--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -80,6 +80,10 @@ class FlaskApi(AbstractRoutingAPI):
 
     def _set_blueprint(self):
         endpoint = flask_utils.flaskify_endpoint(self.base_path)
+        if endpoint == "" and self.base_path != "":
+            endpoint = self.base_path
+        elif endpoint == "":
+            endpoint = "/"
         self.blueprint = flask.Blueprint(
             endpoint,
             __name__,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 connexion = 'connexion.cli:main'
 
 [tool.poetry.dependencies]
-python = '^3.7'
+python = '>=3.8,<4.0'
 asgiref = ">= 3.4"
 clickclick = ">= 1.2"
 httpx = ">= 0.23"
@@ -60,9 +60,9 @@ typing-extensions = ">= 4"
 werkzeug = ">= 2.2.1"
 
 a2wsgi = { version = ">= 1.7", optional = true }
-flask = { version = ">= 2.2", extras = ["async"], optional = true }
 py-swagger-ui = { version = ">= 1.1.0", optional = true }
 uvicorn = { version = ">= 0.17.6", extras = ["standard"], optional = true }
+flask = {version = "3.0.0", extras = ["async"]}
 
 [tool.poetry.extras]
 flask = ["a2wsgi", "flask"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,8 @@ from connexion.exceptions import InvalidSpecification, ResolverError
 from connexion.spec import Specification, canonical_base_path
 from yaml import YAMLError
 
+# import pytest
+
 TEST_FOLDER = pathlib.Path(__file__).parent
 
 
@@ -37,9 +39,10 @@ def test_api():
     assert api4.blueprint.url_prefix == "/v1.0"
 
 
+# @pytest.mark.cheers
 def test_api_base_path_slash():
     api = FlaskApi(TEST_FOLDER / "fixtures/simple/basepath-slash.yaml")
-    assert api.blueprint.name == ""
+    assert api.blueprint.name == "/"
     assert api.blueprint.url_prefix == ""
 
 


### PR DESCRIPTION
Fixes # .

- Modifications required to enable `connexion` to work with `flask 3.0.0`

Changes proposed in this pull request:

 - `Flask Blueprint` requires a name, that is not an empty string. Thus, I add a condition to handle the case of empty string
 - I updated the relevant testcase accordingly
