### PR TITLE
Log handled errors to warning

### DIFF
--- a/connexion/middleware/exceptions.py
+++ b/connexion/middleware/exceptions.py
@@ -72,7 +72,12 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
     @staticmethod
     def problem_handler(_request: ConnexionRequest, exc: ProblemException):
         """Default handler for Connexion ProblemExceptions"""
-        logger.error("%r", exc)
+
+        if 400 <= exc.status <= 499:
+            logger.warning("%r", exc)
+        else:
+            logger.error("%r", exc)
+
         return exc.to_problem()
 
     @staticmethod
@@ -81,6 +86,12 @@ class ExceptionMiddleware(StarletteExceptionMiddleware):
         _request: StarletteRequest, exc: HTTPException, **kwargs
     ) -> StarletteResponse:
         """Default handler for Starlette HTTPException"""
+
+        if 400 <= exc.status_code <= 499:
+            logger.warning("%r", exc)
+        else:
+            logger.error("%r", exc)
+
         logger.error("%r", exc)
         return problem(
             title=http_facts.HTTP_STATUS_CODES.get(exc.status_code),

--- a/connexion/validators/json.py
+++ b/connexion/validators/json.py
@@ -68,7 +68,7 @@ class JSONRequestBodyValidator(AbstractRequestBodyValidator):
             return self._validator.validate(body)
         except ValidationError as exception:
             error_path_msg = format_error_with_path(exception=exception)
-            logger.error(
+            logger.info(
                 f"Validation error: {exception.message}{error_path_msg}",
                 extra={"validator": "body"},
             )
@@ -129,7 +129,7 @@ class JSONResponseBodyValidator(AbstractResponseBodyValidator):
             self.validator.validate(body)
         except ValidationError as exception:
             error_path_msg = format_error_with_path(exception=exception)
-            logger.error(
+            logger.info(
                 f"Validation error: {exception.message}{error_path_msg}",
                 extra={"validator": "body"},
             )

--- a/connexion/validators/json.py
+++ b/connexion/validators/json.py
@@ -77,7 +77,8 @@ class JSONRequestBodyValidator(AbstractRequestBodyValidator):
 
 class DefaultsJSONRequestBodyValidator(JSONRequestBodyValidator):
     """Request body validator for json content types which fills in default values. This Validator
-    intercepts the body, makes changes to it, and replays it for the next ASGI application."""
+    intercepts the body, makes changes to it, and replays it for the next ASGI application.
+    """
 
     MUTABLE_VALIDATION = True
     """This validator might mutate to the body."""
@@ -129,7 +130,7 @@ class JSONResponseBodyValidator(AbstractResponseBodyValidator):
             self.validator.validate(body)
         except ValidationError as exception:
             error_path_msg = format_error_with_path(exception=exception)
-            logger.info(
+            logger.warning(
                 f"Validation error: {exception.message}{error_path_msg}",
                 extra={"validator": "body"},
             )


### PR DESCRIPTION
Fixes #1925.

Changes proposed in this pull request:

 - Log handled errors to `warning` instead of `error`.
 - Log validation errors to `info` because the intent of the log lines in informational. The error is handled by raising a new error.
