### PR TITLE
Introducing Connexion Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- <a id="top"></a>
+<a id="top"></a>
  <p align="center">
      <img src="https://raw.githubusercontent.com/spec-first/connexion/main/docs/images/logo_banner.svg" width="100%"/>
  </p>
@@ -9,6 +9,7 @@
      <a href="https://github.com/spec-first/connexion/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/pypi/l/connexion?style=flat-square&color=brightgreen"></a>
      <a href="https://github.com/spec-first/connexion/actions/workflows/pipeline.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/spec-first/connexion/pipeline.yml?style=flat-square"></a>
      <a href="https://coveralls.io/github/spec-first/connexion?branch=main"><img alt="Coveralls" src="https://img.shields.io/coverallsCoverage/github/spec-first/connexion?style=flat-square"></a>
+     <a href="https://gurubase.io/g/connexion"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Connexion%20Guru-006BFF?style=flat-square"></a>
      <br>
      <br>
      <a href="https://connexion.readthedocs.io/en/stable/"><strong>Explore the docs »</strong></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a id="top"></a>
+ <a id="top"></a>
  <p align="center">
      <img src="https://raw.githubusercontent.com/spec-first/connexion/main/docs/images/logo_banner.svg" width="100%"/>
  </p>
@@ -9,7 +9,7 @@
      <a href="https://github.com/spec-first/connexion/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/pypi/l/connexion?style=flat-square&color=brightgreen"></a>
      <a href="https://github.com/spec-first/connexion/actions/workflows/pipeline.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/spec-first/connexion/pipeline.yml?style=flat-square"></a>
      <a href="https://coveralls.io/github/spec-first/connexion?branch=main"><img alt="Coveralls" src="https://img.shields.io/coverallsCoverage/github/spec-first/connexion?style=flat-square"></a>
-     <a href="https://gurubase.io/g/connexion"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Connexion%20Guru-006BFF?style=flat-square"></a>
+     <a href="https://gurubase.io/g/connexion"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Connexion%20Guru-brightgreen?style=flat-square"></a>
      <br>
      <br>
      <a href="https://connexion.readthedocs.io/en/stable/"><strong>Explore the docs »</strong></a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Connexion Guru](https://gurubase.io/g/connexion) to Gurubase. Connexion Guru uses the data from this repo and data from the [docs](https://connexion.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Connexion Guru", which highlights that Connexion now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Connexion Guru in Gurubase, just let me know that's totally fine.
