### PR TITLE
Add interface to add WSGI middleware

### DIFF
--- a/connexion/types.py
+++ b/connexion/types.py
@@ -1,4 +1,32 @@
+import types
 import typing as t
 
-ReturnType = t.TypeVar("ReturnType")
-MaybeAwaitable = t.Union[t.Awaitable[ReturnType], ReturnType]
+# Maybe Awaitable
+_ReturnType = t.TypeVar("_ReturnType")
+MaybeAwaitable = t.Union[t.Awaitable[_ReturnType], _ReturnType]
+
+# WSGIApp
+Environ = t.Mapping[str, object]
+
+_WriteCallable = t.Callable[[bytes], t.Any]
+_ExcInfo = t.Tuple[type, BaseException, types.TracebackType]
+
+_StartResponseCallable = t.Callable[
+    [
+        str,  # status
+        t.Sequence[t.Tuple[str, str]],  # response headers
+    ],
+    _WriteCallable,  # write() callable
+]
+_StartResponseCallableWithExcInfo = t.Callable[
+    [
+        str,  # status
+        t.Sequence[t.Tuple[str, str]],  # response headers
+        t.Optional[_ExcInfo],  # exc_info
+    ],
+    _WriteCallable,  # write() callable
+]
+StartResponse = t.Union[_StartResponseCallable, _StartResponseCallableWithExcInfo]
+ResponseStream = t.Iterable[bytes]
+
+WSGIApp = t.Callable[[Environ, StartResponse], ResponseStream]

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -64,6 +64,20 @@ You can easily add additional ASGI middleware to the middleware stack with the
             .. automethod:: connexion.FlaskApp.add_middleware
                 :noindex:
 
+        You can also add WSGI middleware to a ``FlaskApp``. Note that it will only be called at the
+        end of the middleware stack. If you need your middleware to act sooner, you will have to
+        use an ASGI middleware instead.
+
+        .. code-block:: python
+
+            app.add_wsgi_middleware(MiddlewareClass, **options)
+
+        .. dropdown:: View a detailed reference of the :code:`add_middleware` method
+            :icon: eye
+
+            .. automethod:: connexion.FlaskApp.add_wsgi_middleware
+                :noindex:
+
     .. tab-item:: ConnexionMiddleware
         :sync: ConnexionMiddleware
 
@@ -77,7 +91,7 @@ You can easily add additional ASGI middleware to the middleware stack with the
 
             app.add_middleware(MiddlewareClass, **options)
 
-        .. dropdown:: View a detailed reference of the :code:`add_middleware` method
+        .. dropdown:: View a detailed reference of the :code:`add_wsgi_middleware` method
             :icon: eye
 
             .. automethod:: connexion.ConnexionMiddleware.add_middleware


### PR DESCRIPTION
As discussed in #1807.

Allowing the injection of WSGI middleware can enable easier migration from Connexion 2 to Connexion 3. The use cases are limited though, as this will only work for middleware that can work at the end of the middleware stack.
