### PR TITLE
Improve JSON req error on disallowed empty body

### DIFF
--- a/connexion/validators/form_data.py
+++ b/connexion/validators/form_data.py
@@ -70,12 +70,13 @@ class FormDataValidator(AbstractRequestBodyValidator):
 
         return data
 
-    def _validate(self, data: dict) -> None:
+    def _validate(self, body: t.Any) -> t.Optional[dict]:
+        if not isinstance(body, dict):
+            raise BadRequestProblem("Parsed body must be a mapping")
         if self._strict_validation:
-            self._validate_params_strictly(data)
-
+            self._validate_params_strictly(body)
         try:
-            self._validator.validate(data)
+            self._validator.validate(body)
         except ValidationError as exception:
             error_path_msg = format_error_with_path(exception=exception)
             logger.error(

--- a/connexion/validators/form_data.py
+++ b/connexion/validators/form_data.py
@@ -70,7 +70,7 @@ class FormDataValidator(AbstractRequestBodyValidator):
 
         return data
 
-    def _validate(self, body: t.Any) -> t.Optional[dict]:
+    def _validate(self, body: t.Any) -> t.Optional[dict]:  # type: ignore[return]
         if not isinstance(body, dict):
             raise BadRequestProblem("Parsed body must be a mapping")
         if self._strict_validation:

--- a/connexion/validators/json.py
+++ b/connexion/validators/json.py
@@ -61,7 +61,9 @@ class JSONRequestBodyValidator(AbstractRequestBodyValidator):
         except json.decoder.JSONDecodeError as e:
             raise BadRequestProblem(detail=str(e))
 
-    def _validate(self, body: dict) -> None:
+    def _validate(self, body: t.Any) -> t.Optional[dict]:
+        if not self._nullable and body is None:
+            raise BadRequestProblem("Request body must not be empty")
         try:
             return self._validator.validate(body)
         except ValidationError as exception:

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -88,3 +88,10 @@ def test_errors(problem_app):
         "Invalid Content-type (text/html)"
     )
     assert unsupported_media_type_body["status"] == 415
+
+
+def test_should_raise_400_for_no_json(simple_app):
+    app_client = simple_app.test_client()
+    response = app_client.post("/v1.0/test-empty-object-body")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Request body must not be empty"


### PR DESCRIPTION
Fixes #1152.

Currently, when a request body is empty, the JSON request validator would parse it into None, which is later passed down to the JSON Schema validator. However, jsonschema's validation error message for this case (when nullable is false) "None is not of type 'object'" is not particularly friendly to either the API user, nor the website developer.

This change adds a specific check before the None value is passed to jsonschema to emit a better error message directly.

I also added some drive-by improvements on function argument typing since _validate in validators don't seem to expect receiving None, but _parse (the result of which is passed to _validate) is totally allowed to return None (or anything really). This does not seem to reflect the logic well.

I’m not exactly sure if this is the best way to do this in Connexion 3.x. [We do have a patch in Connexion 2.x to achieve a similar effect](https://github.com/apache/airflow/commit/e89a7eeea6a7a5a5a30a3f3cf86dfabf7c343412) so if anyone understands how the two implementations correspond please tell me whether the two do the same thing 🙂 