### PR TITLE
Correct pydoc to show swagger_ui_options param type SwaggerUIOptions

### DIFF
--- a/connexion/apps/abstract.py
+++ b/connexion/apps/abstract.py
@@ -75,7 +75,7 @@ class AbstractApp:
             start.
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
-        :param swagger_ui_options: Instance of :class:`options.ConnexionOptions` with
+        :param swagger_ui_options: Instance of :class:`options.SwaggerUIOptions` with
             configuration options for the swagger ui.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has
@@ -162,7 +162,7 @@ class AbstractApp:
             start.
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
-        :param swagger_ui_options: A :class:`options.ConnexionOptions` instance with configuration
+        :param swagger_ui_options: A :class:`options.SwaggerUIOptions` instance with configuration
             options for the swagger ui.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has

--- a/connexion/apps/asynchronous.py
+++ b/connexion/apps/asynchronous.py
@@ -168,7 +168,7 @@ class AsyncApp(AbstractApp):
             start.
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
-        :param swagger_ui_options: Instance of :class:`options.ConnexionOptions` with
+        :param swagger_ui_options: Instance of :class:`options.SwaggerUIOptions` with
             configuration options for the swagger ui.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has

--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -205,7 +205,7 @@ class FlaskApp(AbstractApp):
         :param auth_all_paths: whether to authenticate not paths not defined in the specification.
             Defaults to False.
         :param jsonifier: Custom jsonifier to overwrite json encoding for json responses.
-        :param swagger_ui_options: A :class:`options.ConnexionOptions` instance with configuration
+        :param swagger_ui_options: A :class:`options.SwaggerUIOptions` instance with configuration
             options for the swagger ui.
         :param pythonic_params: When True, CamelCase parameters are converted to snake_case and an
             underscore is appended to any shadowed built-ins. Defaults to False.
@@ -216,7 +216,7 @@ class FlaskApp(AbstractApp):
             start.
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
-        :param swagger_ui_options: Instance of :class:`options.ConnexionOptions` with
+        :param swagger_ui_options: Instance of :class:`options.SwaggerUIOptions` with
             configuration options for the swagger ui.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has

--- a/connexion/middleware/main.py
+++ b/connexion/middleware/main.py
@@ -235,7 +235,7 @@ class ConnexionMiddleware:
             start.
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
-        :param swagger_ui_options: Instance of :class:`options.ConnexionOptions` with
+        :param swagger_ui_options: Instance of :class:`options.SwaggerUIOptions` with
             configuration options for the swagger ui.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has
@@ -391,7 +391,7 @@ class ConnexionMiddleware:
         :param strict_validation: When True, extra form or query parameters not defined in the
             specification result in a validation error. Defaults to False.
         :param swagger_ui_options: A dict with configuration options for the swagger ui. See
-            :class:`options.ConnexionOptions`.
+            :class:`options.SwaggerUIOptions`.
         :param uri_parser_class: Class to use for uri parsing. See :mod:`uri_parsing`.
         :param validate_responses: Whether to validate responses against the specification. This has
             an impact on performance. Defaults to False.


### PR DESCRIPTION
Previously documented as options.ConnexionOptions, which does not exist