### PR TITLE
Inject current request in security handlers

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -70,6 +70,7 @@ The function should accept the following arguments:
 - username
 - password
 - required_scopes (optional)
+- request (optional)
 
 You can find a `minimal Basic Auth example application`_ in Connexion's "examples" folder.
 
@@ -85,6 +86,7 @@ The function should accept the following arguments:
 
 - token
 - required_scopes (optional)
+- request (optional)
 
 You can find a `minimal Bearer example application`_ in Connexion's "examples" folder.
 
@@ -100,6 +102,7 @@ The function should accept the following arguments:
 
 - apikey
 - required_scopes (optional)
+- request (optional)
 
 You can find a `minimal API Key example application`_ in Connexion's "examples" folder.
 
@@ -115,6 +118,7 @@ The function should accept the following arguments:
 
 - token
 - required_scopes (optional)
+- request (optional)
 
 As alternative to an ``x-tokenInfoFunc`` definition, you can set an ``x-tokenInfoUrl`` definition or
 ``TOKENINFO_URL`` environment variable, and connexion will call the url instead of a local
@@ -132,6 +136,7 @@ The function should accept the following arguments:
 
 - required_scopes
 - token_scopes
+- request (optional)
 
 and return a boolean indicating if the validation was successful.
 


### PR DESCRIPTION
Fixes #1881
Fixes #1880
Fixes #1876

Alternative to #1750

This PR makes the current request available to the security handlers by injecting it as a keyword. I think this is a proper alternative to #1750, since this is the only place in the default middleware stack where I expect this to be needed. 

