### PR TITLE
Handle starlette/templating.py:161: DeprecationWarning: The `name` is…

### DIFF
--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -164,14 +164,15 @@ class SwaggerUIAPI(AbstractSpecAPI):
     async def _get_swagger_ui_home(self, req):
         base_path = self._base_path_for_prefix(req)
         template_variables = {
-            "request": req,
             "openapi_spec_url": (base_path + self.options.openapi_spec_path),
             **self.options.swagger_ui_template_arguments,
         }
         if self.options.swagger_ui_config:
             template_variables["configUrl"] = "swagger-ui-config.json"
 
-        return self._templates.TemplateResponse("index.j2", template_variables)
+        return self._templates.TemplateResponse(
+            req, name="index.j2", context=template_variables
+        )
 
     async def _get_swagger_ui_config(self, request):
         return StarletteResponse(


### PR DESCRIPTION
Fixes:
starlette/templating.py:161: DeprecationWarning: The `name` is not the first parameter anymore. The first parameter should be the `Request` instance.
  Replace `TemplateResponse(name, {"request": request})` by `TemplateResponse(request, name)`.


Changes proposed in this pull request:

 -
 -
 -
