### PR TITLE
Set starlette upperbound version to <0.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Jinja2 = ">= 3.0.0"
 python-multipart = ">= 0.0.5"
 PyYAML = ">= 5.1"
 requests = ">= 2.27"
-starlette = ">= 0.27"
+starlette = ">= 0.27, <0.33"
 typing-extensions = ">= 4"
 werkzeug = ">= 2.2.1"
 


### PR DESCRIPTION
Temporary fix for https://github.com/spec-first/connexion/issues/1826

We should release this asap.