### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# dependabot
+# Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# ------------------------------------------------------------------------------
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    # open a single pull-request for all GitHub actions updates
+    github-actions:
+      patterns:
+      - '*'


### PR DESCRIPTION
Changes proposed in this pull request:

 - add dependabot config

Context:

There are some outdated GitHub Actions in your workflows. Instead of updating those manually, you could go for a monthly dependency update from the bot.

What do you think?
