### PR TITLE
Fix 'Edit on GitHub' link on docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,8 @@ try:
         'display_github': True,
         'github_user': 'spec-first',
         'github_repo': 'connexion',
-        'github_version': 'main/docs/',
+        'github_version': 'main',
+        'conf_py_path': '/docs/'
     }
 except:
     pass


### PR DESCRIPTION
Fixes #1797 

[Relevant docs](https://docs.readthedocs.io/en/stable/guides/edit-source-links-sphinx.html#github).