### PR TITLE
Fix file upload for base64 encoded files

### DIFF
--- a/connexion/validators/form_data.py
+++ b/connexion/validators/form_data.py
@@ -61,10 +61,10 @@ class FormDataValidator(AbstractRequestBodyValidator):
                 value = data.getlist(key)
 
                 def is_file(schema):
-                    return (
-                        schema.get("type") == "string"
-                        and schema.get("format") == "binary"
-                    )
+                    return schema.get("type") == "string" and schema.get("format") in [
+                        "binary",
+                        "base64",
+                    ]
 
                 # Single file upload
                 if is_file(param_schema):


### PR DESCRIPTION
Fixes #1825 

Files can be encoded as bytes or base64 ([openapi docs](https://swagger.io/docs/specification/describing-request-body/file-upload/)), we were only handling bytes before.