### PR TITLE
Return NoContent when mocking HTTP 204 operations

### DIFF
--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -49,7 +49,9 @@ class MockResolver(Resolver):
 
     def mock_operation(self, operation, *args, **kwargs):
         resp, code = operation.example_response()
-        if resp is not None:
+        if code == 204:
+            return None, code
+        elif resp is not None:
             return resp, code
         return (
             "No example response defined in the API, and response "

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -4,9 +4,7 @@ This module contains a mock resolver that returns mock functions for operations 
 
 import functools
 import logging
-from http import HTTPStatus
 
-from connexion.datastructures import NoContent
 from connexion.resolver import Resolution, Resolver, ResolverError
 
 logger = logging.getLogger(__name__)
@@ -51,9 +49,7 @@ class MockResolver(Resolver):
 
     def mock_operation(self, operation, *args, **kwargs):
         resp, code = operation.example_response()
-        if code == HTTPStatus.NO_CONTENT:
-            return NoContent, code
-        elif resp is not None:
+        if resp is not None:
             return resp, code
         return (
             "No example response defined in the API, and response "

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -6,8 +6,8 @@ import functools
 import logging
 from http import HTTPStatus
 
-from connexion.resolver import Resolution, Resolver, ResolverError
 from connexion.datastructures import NoContent
+from connexion.resolver import Resolution, Resolver, ResolverError
 
 logger = logging.getLogger(__name__)
 

--- a/connexion/mock.py
+++ b/connexion/mock.py
@@ -4,8 +4,10 @@ This module contains a mock resolver that returns mock functions for operations 
 
 import functools
 import logging
+from http import HTTPStatus
 
 from connexion.resolver import Resolution, Resolver, ResolverError
+from connexion.datastructures import NoContent
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +51,8 @@ class MockResolver(Resolver):
 
     def mock_operation(self, operation, *args, **kwargs):
         resp, code = operation.example_response()
-        if code == 204:
-            return None, code
+        if code == HTTPStatus.NO_CONTENT:
+            return NoContent, code
         elif resp is not None:
             return resp, code
         return (

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -4,8 +4,9 @@ This module defines an OpenAPIOperation class, a Connexion operation specific fo
 
 import logging
 import typing as t
+from http import HTTPStatus
 
-from connexion.datastructures import MediaTypeDict
+from connexion.datastructures import MediaTypeDict, NoContent
 from connexion.operations.abstract import AbstractOperation
 from connexion.uri_parsing import OpenAPIURIParser
 from connexion.utils import build_example_from_schema, deep_get
@@ -170,6 +171,10 @@ class OpenAPIOperation(AbstractOperation):
             status_code = int(status_code)
         except ValueError:
             status_code = 200
+
+        if status_code == HTTPStatus.NO_CONTENT:
+            return NoContent, status_code
+        
         try:
             # TODO also use example header?
             return (

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -174,7 +174,7 @@ class OpenAPIOperation(AbstractOperation):
 
         if status_code == HTTPStatus.NO_CONTENT:
             return NoContent, status_code
-        
+
         try:
             # TODO also use example header?
             return (

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -201,7 +201,7 @@ class Swagger2Operation(AbstractOperation):
 
         if status_code == HTTPStatus.NO_CONTENT:
             return NoContent, status_code
-        
+
         try:
             return (
                 list(deep_get(self._responses, examples_path).values())[0],

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -4,7 +4,9 @@ This module defines a Swagger2Operation class, a Connexion operation specific fo
 
 import logging
 import typing as t
+from http import HTTPStatus
 
+from connexion.datastructures import NoContent
 from connexion.exceptions import InvalidSpecification
 from connexion.operations.abstract import AbstractOperation
 from connexion.uri_parsing import Swagger2URIParser
@@ -196,6 +198,10 @@ class Swagger2Operation(AbstractOperation):
             status_code = int(status_code)
         except ValueError:
             status_code = 200
+
+        if status_code == HTTPStatus.NO_CONTENT:
+            return NoContent, status_code
+        
         try:
             return (
                 list(deep_get(self._responses, examples_path).values())[0],

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,3 +1,4 @@
+from connexion.datastructures import NoContent
 from connexion.mock import MockResolver
 from connexion.operations import OpenAPIOperation, Swagger2Operation
 
@@ -259,6 +260,27 @@ def test_mock_resolver_no_example_nested_in_list_openapi():
     assert status_code == 202
     assert isinstance(response, list)
     assert all(isinstance(c, str) for c in response)
+
+def test_mock_resolver_no_content():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {"204": {}}
+
+    operation = Swagger2Operation(
+        method="GET",
+        path="endpoint",
+        path_parameters=[],
+        operation={"responses": responses},
+        app_produces=["application/json"],
+        app_consumes=["application/json"],
+        definitions={},
+        resolver=resolver,
+    )
+    assert operation.operation_id == "mock-1"
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 204
+    assert response == NoContent
 
 
 def test_mock_resolver_no_examples():

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -261,6 +261,7 @@ def test_mock_resolver_no_example_nested_in_list_openapi():
     assert isinstance(response, list)
     assert all(isinstance(c, str) for c in response)
 
+
 def test_mock_resolver_no_content():
     resolver = MockResolver(mock_all=True)
 

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -87,6 +87,7 @@ def test_mock_resolver_inline_schema_example():
     assert status_code == 200
     assert response == {"foo": "bar"}
 
+
 def test_mock_resolver_no_content():
     resolver = MockResolver(mock_all=True)
 

--- a/tests/test_mock3.py
+++ b/tests/test_mock3.py
@@ -1,3 +1,4 @@
+from connexion.datastructures import NoContent
 from connexion.mock import MockResolver
 from connexion.operations import OpenAPIOperation
 
@@ -85,6 +86,24 @@ def test_mock_resolver_inline_schema_example():
     response, status_code = resolver.mock_operation(operation)
     assert status_code == 200
     assert response == {"foo": "bar"}
+
+def test_mock_resolver_no_content():
+    resolver = MockResolver(mock_all=True)
+
+    responses = {"204": {}}
+
+    operation = OpenAPIOperation(
+        method="GET",
+        path="endpoint",
+        path_parameters=[],
+        operation={"responses": responses},
+        resolver=resolver,
+    )
+    assert operation.operation_id == "mock-1"
+
+    response, status_code = resolver.mock_operation(operation)
+    assert status_code == 204
+    assert response == NoContent
 
 
 def test_mock_resolver_no_examples():


### PR DESCRIPTION
There's never a need to return a response for HTTP 204 - and these code are unlikely to have any "example" response documented  in the spec.

Avoids a uvicorn RuntimeError `"Response content longer than Content-Length"` when mocking a (3.0) spec containing:

```
...
      responses:
        '204':
          description: No Content
        '401':
          description: Unauthorized
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ProblemDetails'
...
```

* We could also move this `if/else` check into the operation's `example_response` method. Thoughts?