### PR TITLE
use connexion logger instead of root logger

### DIFF
--- a/connexion/middleware/request_validation.py
+++ b/connexion/middleware/request_validation.py
@@ -120,7 +120,7 @@ class RequestValidationOperation:
             try:
                 body_validator = self._validator_map["body"][mime_type]  # type: ignore
             except KeyError:
-                logging.info(
+                logger.info(
                     f"Skipping validation. No validator registered for content type: "
                     f"{mime_type}."
                 )

--- a/connexion/middleware/response_validation.py
+++ b/connexion/middleware/response_validation.py
@@ -107,7 +107,7 @@ class ResponseValidationOperation:
                 try:
                     body_validator = self._validator_map["response"][mime_type]  # type: ignore
                 except KeyError:
-                    logging.info(
+                    logger.info(
                         f"Skipping validation. No validator registered for content type: "
                         f"{mime_type}."
                     )


### PR DESCRIPTION
In `request_validation.py` and `response_validation.py` there is a call to `logging.info()` which means the log message goes through the root logger instead of the `connexion.middleware.validation` logger.