### PR TITLE
Fix lifespan example

### DIFF
--- a/docs/lifespan.rst
+++ b/docs/lifespan.rst
@@ -18,7 +18,7 @@ instance.
             from connexion import AsyncApp, ConnexionMiddleware, request
 
             @contextlib.asynccontextmanager
-            def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
+            async def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
                 """Called at startup and shutdown, can yield state which will be available on the
                  request."""
                 client = Client()
@@ -44,7 +44,7 @@ instance.
             from connexion import FlaskApp, ConnexionMiddleware, request
 
             @contextlib.asynccontextmanager
-            def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
+            async def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
                 """Called at startup and shutdown, can yield state which will be available on the
                  request."""
                 client = Client()
@@ -71,7 +71,7 @@ instance.
             from connexion import ConnexionMiddleware, request
 
             @contextlib.asynccontextmanager
-            def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
+            async def lifespan_handler(app: ConnexionMiddleware) -> typing.AsyncIterator:
                 """Called at startup and shutdown, can yield state which will be available on the
                  request."""
                 client = Client()


### PR DESCRIPTION
Thanks a lot for this amazing tool.

When adding a `lifespan_handler` to my server, it only works if the handler is asynchronously. That is consistent with the [tests](https://github.com/spec-first/connexion/blob/994f53fb045f1668ab84c472f7dc06d093470cf1/tests/test_lifespan.py#L13) but not the documentation. So this PR aims to correct the documentation