### PR TITLE
Fix openapi spec in quickstart doc

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -141,6 +141,7 @@ register an API defined by an OpenAPI (or Swagger) specification.
                   operationId: run.post_greeting
                   responses:
                     200:
+                      description: "Greeting response"
                       content:
                         text/plain:
                           schema:


### PR DESCRIPTION
Using openapi spec from quickstart results in
```
connexion.exceptions.InvalidSpecification: {'content': {'text/plain': {'schema': {'type': 'string'}}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['responses']['patternProperties']['^[1-5](?:\\d{2}|XX)$']:
    {'oneOf': [{'$ref': '#/definitions/Response'},
               {'$ref': '#/definitions/Reference'}]}

On instance['paths']['/greeting/{name}']['get']['responses']['200']:
    {'content': {'text/plain': {'schema': {'type': 'string'}}}}  
```
because `description` is missing in the spec and it is a required property for `#/definitions/Response`. https://github.com/spec-first/connexion/blob/main/connexion/resources/schemas/v3.0/schema.json#L596-L602
