### PR TITLE
Fix FlaskApp exception handlers

### DIFF
--- a/connexion/http_facts.py
+++ b/connexion/http_facts.py
@@ -5,3 +5,70 @@ This module contains definitions of the HTTP protocol.
 FORM_CONTENT_TYPES = ["application/x-www-form-urlencoded", "multipart/form-data"]
 
 METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+HTTP_STATUS_CODES = {
+    100: "Continue",
+    101: "Switching Protocols",
+    102: "Processing",
+    103: "Early Hints",  # see RFC 8297
+    200: "OK",
+    201: "Created",
+    202: "Accepted",
+    203: "Non Authoritative Information",
+    204: "No Content",
+    205: "Reset Content",
+    206: "Partial Content",
+    207: "Multi Status",
+    208: "Already Reported",  # see RFC 5842
+    226: "IM Used",  # see RFC 3229
+    300: "Multiple Choices",
+    301: "Moved Permanently",
+    302: "Found",
+    303: "See Other",
+    304: "Not Modified",
+    305: "Use Proxy",
+    306: "Switch Proxy",  # unused
+    307: "Temporary Redirect",
+    308: "Permanent Redirect",
+    400: "Bad Request",
+    401: "Unauthorized",
+    402: "Payment Required",  # unused
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    407: "Proxy Authentication Required",
+    408: "Request Timeout",
+    409: "Conflict",
+    410: "Gone",
+    411: "Length Required",
+    412: "Precondition Failed",
+    413: "Request Entity Too Large",
+    414: "Request URI Too Long",
+    415: "Unsupported Media Type",
+    416: "Requested Range Not Satisfiable",
+    417: "Expectation Failed",
+    418: "I'm a teapot",  # see RFC 2324
+    421: "Misdirected Request",  # see RFC 7540
+    422: "Unprocessable Entity",
+    423: "Locked",
+    424: "Failed Dependency",
+    425: "Too Early",  # see RFC 8470
+    426: "Upgrade Required",
+    428: "Precondition Required",  # see RFC 6585
+    429: "Too Many Requests",
+    431: "Request Header Fields Too Large",
+    449: "Retry With",  # proprietary MS extension
+    451: "Unavailable For Legal Reasons",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+    505: "HTTP Version Not Supported",
+    506: "Variant Also Negotiates",  # see RFC 2295
+    507: "Insufficient Storage",
+    508: "Loop Detected",  # see RFC 5842
+    510: "Not Extended",
+    511: "Network Authentication Failed",
+}

--- a/connexion/lifecycle.py
+++ b/connexion/lifecycle.py
@@ -260,5 +260,6 @@ class ConnexionResponse:
         self.content_type = content_type
         self.body = body
         self.headers = headers or {}
-        self.headers.update({"Content-Type": content_type})
+        if content_type:
+            self.headers.update({"Content-Type": content_type})
         self.is_streamed = is_streamed

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -4,20 +4,20 @@ Exception Handling
 Connexion allows you to register custom error handlers to convert Python ``Exceptions`` into HTTP
 problem responses.
 
+You can register error handlers on:
+
+- The exception class to handle
+  If this exception class is raised somewhere in your application or the middleware stack,
+  it will be passed to your handler.
+- The HTTP status code to handle
+  Connexion will raise ``starlette.HTTPException`` errors when it encounters any issues
+  with a request or response. You can intercept these exceptions with specific status codes
+  if you want to return custom responses.
+
 .. tab-set::
 
     .. tab-item:: AsyncApp
         :sync: AsyncApp
-
-        You can register error handlers on:
-
-        - The exception class to handle
-          If this exception class is raised somewhere in your application or the middleware stack,
-          it will be passed to your handler.
-        - The HTTP status code to handle
-          Connexion will raise ``starlette.HTTPException`` errors when it encounters any issues
-          with a request or response. You can intercept these exceptions with specific status codes
-          if you want to return custom responses.
 
         .. code-block:: python
 
@@ -40,17 +40,6 @@ problem responses.
     .. tab-item:: FlaskApp
         :sync: FlaskApp
 
-        You can register error handlers on:
-
-        - The exception class to handle
-          If this exception class is raised somewhere in your application or the middleware stack,
-          it will be passed to your handler.
-        - The HTTP status code to handle
-          Connexion will raise ``starlette.HTTPException`` errors when it encounters any issues
-          with a request or response. The underlying Flask application will raise
-          ``werkzeug.HTTPException`` errors. You can intercept both of these exceptions with
-          specific status codes if you want to return custom responses.
-
         .. code-block:: python
 
             from connexion import FlaskApp
@@ -69,20 +58,34 @@ problem responses.
             .. automethod:: connexion.FlaskApp.add_error_handler
                 :noindex:
 
+        .. note::
+
+            .. warning::
+
+                ⚠️ **The following is not recommended as it complicates the exception handling logic,**
+
+            You can also register error handlers on the underlying flask application directly.
+
+            .. code-block:: python
+
+                flask_app = app.app
+                flask_app.register_error_handler(FileNotFoundError, not_found)
+                flask_app.register_error_handler(404, not_found)
+
+            `Flask documentation`_
+
+            Error handlers registered this way:
+
+            - Will only intercept exceptions thrown in the application, not in the Connexion
+              middleware.
+            - Can intercept exceptions before they reach the error handlers registered on the
+              connexion app.
+            - When registered on status code, will intercept only
+              ``werkzeug.exceptions.HTTPException`` thrown by werkzeug / Flask not
+              ``starlette.exceptions.HTTPException``.
+
     .. tab-item:: ConnexionMiddleware
         :sync: ConnexionMiddleware
-
-        You can register error handlers on:
-
-        - The exception class to handle
-          If this exception class is raised somewhere in your application or the middleware stack,
-          it will be passed to your handler.
-        - The HTTP status code to handle
-          Connexion will raise ``starlette.HTTPException`` errors when it encounters any issues
-          with a request or response. You can intercept these exceptions with specific status codes
-          if you want to return custom responses.
-          Note that this might not catch ``HTTPExceptions`` with the same status code raised by
-          your wrapped ASGI/WSGI framework.
 
         .. code-block:: python
 
@@ -105,9 +108,16 @@ problem responses.
             .. automethod:: connexion.ConnexionMiddleware.add_error_handler
                 :noindex:
 
+        .. note::
+
+            This might not catch ``HTTPExceptions`` with the same status code raised by
+            your wrapped ASGI/WSGI framework.
+
 .. note::
 
     Error handlers can be ``async`` coroutines as well.
+
+.. _Flask documentation: https://flask.palletsprojects.com/en/latest/errorhandling/#error-handlers
 
 Default Exception Handling
 --------------------------

--- a/docs/v3.rst
+++ b/docs/v3.rst
@@ -139,8 +139,9 @@ Smaller breaking changes
   has been added to work with Flask's ``MethodView`` specifically.
 * Built-in support for uWSGI has been removed. You can re-add this functionality using a custom middleware.
 * The request body is now passed through for ``GET``, ``HEAD``, ``DELETE``, ``CONNECT`` and ``OPTIONS`` methods as well.
-* Error handlers registered on the on the underlying Flask app directly will be ignored. You
-  should register them on the Connexion app directly.
+* The signature of error handlers has changed and default Flask error handlers are now replaced
+  with default Connexion error handlers which work the same for ``AsyncApp`` and
+  ``ConnexionMiddleware``.
 
 
 Non-breaking changes


### PR DESCRIPTION
Fixes #1787 

In the `FlaskApp`, the error handlers were still registered on the underlying Flask app instead of on the `ExceptionMiddleware`, which led to them not following the documented behavior.

The documentation was also incorrect about ignoring error handlers registered on the flask application. We are only ignoring the default error handlers registered by Flask itself.

This is a breaking change, however, since this functionality was not following the documented behavior, and 3.0.0 was only recently released, I propose to release this as a patch version.

