### PR TITLE
Specification use raw spec on clone

### DIFF
--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -196,7 +196,7 @@ class Specification(Mapping):
         return OpenAPISpecification(spec, base_uri=base_uri)
 
     def clone(self):
-        return type(self)(copy.deepcopy(self._spec))
+        return type(self)(copy.deepcopy(self._raw_spec))
 
     @classmethod
     def load(cls, spec, *, arguments=None):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from connexion.middleware import MiddlewarePosition
 from starlette.middleware.cors import CORSMiddleware
+from connexion.options import SwaggerUIOptions
 from starlette.types import Receive, Scope, Send
 
 from conftest import OPENAPI3_SPEC, build_app_from_fixture
@@ -19,6 +20,17 @@ def simple_app(spec, app_class):
 def simple_openapi_app(app_class):
     return build_app_from_fixture(
         "simple", app_class=app_class, spec_file=OPENAPI3_SPEC, validate_responses=True
+    )
+
+
+@pytest.fixture(scope="session")
+def swagger_app(spec, app_class):
+    return build_app_from_fixture(
+        "simple",
+        app_class=app_class,
+        spec_file=spec,
+        validate_responses=True,
+        swagger_ui_options=SwaggerUIOptions(spec_path="/spec.json"),
     )
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,8 +2,8 @@ import logging
 
 import pytest
 from connexion.middleware import MiddlewarePosition
-from starlette.middleware.cors import CORSMiddleware
 from connexion.options import SwaggerUIOptions
+from starlette.middleware.cors import CORSMiddleware
 from starlette.types import Receive, Scope, Send
 
 from conftest import OPENAPI3_SPEC, build_app_from_fixture

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,7 +24,7 @@ def simple_openapi_app(app_class):
 
 
 @pytest.fixture(scope="session")
-def swagger_app(spec, app_class):
+def swagger_ui_app(spec, app_class):
     return build_app_from_fixture(
         "simple",
         app_class=app_class,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,11 +24,11 @@ def simple_openapi_app(app_class):
 
 
 @pytest.fixture(scope="session")
-def swagger_ui_app(spec, app_class):
+def swagger_ui_app(app_class):
     return build_app_from_fixture(
         "simple",
         app_class=app_class,
-        spec_file=spec,
+        spec_file=OPENAPI3_SPEC,
         validate_responses=True,
         swagger_ui_options=SwaggerUIOptions(spec_path="/spec.json"),
     )

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,6 +1,5 @@
 
-def test_simple(swagger_app):
+def test_simple(swagger_ui_app):
     app_client = swagger_ui_app.test_client()
-    for api in swagger_app.middleware.apis:
-        response = app_client.get(api.specification.base_path+"/spec.json")
-        assert response.status_code == 200
+    response = app_client.get("/v1.0/spec.json")
+    assert response.status_code == 200

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,0 +1,31 @@
+from connexion.middleware.swagger_ui import SwaggerUIConfig
+
+
+def test_swagger(simple_app):
+    app_client = simple_app.test_client()
+    for api in simple_app.middleware.apis:
+        if api.kwargs['swagger_ui_options']:
+            swagger_ui_options = api.kwargs['swagger_ui_options']
+        else:
+            swagger_ui_options = simple_app.middleware.options.swagger_ui_options
+
+        options = SwaggerUIConfig(
+            swagger_ui_options, oas_version=api.specification.version
+        )
+        response = app_client.get(api.specification.base_path+options.openapi_spec_path)
+        assert response.status_code == 200
+
+
+def test_openapi(simple_openapi_app):
+    app_client = simple_openapi_app.test_client()
+    for api in simple_openapi_app.middleware.apis:
+        if api.kwargs['swagger_ui_options']:
+            swagger_ui_options = api.kwargs['swagger_ui_options']
+        else:
+            swagger_ui_options = simple_openapi_app.middleware.options.swagger_ui_options
+
+        options = SwaggerUIConfig(
+            swagger_ui_options, oas_version=api.specification.version
+        )
+        response = app_client.get(api.specification.base_path+options.openapi_spec_path)
+        assert response.status_code == 200

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,7 +1,7 @@
 from connexion.middleware.swagger_ui import SwaggerUIConfig
 
 
-def test_swagger(simple_app):
+def test_simple(simple_app):
     app_client = simple_app.test_client()
     for api in simple_app.middleware.apis:
         if api.kwargs['swagger_ui_options']:
@@ -16,7 +16,7 @@ def test_swagger(simple_app):
         assert response.status_code == 200
 
 
-def test_openapi(simple_openapi_app):
+def test_simple_openapi(simple_openapi_app):
     app_client = simple_openapi_app.test_client()
     for api in simple_openapi_app.middleware.apis:
         if api.kwargs['swagger_ui_options']:

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,31 +1,6 @@
-from connexion.middleware.swagger_ui import SwaggerUIConfig
 
-
-def test_simple(simple_app):
-    app_client = simple_app.test_client()
-    for api in simple_app.middleware.apis:
-        if api.kwargs['swagger_ui_options']:
-            swagger_ui_options = api.kwargs['swagger_ui_options']
-        else:
-            swagger_ui_options = simple_app.middleware.options.swagger_ui_options
-
-        options = SwaggerUIConfig(
-            swagger_ui_options, oas_version=api.specification.version
-        )
-        response = app_client.get(api.specification.base_path+options.openapi_spec_path)
-        assert response.status_code == 200
-
-
-def test_simple_openapi(simple_openapi_app):
-    app_client = simple_openapi_app.test_client()
-    for api in simple_openapi_app.middleware.apis:
-        if api.kwargs['swagger_ui_options']:
-            swagger_ui_options = api.kwargs['swagger_ui_options']
-        else:
-            swagger_ui_options = simple_openapi_app.middleware.options.swagger_ui_options
-
-        options = SwaggerUIConfig(
-            swagger_ui_options, oas_version=api.specification.version
-        )
-        response = app_client.get(api.specification.base_path+options.openapi_spec_path)
+def test_simple(swagger_app):
+    app_client = swagger_app.test_client()
+    for api in swagger_app.middleware.apis:
+        response = app_client.get(api.specification.base_path+"/spec.json")
         assert response.status_code == 200

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,4 +1,3 @@
-
 def test_simple(swagger_ui_app):
     app_client = swagger_ui_app.test_client()
     response = app_client.get("/v1.0/spec.json")

--- a/tests/api/test_swagger_ui.py
+++ b/tests/api/test_swagger_ui.py
@@ -1,6 +1,6 @@
 
 def test_simple(swagger_app):
-    app_client = swagger_app.test_client()
+    app_client = swagger_ui_app.test_client()
     for api in swagger_app.middleware.apis:
         response = app_client.get(api.specification.base_path+"/spec.json")
         assert response.status_code == 200


### PR DESCRIPTION
Fixes #1829.



Changes proposed in this pull request:

 - Use _raw_spec when cloning
