### PR TITLE
Fix swagger UI for split specs

### DIFF
--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -63,7 +63,7 @@ class SwaggerUIAPI(AbstractSpecAPI):
             "route_root_path", request.scope.get("root_path", "")
         ).rstrip("/")
 
-    def _spec_for_prefix(self, request):
+    def _spec_for_prefix(self, request) -> dict:
         """
         returns a spec with a modified basePath / servers block
         which corresponds to the incoming request path.

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -204,7 +204,7 @@ class Specification(Mapping):
         return OpenAPISpecification(spec, base_uri=base_uri)
 
     def clone(self):
-        return type(self)(copy.deepcopy(self._raw_spec))
+        return type(self)(copy.deepcopy(self._spec))
 
     @classmethod
     def load(cls, spec, *, arguments=None):


### PR DESCRIPTION
Fixes #1909 

This PR uses the already resolved spec when swagger UI requests it.