### PR TITLE
auth module documentation suggestion

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -29,7 +29,7 @@ validate the incoming credentials, and return information about the authenticate
 The validation function must either be defined in the API security definition
 as ``x-{type}InfoFunc``, or in the environment variables as ``{TYPE}INFO_FUNC``. The function
 should be referenced as a string using the same syntax that is used to connect an ``operationId``
-to a Python function when :ref:`routing <Routing:Explicit routing>`. This means that even if you used a resolver for the operation id, you need to specify the complete path to the security module
+to a Python function when :ref:`routing <Routing:Explicit routing>`. Note that even if you used a resolver for the operation id, it is not applied to the validation function, and you need to specify the complete path to the security module
 
 While the validation functions should accept different arguments based on the authentication type
 (as documented below), they should all return a dict which complies with `RFC 7662 <rfc7662_>`_:

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -29,7 +29,7 @@ validate the incoming credentials, and return information about the authenticate
 The validation function must either be defined in the API security definition
 as ``x-{type}InfoFunc``, or in the environment variables as ``{TYPE}INFO_FUNC``. The function
 should be referenced as a string using the same syntax that is used to connect an ``operationId``
-to a Python function when :ref:`routing <Routing:Explicit routing>`.
+to a Python function when :ref:`routing <Routing:Explicit routing>`. This means that even if you used a resolver for the operation id, you need to specify the complete path to the security module
 
 While the validation functions should accept different arguments based on the authentication type
 (as documented below), they should all return a dict which complies with `RFC 7662 <rfc7662_>`_:


### PR DESCRIPTION
After going back and forth because I kept having a "module not found" error, I finally tried to use the complete path. 
I realized afterward that the doc specified you had to use "explicit" routing but I set up the routing so long ago that it didn't click. I was focused on the "same syntax that is used to connect an operationId". 

This may not be the best way to clarify it (maybe a Troubleshooting section ?) but I just thought I would make a suggestion.

Thanks for your work !