### PR TITLE
Update the import statements for the cookbook snippets

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -16,13 +16,14 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: AsyncApp
 
         .. code-block:: python
+            from pathlib import Path
 
             from connexion import AsyncApp
             from connexion.middleware import MiddlewarePosition
             from starlette.middleware.cors import CORSMiddleware
 
 
-            app = connexion.AsyncApp(__name__)
+            app = AsyncApp(__name__)
 
             app.add_middleware(
                 CORSMiddleware,
@@ -48,13 +49,14 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: FlaskApp
 
         .. code-block:: python
+            from pathlib import Path
 
             from connexion import FlaskApp
             from connexion.middleware import MiddlewarePosition
             from starlette.middleware.cors import CORSMiddleware
 
 
-            app = connexion.FlaskApp(__name__)
+            app = FlaskApp(__name__)
 
             app.add_middleware(
                 CORSMiddleware,
@@ -80,10 +82,11 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: ConnexionMiddleware
 
         .. code-block:: python
+            from pathlib import Path
 
             from asgi_framework import App
             from connexion import ConnexionMiddleware
-            from connexion.lifecycle import ConnexionRequest, ConnexionResponse
+            from starlette.middleware.cors import CORSMiddleware
 
             app = App(__name__)
             app = ConnexionMiddleware(app)

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -16,6 +16,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: AsyncApp
 
         .. code-block:: python
+        
             from pathlib import Path
 
             from connexion import AsyncApp
@@ -49,6 +50,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: FlaskApp
 
         .. code-block:: python
+        
             from pathlib import Path
 
             from connexion import FlaskApp
@@ -82,6 +84,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
         :sync: ConnexionMiddleware
 
         .. code-block:: python
+        
             from pathlib import Path
 
             from asgi_framework import App


### PR DESCRIPTION
Updates the import statements on https://connexion.readthedocs.io/en/stable/cookbook.html


A few of the import statements were missing, or didn't match the example code because they imported at the wrong depth.
This should make the code in the cookbook copy-pasteable.