### PR TITLE
Drop Python 3.7 in favor of 3.11 and 3.12

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -79,7 +79,7 @@ class FlaskApi(AbstractRoutingAPI):
         self._set_blueprint()
 
     def _set_blueprint(self):
-        endpoint = flask_utils.flaskify_endpoint(self.base_path)
+        endpoint = flask_utils.flaskify_endpoint(self.base_path) or "/"
         self.blueprint = flask.Blueprint(
             endpoint,
             __name__,

--- a/connexion/cli.py
+++ b/connexion/cli.py
@@ -3,6 +3,7 @@ This module defines a command-line interface (CLI) that runs an OpenAPI specific
 starting point for developing your API with Connexion.
 """
 
+import importlib.metadata
 import logging
 import sys
 from os import path
@@ -12,11 +13,6 @@ from clickclick import AliasedGroup
 
 import connexion
 from connexion.mock import MockResolver
-
-try:
-    import importlib_metadata
-except ImportError:
-    import importlib.metadata as importlib_metadata  # type: ignore
 
 logger = logging.getLogger("connexion.cli")
 
@@ -35,7 +31,7 @@ app = None
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo(f"Connexion {importlib_metadata.version('connexion')}")
+    click.echo(f"Connexion {importlib.metadata.version('connexion')}")
     ctx.exit()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
@@ -44,11 +44,10 @@ classifiers = [
 connexion = 'connexion.cli:main'
 
 [tool.poetry.dependencies]
-python = '^3.7'
+python = '^3.8'
 asgiref = ">= 3.4"
 clickclick = ">= 1.2"
 httpx = ">= 0.23"
-importlib_metadata = { version = ">=6.0.0", python = "<3.8" }
 inflection = ">= 0.3.1"
 jsonschema = ">= 4.0.1"
 Jinja2 = ">= 3.0.0"

--- a/tests/decorators/test_parameter.py
+++ b/tests/decorators/test_parameter.py
@@ -1,11 +1,5 @@
 import sys
-from unittest.mock import MagicMock
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Python 3.7
-    AsyncMock = None
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from connexion.decorators.parameter import (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,7 +39,7 @@ def test_api():
 
 def test_api_base_path_slash():
     api = FlaskApi(TEST_FOLDER / "fixtures/simple/basepath-slash.yaml")
-    assert api.blueprint.name == ""
+    assert api.blueprint.name == "/"
     assert api.blueprint.url_prefix == ""
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,16 @@ extend-ignore=E203,RST303
 [tox]
 isolated_build = True
 envlist =
-    {py37,py38,py39,py310}-{min,pypi}
+    {py38,py39,py310,py311,py312}-{min,pypi}
     pre-commit
 
 [gh-actions]
 python =
-    3.7: py37-min,py37-pypi
     3.8: py38-min,py38-pypi
     3.9: py39-min,py39-pypi
-    3.10: py310-min,py310-pypi,pre-commit
+    3.10: py310-min,py310-pypi
+    3.11: py311-min,py311-pypi,pre-commit
+    3.12: py312-min,py312-pypi
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -9,16 +9,17 @@ extend-ignore=E203,RST303
 [tox]
 isolated_build = True
 envlist =
-    {py38,py39,py310,py311,py312}-{min,pypi}
+    py38-min
+    {py38,py39,py310,py311,py312}-pypi
     pre-commit
 
 [gh-actions]
 python =
     3.8: py38-min,py38-pypi
-    3.9: py39-min,py39-pypi
-    3.10: py310-min,py310-pypi
-    3.11: py311-min,py311-pypi,pre-commit
-    3.12: py312-min,py312-pypi
+    3.9: py39-pypi
+    3.10: py310-pypi
+    3.11: py311-pypi,pre-commit
+    3.12: py312-pypi
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
Python 3.7 is end of life. We should support the newer versions instead.

I also changed tox to only run against the minimum dependency versions on the lowest Python version, since this should lead to the lowest versions over all Python versions, and hopefully helps speed up our pipelines :)