### PR TITLE
Fix CORS headers not set on exceptions

### DIFF
--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -102,7 +102,8 @@ class MiddlewarePosition(enum.Enum):
     leverage any routing information yet and should implement your middleware to work globally
     instead of on an operation level.
 
-    Usefull for CORS middleware which should be applied before the exception middleware.
+    Useful for CORS middleware which should be applied before the exception middleware.
+    :meta hide-value:
     """
     BEFORE_SWAGGER = SwaggerUIMiddleware
     """Add before the :class:`SwaggerUIMiddleware`. This is useful if you want your changes to

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -103,6 +103,7 @@ class MiddlewarePosition(enum.Enum):
     instead of on an operation level.
 
     Useful for CORS middleware which should be applied before the exception middleware.
+
     :meta hide-value:
     """
     BEFORE_SWAGGER = SwaggerUIMiddleware

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -102,7 +102,9 @@ class MiddlewarePosition(enum.Enum):
     leverage any routing information yet and should implement your middleware to work globally
     instead of on an operation level.
 
-    Useful for CORS middleware which should be applied before the exception middleware.
+    Useful for middleware which should also be applied to error responses. Note that errors
+    raised here will not be handled by the exception handlers and will always result in an
+    internal server error response.
 
     :meta hide-value:
     """

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -16,6 +16,7 @@ from connexion.lifecycle import ConnexionRequest, ConnexionResponse
 from connexion.middleware.abstract import SpecMiddleware
 from connexion.middleware.context import ContextMiddleware
 from connexion.middleware.exceptions import ExceptionMiddleware
+from connexion.middleware.server_error import ServerErrorMiddleware
 from connexion.middleware.lifespan import Lifespan, LifespanMiddleware
 from connexion.middleware.request_validation import RequestValidationMiddleware
 from connexion.middleware.response_validation import ResponseValidationMiddleware
@@ -92,6 +93,17 @@ class _Options:
 class MiddlewarePosition(enum.Enum):
     """Positions to insert a middleware"""
 
+    BEFORE_EXCEPTION = ExceptionMiddleware
+    """Add before the :class:`ExceptionMiddleware`. This is useful if you want your changes to
+    affect the way exceptions are handled, such as a custom error handler.
+
+    Be mindful that security has not yet been applied at this stage.
+    Additionally, the inserted middleware is positioned before the RoutingMiddleware, so you cannot
+    leverage any routing information yet and should implement your middleware to work globally
+    instead of on an operation level.
+
+    Usefull for CORS middleware which should be applied before the exception middleware.
+    """
     BEFORE_SWAGGER = SwaggerUIMiddleware
     """Add before the :class:`SwaggerUIMiddleware`. This is useful if you want your changes to
     affect the Swagger UI, such as a path altering middleware that should also alter the paths
@@ -164,6 +176,7 @@ class ConnexionMiddleware:
     provided application."""
 
     default_middlewares = [
+        ServerErrorMiddleware,
         ExceptionMiddleware,
         SwaggerUIMiddleware,
         RoutingMiddleware,

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -16,12 +16,12 @@ from connexion.lifecycle import ConnexionRequest, ConnexionResponse
 from connexion.middleware.abstract import SpecMiddleware
 from connexion.middleware.context import ContextMiddleware
 from connexion.middleware.exceptions import ExceptionMiddleware
-from connexion.middleware.server_error import ServerErrorMiddleware
 from connexion.middleware.lifespan import Lifespan, LifespanMiddleware
 from connexion.middleware.request_validation import RequestValidationMiddleware
 from connexion.middleware.response_validation import ResponseValidationMiddleware
 from connexion.middleware.routing import RoutingMiddleware
 from connexion.middleware.security import SecurityMiddleware
+from connexion.middleware.server_error import ServerErrorMiddleware
 from connexion.middleware.swagger_ui import SwaggerUIMiddleware
 from connexion.options import SwaggerUIOptions
 from connexion.resolver import Resolver

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -1,11 +1,7 @@
-import logging
-
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
 from starlette.types import ASGIApp
-
-logger = logging.getLogger(__name__)
 
 
 class ServerErrorMiddleware(StarletteServerErrorMiddleware):

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -14,6 +14,3 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
 
     def __init__(self, next_app: ASGIApp):
         super().__init__(next_app)
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        await super().__call__(scope, receive, send)

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -4,12 +4,12 @@ import typing as t
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
-from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp
 
 from connexion.exceptions import InternalServerError
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
 from connexion.middleware.exceptions import connexion_wrapper
+from connexion.types import MaybeAwaitable
 
 logger = logging.getLogger(__name__)
 
@@ -21,14 +21,16 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
     def __init__(
         self,
         next_app: ASGIApp,
-        handler: t.Optional[t.Callable[[ConnexionRequest, Exception], t.Any]] = None,
+        handler: t.Optional[
+            t.Callable[[ConnexionRequest, Exception], MaybeAwaitable[ConnexionResponse]]
+        ] = None,
     ):
         handler = connexion_wrapper(handler) if handler else None
         super().__init__(next_app, handler=handler)
 
     @staticmethod
     @connexion_wrapper
-    def error_response(_request: StarletteRequest, exc: Exception) -> ConnexionResponse:
+    def error_response(_request: ConnexionRequest, exc: Exception) -> ConnexionResponse:
         """Default handler for any unhandled Exception"""
         logger.error("%r", exc, exc_info=exc)
         return InternalServerError().to_problem()

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -1,52 +1,15 @@
-import asyncio
-import functools
 import logging
-import typing as t
 
-from starlette.concurrency import run_in_threadpool
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
 from starlette.requests import Request as StarletteRequest
-from starlette.responses import Response as StarletteResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from connexion.exceptions import InternalServerError
-from connexion.lifecycle import ConnexionRequest, ConnexionResponse
-from connexion.types import MaybeAwaitable
+from connexion.lifecycle import ConnexionResponse
 
 logger = logging.getLogger(__name__)
-
-
-def connexion_wrapper(
-    handler: t.Callable[
-        [ConnexionRequest, Exception], MaybeAwaitable[ConnexionResponse]
-    ]
-) -> t.Callable[[StarletteRequest, Exception], t.Awaitable[StarletteResponse]]:
-    """Wrapper that translates Starlette requests to Connexion requests before passing
-    them to the error handler, and translates the returned Connexion responses to
-    Starlette responses."""
-
-    @functools.wraps(handler)
-    async def wrapper(request: StarletteRequest, exc: Exception) -> StarletteResponse:
-        request = ConnexionRequest.from_starlette_request(request)
-
-        if asyncio.iscoroutinefunction(handler):
-            response = await handler(request, exc)  # type: ignore
-        else:
-            response = await run_in_threadpool(handler, request, exc)
-
-        while asyncio.iscoroutine(response):
-            response = await response
-
-        return StarletteResponse(
-            content=response.body,
-            status_code=response.status_code,
-            media_type=response.mimetype,
-            headers=response.headers,
-        )
-
-    return wrapper
 
 
 class ServerErrorMiddleware(StarletteServerErrorMiddleware):

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -20,9 +20,11 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
 
     def __init__(self, next_app: ASGIApp, handler: t.Optional[
             t.Callable[[ConnexionRequest, Exception], t.Any]] = None):
-        super().__init__(next_app, handler=connexion_wrapper(handler or self.error_response))
+        handler = connexion_wrapper(handler) if handler else None
+        super().__init__(next_app, handler=handler)
 
     @staticmethod
+    @connexion_wrapper
     def error_response(
         _request: StarletteRequest, exc: Exception
     ) -> ConnexionResponse:

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -18,17 +18,17 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
     """Subclass of starlette ServerErrorMiddleware to change handling of Unhandled Server
     exceptions to existing connexion behavior."""
 
-    def __init__(self, next_app: ASGIApp, handler: t.Optional[
-            t.Callable[[ConnexionRequest, Exception], t.Any]] = None):
+    def __init__(
+        self,
+        next_app: ASGIApp,
+        handler: t.Optional[t.Callable[[ConnexionRequest, Exception], t.Any]] = None,
+    ):
         handler = connexion_wrapper(handler) if handler else None
         super().__init__(next_app, handler=handler)
 
     @staticmethod
     @connexion_wrapper
-    def error_response(
-        _request: StarletteRequest, exc: Exception
-    ) -> ConnexionResponse:
+    def error_response(_request: StarletteRequest, exc: Exception) -> ConnexionResponse:
         """Default handler for any unhandled Exception"""
         logger.error("%r", exc, exc_info=exc)
         return InternalServerError().to_problem()
-

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -1,0 +1,68 @@
+import asyncio
+import functools
+import logging
+import typing as t
+
+from starlette.concurrency import run_in_threadpool
+from starlette.middleware.errors import (
+    ServerErrorMiddleware as StarletteServerErrorMiddleware,
+)
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from connexion.exceptions import InternalServerError
+from connexion.lifecycle import ConnexionRequest, ConnexionResponse
+from connexion.types import MaybeAwaitable
+
+logger = logging.getLogger(__name__)
+
+
+def connexion_wrapper(
+    handler: t.Callable[
+        [ConnexionRequest, Exception], MaybeAwaitable[ConnexionResponse]
+    ]
+) -> t.Callable[[StarletteRequest, Exception], t.Awaitable[StarletteResponse]]:
+    """Wrapper that translates Starlette requests to Connexion requests before passing
+    them to the error handler, and translates the returned Connexion responses to
+    Starlette responses."""
+
+    @functools.wraps(handler)
+    async def wrapper(request: StarletteRequest, exc: Exception) -> StarletteResponse:
+        request = ConnexionRequest.from_starlette_request(request)
+
+        if asyncio.iscoroutinefunction(handler):
+            response = await handler(request, exc)  # type: ignore
+        else:
+            response = await run_in_threadpool(handler, request, exc)
+
+        while asyncio.iscoroutine(response):
+            response = await response
+
+        return StarletteResponse(
+            content=response.body,
+            status_code=response.status_code,
+            media_type=response.mimetype,
+            headers=response.headers,
+        )
+
+    return wrapper
+
+
+class ServerErrorMiddleware(StarletteServerErrorMiddleware):
+    """Subclass of starlette ServerErrorMiddleware to change handling of Unhandled Server
+    exceptions to existing connexion behavior."""
+
+    def __init__(self, next_app: ASGIApp):
+        super().__init__(next_app)
+
+    @staticmethod
+    def error_response(
+        _request: StarletteRequest, exc: Exception
+    ) -> ConnexionResponse:
+        """Default handler for any unhandled Exception"""
+        logger.error("%r", exc, exc_info=exc)
+        return InternalServerError().to_problem()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await super().__call__(scope, receive, send)

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -8,8 +8,8 @@ from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp
 
 from connexion.exceptions import InternalServerError
-from connexion.middleware.exceptions import connexion_wrapper
 from connexion.lifecycle import ConnexionRequest, ConnexionResponse
+from connexion.middleware.exceptions import connexion_wrapper
 
 logger = logging.getLogger(__name__)
 

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -1,12 +1,32 @@
+import logging
+import typing as t
+
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
+from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp
+
+from connexion.exceptions import InternalServerError
+from connexion.middleware.exceptions import connexion_wrapper
+from connexion.lifecycle import ConnexionRequest, ConnexionResponse
+
+logger = logging.getLogger(__name__)
 
 
 class ServerErrorMiddleware(StarletteServerErrorMiddleware):
     """Subclass of starlette ServerErrorMiddleware to change handling of Unhandled Server
     exceptions to existing connexion behavior."""
 
-    def __init__(self, next_app: ASGIApp):
-        super().__init__(next_app)
+    def __init__(self, next_app: ASGIApp, handler: t.Optional[
+            t.Callable[[ConnexionRequest, Exception], t.Any]] = None):
+        super().__init__(next_app, handler=connexion_wrapper(handler or self.error_response))
+
+    @staticmethod
+    def error_response(
+        _request: StarletteRequest, exc: Exception
+    ) -> ConnexionResponse:
+        """Default handler for any unhandled Exception"""
+        logger.error("%r", exc, exc_info=exc)
+        return InternalServerError().to_problem()
+

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -20,9 +20,7 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
         super().__init__(next_app)
 
     @staticmethod
-    def error_response(
-        _request: StarletteRequest, exc: Exception
-    ) -> ConnexionResponse:
+    def error_response(_request: StarletteRequest, exc: Exception) -> ConnexionResponse:
         """Default handler for any unhandled Exception"""
         logger.error("%r", exc, exc_info=exc)
         return InternalServerError().to_problem()

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -3,7 +3,7 @@ import logging
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
 

--- a/connexion/middleware/server_error.py
+++ b/connexion/middleware/server_error.py
@@ -3,11 +3,7 @@ import logging
 from starlette.middleware.errors import (
     ServerErrorMiddleware as StarletteServerErrorMiddleware,
 )
-from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp, Receive, Scope, Send
-
-from connexion.exceptions import InternalServerError
-from connexion.lifecycle import ConnexionResponse
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +14,6 @@ class ServerErrorMiddleware(StarletteServerErrorMiddleware):
 
     def __init__(self, next_app: ASGIApp):
         super().__init__(next_app)
-
-    @staticmethod
-    def error_response(_request: StarletteRequest, exc: Exception) -> ConnexionResponse:
-        """Default handler for any unhandled Exception"""
-        logger.error("%r", exc, exc_info=exc)
-        return InternalServerError().to_problem()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         await super().__call__(scope, receive, send)

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -28,7 +28,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
 
             app.add_middleware(
                 CORSMiddleware,
-                position=MiddlewarePosition.BEFORE_ROUTING,
+                position=MiddlewarePosition.BEFORE_EXCEPTION,
                 allow_origins=["*"],
                 allow_credentials=True,
                 allow_methods=["*"],
@@ -62,7 +62,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
 
             app.add_middleware(
                 CORSMiddleware,
-                position=MiddlewarePosition.BEFORE_ROUTING,
+                position=MiddlewarePosition.BEFORE_EXCEPTION,
                 allow_origins=["*"],
                 allow_credentials=True,
                 allow_methods=["*"],
@@ -96,7 +96,7 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
 
             app.add_middleware(
                 CORSMiddleware,
-                position=MiddlewarePosition.BEFORE_ROUTING,
+                position=MiddlewarePosition.BEFORE_EXCEPTION,
                 allow_origins=["*"],
                 allow_credentials=True,
                 allow_methods=["*"],

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -8,6 +8,8 @@ following order:
 .. csv-table::
     :widths: 30, 70
 
+    **ServerErrorMiddleware**, "Returns server errors for any exceptions not caught by the
+    ExceptionMiddleware"
     **ExceptionMiddleware**, Handles exceptions raised by the middleware stack or application
     **SwaggerUIMiddleware**, Adds a Swagger UI to your application
     **RoutingMiddleware**, "Routes incoming requests to the right operation defined in the

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,11 +1,11 @@
-from functools import partial
 import logging
+from functools import partial
 
 import pytest
-from starlette.types import Receive, Scope, Send
 from connexion import ConnexionMiddleware
 from connexion.middleware.server_error import ServerErrorMiddleware
 from starlette.middleware.cors import CORSMiddleware
+from starlette.types import Receive, Scope, Send
 
 from conftest import FIXTURES_FOLDER, OPENAPI3_SPEC, build_app_from_fixture
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -16,24 +16,30 @@ def simple_app(spec, app_class):
         "simple", app_class=app_class, spec_file=spec, validate_responses=True
     )
 
+
 @pytest.fixture(scope="session")
 def simple_openapi_app(app_class):
     return build_app_from_fixture(
         "simple", app_class=app_class, spec_file=OPENAPI3_SPEC, validate_responses=True
     )
 
+
 @pytest.fixture(scope="session")
 def cors_openapi_app(app_class):
     middlewares = [*ConnexionMiddleware.default_middlewares]
-    cors_middleware = partial(CORSMiddleware, allow_origins=['http://localhost'])
+    cors_middleware = partial(CORSMiddleware, allow_origins=["http://localhost"])
     # CORS should always be directly after ServerErrorMiddleware
     server_error_idx = middlewares.index(ServerErrorMiddleware)
-    middlewares.insert(server_error_idx+1, cors_middleware)
+    middlewares.insert(server_error_idx + 1, cors_middleware)
 
     return build_app_from_fixture(
-        "simple", app_class=app_class, spec_file=OPENAPI3_SPEC, middlewares=middlewares,
-        validate_responses=True
+        "simple",
+        app_class=app_class,
+        spec_file=OPENAPI3_SPEC,
+        middlewares=middlewares,
+        validate_responses=True,
     )
+
 
 @pytest.fixture(scope="session")
 def reverse_proxied_app(spec, app_class):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,6 +9,7 @@ from starlette.types import Receive, Scope, Send
 
 from conftest import FIXTURES_FOLDER, OPENAPI3_SPEC, build_app_from_fixture
 
+
 @pytest.fixture(scope="session")
 def simple_app(spec, app_class):
     return build_app_from_fixture(

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -14,7 +14,7 @@ def test_cors_invalid(cors_openapi_app):
     response = app_client.options(
         "/v1.0/goodday/dan", headers={
             "Origin": "http://0.0.0.0",
-            "access-control-request-method": "POST"
+            "Access-Control-Request-Method": "POST"
         }
     )
     assert response.status_code == 400

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -1,5 +1,6 @@
 import json
 
+
 def test_cors_valid(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
     origin = "http://localhost"

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -1,0 +1,57 @@
+from connexion.middleware import MiddlewarePosition
+from starlette.middleware.cors import CORSMiddleware
+
+def test_cors_no_error(simple_app):
+    app_client = simple_app.test_client()
+    simple_app.add_middleware(
+        CORSMiddleware,
+        position=MiddlewarePosition.BEFORE_EXCEPTION,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    response = app_client.post("/v1.0/goodday/dan", data={})
+    assert response.status_code == 201
+    assert "Access-Control-Allow-Origin" in response.headers
+
+def test_cors_validation_error(simple_openapi_app):
+    app_client = simple_openapi_app.test_client()
+    simple_openapi_app.add_middleware(
+        CORSMiddleware,
+        position=MiddlewarePosition.BEFORE_EXCEPTION,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    response = app_client.post("/v1.0/body-not-allowed-additional-properties", data={})
+    assert response.status_code == 400
+    assert "Access-Control-Allow-Origin" in response.headers
+
+def test_cors_server_error(simple_openapi_app):
+    app_client = simple_openapi_app.test_client()
+    simple_openapi_app.add_middleware(
+        CORSMiddleware,
+        position=MiddlewarePosition.BEFORE_EXCEPTION,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    response = app_client.post("/v1.0/goodday/noheader", data={})
+    assert (
+        response.status_code == 500
+    )  # view_func has not returned what was promised in spec
+    assert response.headers.get("content-type") == "application/problem+json"
+    data = response.json()
+    assert data["type"] == "about:blank"
+    assert data["title"] == "Internal Server Error"
+    assert (
+        data["detail"]
+        == "Keys in response header don't match response specification. Difference: location"
+    )
+    assert data["status"] == 500
+
+    assert "Access-Control-Allow-Origin" in response.headers

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -12,7 +12,10 @@ def test_cors_valid(cors_openapi_app):
 def test_cors_invalid(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
     response = app_client.options(
-        "/v1.0/goodday/dan", headers={"Origin": "http://0.0.0.0"}
+        "/v1.0/goodday/dan", headers={
+            "Origin": "http://0.0.0.0",
+            "access-control-request-method": "POST"
+        }
     )
     assert response.status_code == 400
     assert "Access-Control-Allow-Origin" not in response.headers

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -4,9 +4,7 @@ import json
 def test_cors_valid(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
     origin = "http://localhost"
-    response = app_client.post(
-        "/v1.0/goodday/dan", data={}, headers={"Origin": origin}
-    )
+    response = app_client.post("/v1.0/goodday/dan", data={}, headers={"Origin": origin})
     assert response.status_code == 201
     assert "Access-Control-Allow-Origin" in response.headers
     assert origin == response.headers["Access-Control-Allow-Origin"]
@@ -15,10 +13,8 @@ def test_cors_valid(cors_openapi_app):
 def test_cors_invalid(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
     response = app_client.options(
-        "/v1.0/goodday/dan", headers={
-            "Origin": "http://0.0.0.0",
-            "Access-Control-Request-Method": "POST"
-        }
+        "/v1.0/goodday/dan",
+        headers={"Origin": "http://0.0.0.0", "Access-Control-Request-Method": "POST"},
     )
     assert response.status_code == 400
     assert "Access-Control-Allow-Origin" not in response.headers

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -1,57 +1,31 @@
-from connexion.middleware import MiddlewarePosition
-from starlette.middleware.cors import CORSMiddleware
+import json
 
-def test_cors_no_error(simple_app):
-    app_client = simple_app.test_client()
-    simple_app.add_middleware(
-        CORSMiddleware,
-        position=MiddlewarePosition.BEFORE_EXCEPTION,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+def test_cors_valid(cors_openapi_app):
+    app_client = cors_openapi_app.test_client()
+    response = app_client.post(
+        "/v1.0/goodday/dan", data={}, headers={"Origin": "http://localhost"}
     )
-    response = app_client.post("/v1.0/goodday/dan", data={})
     assert response.status_code == 201
     assert "Access-Control-Allow-Origin" in response.headers
 
-def test_cors_validation_error(simple_openapi_app):
-    app_client = simple_openapi_app.test_client()
-    simple_openapi_app.add_middleware(
-        CORSMiddleware,
-        position=MiddlewarePosition.BEFORE_EXCEPTION,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+
+def test_cors_validation_error(cors_openapi_app):
+    app_client = cors_openapi_app.test_client()
+
+    response = app_client.post(
+        "/v1.0/body-not-allowed-additional-properties",
+        data={},
+        headers={"Origin": "http://localhost"},
     )
-    response = app_client.post("/v1.0/body-not-allowed-additional-properties", data={})
     assert response.status_code == 400
     assert "Access-Control-Allow-Origin" in response.headers
 
-def test_cors_server_error(simple_openapi_app):
-    app_client = simple_openapi_app.test_client()
-    simple_openapi_app.add_middleware(
-        CORSMiddleware,
-        position=MiddlewarePosition.BEFORE_EXCEPTION,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
 
-    response = app_client.post("/v1.0/goodday/noheader", data={})
-    assert (
-        response.status_code == 500
-    )  # view_func has not returned what was promised in spec
-    assert response.headers.get("content-type") == "application/problem+json"
-    data = response.json()
-    assert data["type"] == "about:blank"
-    assert data["title"] == "Internal Server Error"
-    assert (
-        data["detail"]
-        == "Keys in response header don't match response specification. Difference: location"
+def test_cors_server_error(cors_openapi_app):
+    app_client = cors_openapi_app.test_client()
+    response = app_client.post(
+        "/v1.0/goodday/noheader", data={}, headers={"Origin": "http://localhost"}
     )
-    assert data["status"] == 500
+    assert response.status_code == 500
 
     assert "Access-Control-Allow-Origin" in response.headers

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -9,9 +9,17 @@ def test_cors_valid(cors_openapi_app):
     assert "Access-Control-Allow-Origin" in response.headers
 
 
+def test_cors_invalid(cors_openapi_app):
+    app_client = cors_openapi_app.test_client()
+    response = app_client.options(
+        "/v1.0/goodday/dan", headers={"Origin": "http://0.0.0.0"}
+    )
+    assert response.status_code == 400
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
 def test_cors_validation_error(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
-
     response = app_client.post(
         "/v1.0/body-not-allowed-additional-properties",
         data={},

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -2,11 +2,13 @@ import json
 
 def test_cors_valid(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
+    origin = "http://localhost"
     response = app_client.post(
-        "/v1.0/goodday/dan", data={}, headers={"Origin": "http://localhost"}
+        "/v1.0/goodday/dan", data={}, headers={"Origin": origin}
     )
     assert response.status_code == 201
     assert "Access-Control-Allow-Origin" in response.headers
+    assert origin == response.headers["Access-Control-Allow-Origin"]
 
 
 def test_cors_invalid(cors_openapi_app):
@@ -23,19 +25,23 @@ def test_cors_invalid(cors_openapi_app):
 
 def test_cors_validation_error(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
+    origin = "http://localhost"
     response = app_client.post(
         "/v1.0/body-not-allowed-additional-properties",
         data={},
-        headers={"Origin": "http://localhost"},
+        headers={"Origin": origin},
     )
     assert response.status_code == 400
     assert "Access-Control-Allow-Origin" in response.headers
+    assert origin == response.headers["Access-Control-Allow-Origin"]
 
 
 def test_cors_server_error(cors_openapi_app):
     app_client = cors_openapi_app.test_client()
+    origin = "http://localhost"
     response = app_client.post(
-        "/v1.0/goodday/noheader", data={}, headers={"Origin": "http://localhost"}
+        "/v1.0/goodday/noheader", data={}, headers={"Origin": origin}
     )
     assert response.status_code == 500
     assert "Access-Control-Allow-Origin" in response.headers
+    assert origin == response.headers["Access-Control-Allow-Origin"]

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -35,5 +35,4 @@ def test_cors_server_error(cors_openapi_app):
         "/v1.0/goodday/noheader", data={}, headers={"Origin": "http://localhost"}
     )
     assert response.status_code == 500
-
     assert "Access-Control-Allow-Origin" in response.headers


### PR DESCRIPTION
Fixes #1820.
Correct error handling in response to CORS.


Changes proposed in this pull request:

 - Add a MiddlewarePosition before Exception handling so CORS is always returned
 - Add ServerError Middleware to handle unhandled errors between the ServerError- and ExceptionMiddleware
 - Update corresponding docs

