### PR TITLE
Switch back from py-swagger-ui to swagger-ui-bundle

### DIFF
--- a/connexion/options.py
+++ b/connexion/options.py
@@ -6,7 +6,7 @@ import logging
 import typing as t
 
 try:
-    from py_swagger_ui import swagger_ui_path as default_template_dir
+    from swagger_ui_bundle import swagger_ui_path as default_template_dir
 except ImportError:
     default_template_dir = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,12 @@ werkzeug = ">= 2.2.1"
 
 a2wsgi = { version = ">= 1.7", optional = true }
 flask = { version = ">= 2.2", extras = ["async"], optional = true }
-py-swagger-ui = { version = ">= 1.1.0", optional = true }
+swagger-ui-bundle = { version = ">= 1.1.0", optional = true }
 uvicorn = { version = ">= 0.17.6", extras = ["standard"], optional = true }
 
 [tool.poetry.extras]
 flask = ["a2wsgi", "flask"]
-swagger-ui = ["py-swagger-ui"]
+swagger-ui = ["swagger-ui-bundle"]
 uvicorn = ["uvicorn"]
 
 [tool.poetry.group.tests.dependencies]


### PR DESCRIPTION
Tested with `swagger-ui-bundle==1.1.0` from Test PyPI.

Opening this as a draft PR, since I didn't publish `swagger-ui-bundle` to the main PyPI yet, which I would like to do shortly before we release Connexion 3. 

Before Connexion 2.8, the `swagger_ui_bundle` version didn't have an upper bound. So if anyone runs into any issues because of this update, I'd rather have them come look for answers when Connexion 3 is out.