### PR TITLE
Remove semicolon from text/plain content type in example Swagger specs

### DIFF
--- a/examples/frameworks/spec/swagger.yaml
+++ b/examples/frameworks/spec/swagger.yaml
@@ -13,7 +13,7 @@ paths:
       description: Generates a greeting message.
       operationId: post_greeting
       produces:
-        - text/plain;
+        - text/plain
       responses:
         '200':
           description: greeting response

--- a/examples/helloworld/spec/swagger.yaml
+++ b/examples/helloworld/spec/swagger.yaml
@@ -13,7 +13,7 @@ paths:
       description: Generates a greeting message.
       operationId: hello.post_greeting
       produces:
-        - text/plain;
+        - text/plain
       responses:
         '200':
           description: greeting response


### PR DESCRIPTION
The extra semicolon causes a `NonConformingResponseHeaders` exception
when response validation is enabled for the Swagger spec in these examples.