### PR TITLE
Update sqlalchemy example to work with Python 3.8, 3.9 and 3.10

### DIFF
--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import orm
 from connexion import FlaskApp, NoContent
 
+
 def get_pets(limit, animal_type=None):
     with db_session_factory() as db_session:
         q = db_session.query(orm.Pet)
@@ -27,7 +28,7 @@ def put_pet(pet_id, pet):
             p.update(**pet)
         else:
             logging.info("Creating pet %s..", pet_id)
-            pet["created"] = datetime.now(timezone.UTC)
+            pet["created"] = datetime.now(timezone.utc)
             db_session.add(orm.Pet(**pet))
         db_session.commit()
         return NoContent, (200 if p is not None else 201)

--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 import logging
 
 import connexion
@@ -29,7 +30,7 @@ def put_pet(pet_id, pet):
             p.update(**pet)
         else:
             logging.info("Creating pet %s..", pet_id)
-            pet["created"] = datetime.datetime.now(datetime.UTC)
+            pet["created"] = datetime.datetime.now(timezone.UTC)
             db_session.add(orm.Pet(**pet))
         db_session.commit()
         return NoContent, (200 if p is not None else 201)

--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -1,11 +1,8 @@
-import datetime
-from datetime import timezone
 import logging
+from datetime import datetime, timezone
 
-import connexion
 import orm
-from connexion import NoContent
-
+from connexion import FlaskApp, NoContent
 
 def get_pets(limit, animal_type=None):
     with db_session_factory() as db_session:
@@ -30,7 +27,7 @@ def put_pet(pet_id, pet):
             p.update(**pet)
         else:
             logging.info("Creating pet %s..", pet_id)
-            pet["created"] = datetime.datetime.now(timezone.UTC)
+            pet["created"] = datetime.now(timezone.UTC)
             db_session.add(orm.Pet(**pet))
         db_session.commit()
         return NoContent, (200 if p is not None else 201)
@@ -57,7 +54,7 @@ pets = {
 }
 for id_, pet in pets.items():
     put_pet(id_, pet)
-app = connexion.FlaskApp(__name__, specification_dir="spec")
+app = FlaskApp(__name__, specification_dir="spec")
 app.add_api("openapi.yaml")
 app.add_api("swagger.yaml")
 

--- a/examples/sqlalchemy/app.py
+++ b/examples/sqlalchemy/app.py
@@ -1,8 +1,9 @@
 import logging
 from datetime import datetime, timezone
 
+import connexion
 import orm
-from connexion import FlaskApp, NoContent
+from connexion import NoContent
 
 
 def get_pets(limit, animal_type=None):
@@ -55,7 +56,7 @@ pets = {
 }
 for id_, pet in pets.items():
     put_pet(id_, pet)
-app = FlaskApp(__name__, specification_dir="spec")
+app = connexion.FlaskApp(__name__, specification_dir="spec")
 app.add_api("openapi.yaml")
 app.add_api("swagger.yaml")
 


### PR DESCRIPTION
When trying to work with this example I received the error:
```bash
AttributeError: module 'datetime' has no attribute 'UTC'
```

Doing some research, it seems the new pattern is to pull UTC from timezone. Making the suggested edit as a PR

Fixes # .



Changes proposed in this pull request:

 -
 -
 -
