### PR TITLE
Improve type hints nullable parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ ci:
   autoupdate_branch: "main"
   autoupdate_schedule: monthly
 repos:
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
     hooks:
       - id: flake8
         files: "^connexion/"

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -200,7 +200,7 @@ class AbstractApp:
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         **options,
     ):
         """

--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -197,7 +197,11 @@ class AbstractApp:
         )
 
     def add_url_rule(
-        self, rule, endpoint: str = None, view_func: t.Callable = None, **options
+        self,
+        rule,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Callable = None,
+        **options,
     ):
         """
         Connects a URL rule.  Works exactly like the `route` decorator.
@@ -271,7 +275,7 @@ class AbstractApp:
         passed to the ``StarletteClient``."""
         return TestClient(self, **kwargs)
 
-    def run(self, import_string: str = None, **kwargs):
+    def run(self, import_string: t.Optional[str] = None, **kwargs):
         """Run the application using uvicorn.
 
         :param import_string: application as import string (eg. "main:app"). This is needed to run

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -113,7 +113,7 @@ class AsyncASGIApp(RoutedMiddleware[AsyncApi]):
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         methods: t.List[str] = None,
         **options,
     ):
@@ -203,7 +203,7 @@ class AsyncApp(AbstractApp):
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         **options,
     ):
         self._middleware_app.add_url_rule(

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -100,7 +100,7 @@ class AsyncASGIApp(RoutedMiddleware[AsyncApi]):
         self.router = Router()
         super().__init__(self.router)
 
-    def add_api(self, *args, name: str = None, **kwargs):
+    def add_api(self, *args, name: t.Optional[str] = None, **kwargs):
         api = super().add_api(*args, **kwargs)
 
         if name is not None:
@@ -112,7 +112,7 @@ class AsyncASGIApp(RoutedMiddleware[AsyncApi]):
     def add_url_rule(
         self,
         rule,
-        endpoint: str = None,
+        endpoint: t.Optional[str] = None,
         view_func: t.Callable = None,
         methods: t.List[str] = None,
         **options,
@@ -200,7 +200,11 @@ class AsyncApp(AbstractApp):
         )
 
     def add_url_rule(
-        self, rule, endpoint: str = None, view_func: t.Callable = None, **options
+        self,
+        rule,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Callable = None,
+        **options,
     ):
         self._middleware_app.add_url_rule(
             rule, endpoint=endpoint, view_func=view_func, **options

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -120,7 +120,7 @@ class FlaskApi(AbstractRoutingAPI):
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         **options,
     ):
         return self.blueprint.add_url_rule(rule, endpoint, view_func, **options)
@@ -154,7 +154,7 @@ class FlaskASGIApp(SpecMiddleware):
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         **options,
     ):
         return self.app.add_url_rule(rule, endpoint, view_func, **options)
@@ -260,7 +260,7 @@ class FlaskApp(AbstractApp):
         self,
         rule,
         endpoint: t.Optional[str] = None,
-        view_func: t.Callable = None,
+        view_func: t.Optional[t.Callable] = None,
         **options,
     ):
         self._middleware_app.add_url_rule(

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -108,12 +108,20 @@ class FlaskApi(AbstractRoutingAPI):
         return flask_path, endpoint_name
 
     def _add_operation_internal(
-        self, method: str, path: str, operation: t.Callable, name: str = None
+        self,
+        method: str,
+        path: str,
+        operation: t.Callable,
+        name: t.Optional[str] = None,
     ) -> None:
         self.blueprint.add_url_rule(path, name, operation, methods=[method])
 
     def add_url_rule(
-        self, rule, endpoint: str = None, view_func: t.Callable = None, **options
+        self,
+        rule,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Callable = None,
+        **options,
     ):
         return self.blueprint.add_url_rule(rule, endpoint, view_func, **options)
 
@@ -132,7 +140,7 @@ class FlaskASGIApp(SpecMiddleware):
 
         self.asgi_app = WSGIMiddleware(self.app.wsgi_app)
 
-    def add_api(self, specification, *, name: str = None, **kwargs):
+    def add_api(self, specification, *, name: t.Optional[str] = None, **kwargs):
         api = FlaskApi(specification, **kwargs)
 
         if name is not None:
@@ -143,7 +151,11 @@ class FlaskASGIApp(SpecMiddleware):
         return api
 
     def add_url_rule(
-        self, rule, endpoint: str = None, view_func: t.Callable = None, **options
+        self,
+        rule,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Callable = None,
+        **options,
     ):
         return self.app.add_url_rule(rule, endpoint, view_func, **options)
 
@@ -245,7 +257,11 @@ class FlaskApp(AbstractApp):
         raise starlette.exceptions.HTTPException(exc.code, detail=exc.description)
 
     def add_url_rule(
-        self, rule, endpoint: str = None, view_func: t.Callable = None, **options
+        self,
+        rule,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Callable = None,
+        **options,
     ):
         self._middleware_app.add_url_rule(
             rule, endpoint=endpoint, view_func=view_func, **options

--- a/connexion/exceptions.py
+++ b/connexion/exceptions.py
@@ -75,7 +75,13 @@ class ClientProblem(ProblemException):
     """Base exception for any 4XX error. Returns 400 by default, however
     :class:`BadRequestProblem` should be preferred for 400 errors."""
 
-    def __init__(self, status: int = 400, title: str = None, *, detail: str = None):
+    def __init__(
+        self,
+        status: int = 400,
+        title: t.Optional[str] = None,
+        *,
+        detail: t.Optional[str] = None,
+    ):
         super().__init__(status=status, title=title, detail=detail)
 
 

--- a/connexion/frameworks/abstract.py
+++ b/connexion/frameworks/abstract.py
@@ -24,7 +24,7 @@ class Framework(Protocol):
         data: t.Any,
         *,
         content_type: t.Optional[str] = None,
-        headers: dict = None,
+        headers: t.Optional[dict] = None,
         status_code: int = None
     ):
         raise NotImplementedError

--- a/connexion/frameworks/abstract.py
+++ b/connexion/frameworks/abstract.py
@@ -23,7 +23,7 @@ class Framework(Protocol):
         cls,
         data: t.Any,
         *,
-        content_type: str = None,
+        content_type: t.Optional[str] = None,
         headers: dict = None,
         status_code: int = None
     ):

--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -38,7 +38,7 @@ class Flask(Framework):
         data: t.Any,
         *,
         content_type: t.Optional[str] = None,
-        headers: dict = None,
+        headers: t.Optional[dict] = None,
         status_code: int = None
     ):
         if cls.is_framework_response(data):

--- a/connexion/frameworks/flask.py
+++ b/connexion/frameworks/flask.py
@@ -37,7 +37,7 @@ class Flask(Framework):
         cls,
         data: t.Any,
         *,
-        content_type: str = None,
+        content_type: t.Optional[str] = None,
         headers: dict = None,
         status_code: int = None
     ):

--- a/connexion/frameworks/starlette.py
+++ b/connexion/frameworks/starlette.py
@@ -31,7 +31,7 @@ class Starlette(Framework):
         cls,
         data: t.Any,
         *,
-        content_type: str = None,
+        content_type: t.Optional[str] = None,
         headers: dict = None,
         status_code: int = None,
     ):

--- a/connexion/frameworks/starlette.py
+++ b/connexion/frameworks/starlette.py
@@ -32,7 +32,7 @@ class Starlette(Framework):
         data: t.Any,
         *,
         content_type: t.Optional[str] = None,
-        headers: dict = None,
+        headers: t.Optional[dict] = None,
         status_code: int = None,
     ):
         if isinstance(data, dict) or isinstance(data, list):

--- a/connexion/middleware/abstract.py
+++ b/connexion/middleware/abstract.py
@@ -141,7 +141,7 @@ class AbstractRoutingAPI(AbstractSpecAPI, t.Generic[OP]):
 
     @abc.abstractmethod
     def _add_operation_internal(
-        self, method: str, path: str, operation: OP, name: str = None
+        self, method: str, path: str, operation: OP, name: t.Optional[str] = None
     ) -> None:
         """
         Adds the operation according to the user framework in use.

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -464,7 +464,7 @@ class ConnexionMiddleware:
         error_handler = (code_or_exception, function)
         self.error_handlers.append(error_handler)
 
-    def run(self, import_string: str = None, **kwargs):
+    def run(self, import_string: t.Optional[str] = None, **kwargs):
         """Run the application using uvicorn.
 
         :param import_string: application as import string (eg. "main:app"). This is needed to run

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -87,7 +87,11 @@ class RoutingAPI(AbstractRoutingAPI):
         return starlette_path, starlette_path
 
     def _add_operation_internal(
-        self, method: str, path: str, operation: RoutingOperation, name: str = None
+        self,
+        method: str,
+        path: str,
+        operation: RoutingOperation,
+        name: t.Optional[str] = None,
     ) -> None:
         self.router.add_route(path, operation, methods=[method])
 

--- a/connexion/middleware/security.py
+++ b/connexion/middleware/security.py
@@ -113,7 +113,11 @@ class SecurityOperation:
 
 class SecurityAPI(RoutedAPI[SecurityOperation]):
     def __init__(
-        self, *args, auth_all_paths: bool = False, security_map: dict = None, **kwargs
+        self,
+        *args,
+        auth_all_paths: bool = False,
+        security_map: t.Optional[dict] = None,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
 

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -5,6 +5,7 @@ and functionality shared between Swagger 2 and OpenAPI 3 specifications.
 
 import abc
 import logging
+import typing as t
 
 from connexion.utils import all_json
 
@@ -168,13 +169,13 @@ class AbstractOperation(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def body_schema(self, content_type: str = None) -> dict:
+    def body_schema(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body schema definition for this operation.
         """
 
     @abc.abstractmethod
-    def body_definition(self, content_type: str = None) -> dict:
+    def body_definition(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body definition for this operation.
         :rtype: dict

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -3,6 +3,7 @@ This module defines an OpenAPIOperation class, a Connexion operation specific fo
 """
 
 import logging
+import typing as t
 
 from connexion.datastructures import MediaTypeDict
 from connexion.operations.abstract import AbstractOperation
@@ -212,13 +213,13 @@ class OpenAPIOperation(AbstractOperation):
     def body_name(self, _content_type: str) -> str:
         return self.request_body.get("x-body-name", "body")
 
-    def body_schema(self, content_type: str = None) -> dict:
+    def body_schema(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body schema definition for this operation.
         """
         return self.body_definition(content_type).get("schema", {})
 
-    def body_definition(self, content_type: str = None) -> dict:
+    def body_definition(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body complete definition for this operation.
 

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -215,17 +215,17 @@ class Swagger2Operation(AbstractOperation):
 
         return (build_example_from_schema(schema), status_code)
 
-    def body_name(self, content_type: str = None) -> str:
+    def body_name(self, content_type: t.Optional[str] = None) -> str:
         return self.body_definition(content_type).get("name", "body")
 
-    def body_schema(self, content_type: str = None) -> dict:
+    def body_schema(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body schema definition for this operation.
         """
         body_definition = self.body_definition(content_type)
         return self.with_definitions(body_definition).get("schema", {})
 
-    def body_definition(self, content_type: str = None) -> dict:
+    def body_definition(self, content_type: t.Optional[str] = None) -> dict:
         """
         The body complete definition for this operation.
 

--- a/connexion/testing.py
+++ b/connexion/testing.py
@@ -14,7 +14,7 @@ class TestContext:
     def __init__(
         self,
         *,
-        context: dict = None,
+        context: t.Optional[dict] = None,
         operation: AbstractOperation = None,
         receive: Receive = None,
         scope: Scope = None,

--- a/connexion/testing.py
+++ b/connexion/testing.py
@@ -15,9 +15,9 @@ class TestContext:
         self,
         *,
         context: t.Optional[dict] = None,
-        operation: AbstractOperation = None,
-        receive: Receive = None,
-        scope: Scope = None,
+        operation: t.Optional[AbstractOperation] = None,
+        receive: t.Optional[Receive] = None,
+        scope: t.Optional[Scope] = None,
     ) -> None:
         self.context = context if context is not None else self.build_context()
         self.operation = operation if operation is not None else self.build_operation()


### PR DESCRIPTION
Improve type hints for arguments that are nullables and fix _flake8_ pre-commit hook.

Changes proposed in this pull request:

 - Update _pre-commit_ configuration with the latest version of _flake8_ to prevent errors
 - Improve type hints for parameters that are nullables

