### PR TITLE
Now will distinguish between status codes the expected inferred type

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -27,7 +27,7 @@ class BaseResponseDecorator:
 
     def build_framework_response(self, handler_response):
         data, status_code, headers = self._unpack_handler_response(handler_response)
-        content_type = self._infer_content_type(data, headers)
+        content_type = self._infer_content_type(data, status_code, headers)
         if not self.framework.is_framework_response(data):
             data = self._serialize_data(data, content_type=content_type)
             status_code = status_code or self._infer_status_code(data)
@@ -37,7 +37,7 @@ class BaseResponseDecorator:
         )
 
     @staticmethod
-    def _infer_content_type(data: t.Any, headers: dict) -> t.Optional[str]:
+    def _infer_content_type(data: t.Any, status_code: int, headers: dict) -> t.Optional[str]:
         """Infer the response content type from the returned data, headers and operation spec.
 
         :param data: Response data
@@ -50,7 +50,7 @@ class BaseResponseDecorator:
         content_type = utils.extract_content_type(headers)
 
         # TODO: don't default
-        produces = list(set(operation.produces))
+        produces = list(set(operation.responses.get(str(status_code), {}).get("content", {}).keys()))
         if data is not None and not produces:
             produces = ["application/json"]
 


### PR DESCRIPTION
Fixes #1956 .



Changes proposed in this pull request:

 - Now instead merging 2 different responses as available options, will check for the status code the available options, after that if you still have multiple content types it will raise the error, and users should specify in headers the correct one
 -
 -
