### PR TITLE
Add API-key scope checking

### DIFF
--- a/connexion/security.py
+++ b/connexion/security.py
@@ -243,9 +243,10 @@ class ApiKeySecurityHandler(AbstractSecurityHandler):
             apikey_info_func,
             security_scheme["in"],
             security_scheme["name"],
+            required_scopes,
         )
 
-    def _get_verify_func(self, api_key_info_func, loc, name):
+    def _get_verify_func(self, api_key_info_func, loc, name, required_scopes):
         check_api_key_func = self.check_api_key(api_key_info_func)
 
         def wrapper(request: ConnexionRequest):
@@ -262,7 +263,7 @@ class ApiKeySecurityHandler(AbstractSecurityHandler):
             if api_key is None:
                 return NO_VALUE
 
-            return check_api_key_func(request, api_key)
+            return check_api_key_func(request, api_key, required_scopes=required_scopes)
 
         return wrapper
 

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -209,7 +209,7 @@ async def test_verify_apikey_query():
 
     security_handler_factory = ApiKeySecurityHandler()
     wrapped_func = security_handler_factory._get_verify_func(
-        apikey_info, "query", "auth"
+        apikey_info, "query", "auth", None
     )
 
     request = ConnexionRequest(scope={"type": "http", "query_string": b"auth=foobar"})
@@ -225,7 +225,7 @@ async def test_verify_apikey_header():
 
     security_handler_factory = ApiKeySecurityHandler()
     wrapped_func = security_handler_factory._get_verify_func(
-        apikey_info, "header", "X-Auth"
+        apikey_info, "header", "X-Auth", None
     )
 
     request = ConnexionRequest(
@@ -279,10 +279,10 @@ async def test_multiple_schemes():
     security_handler_factory = SecurityHandlerFactory()
     apikey_security_handler_factory = ApiKeySecurityHandler()
     wrapped_func_key1 = apikey_security_handler_factory._get_verify_func(
-        apikey1_info, "header", "X-Auth-1"
+        apikey1_info, "header", "X-Auth-1", []
     )
     wrapped_func_key2 = apikey_security_handler_factory._get_verify_func(
-        apikey2_info, "header", "X-Auth-2"
+        apikey2_info, "header", "X-Auth-2", []
     )
     schemes = {
         "key1": wrapped_func_key1,

--- a/tests/decorators/test_security.py
+++ b/tests/decorators/test_security.py
@@ -262,7 +262,7 @@ async def test_verify_apikey_scopes():
             scope={"type": "http", "headers": [[b"x-auth", b"admin foobar"]]}
         )
 
-        assert await wrapped_func(request) is not None
+        assert await wrapped_func(request) == {"sub": "foo"}
 
 
 async def test_multiple_schemes():

--- a/tests/test_operation2.py
+++ b/tests/test_operation2.py
@@ -587,7 +587,7 @@ def test_no_token_info():
 def test_multiple_security_schemes_and():
     """Tests an operation with multiple security schemes in AND fashion."""
 
-    def return_api_key_name(func, in_, name):
+    def return_api_key_name(func, in_, name, scopes):
         return name
 
     class MockApiKeyHandler(ApiKeySecurityHandler):
@@ -610,8 +610,8 @@ def test_multiple_security_schemes_and():
     )
 
     assert verify_api_key.call_count == 2
-    verify_api_key.assert_any_call(math.ceil, "header", "X-Auth-1")
-    verify_api_key.assert_any_call(math.ceil, "header", "X-Auth-2")
+    verify_api_key.assert_any_call(math.ceil, "header", "X-Auth-1", [])
+    verify_api_key.assert_any_call(math.ceil, "header", "X-Auth-2", [])
     # Assert verify_multiple_schemes is called with mapping from scheme name
     # to result of security_handler_factory.verify_api_key()
     verify_multiple.assert_called_with({"key1": "X-Auth-1", "key2": "X-Auth-2"})


### PR DESCRIPTION
Fixes # N/A

The current documentation mentions that API-key
security supports scopes: "
The function should accept the following arguments:
- apikey
- required_scopes (optional) "

However, the scopes were not passed to the checker.

Changes proposed in this pull request:

 - Add missing parameter routing to ApiKeySecurityHandler
 - Add a unit test for API-key scopes
