### PR TITLE
Enhance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ built using either the `AsyncApp` or `FlaskApp`.
 - The `AsyncApp` is a lightweight application with native asynchronous support. Use it if you
   are starting a new project and have no specific reason to use one of the other options.
 
-  ```Python
+  ```python
       from connexion import AsyncApp
 
       app = AsyncApp(__name__)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The operation described in your specification is automatically linked to your Py
 **run.py**
 
 ```python
-   def post_greeting(name: str, greeting: str):  # Paramaeters are automatically unpacked
+   def post_greeting(name: str, greeting: str):  # Parameters are automatically unpacked
        return f"{greeting} {name}", 200          # Responses are automatically serialized
 
    app.add_api("openapi.yaml")

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,22 +1,21 @@
 Command-Line Interface
 ======================
-For convenience Connexion provides a command-line interface
-(CLI). This interface aims to be a starting point in developing or
-testing OpenAPI specifications with Connexion.
+For convenience, Connexion provides a command-line interface (CLI). 
+This interface serves as a starting point for developing or testing 
+OpenAPI specifications with Connexion.
 
 Running an OpenAPI specification
 --------------------------------
 
-The subcommand ``run`` of Connexion's CLI makes it easy to run OpenAPI
-specifications directly even before any operation handler function gets
-implemented. This allows you to verify and inspect how your API will
-work with Connexion.
+The ``run`` subcommand of Connexion's CLI makes it easy to run OpenAPI 
+specifications directly, even before any operation handler functions are 
+implemented.
 
 To run your specification, execute in your shell:
 
 .. code-block:: bash
 
-     $ connexion run your_api.yaml --stub
+    $ connexion run your_api.yaml --stub
 
 This command will tell Connexion to run the ``your_api.yaml``
 specification file attaching a stub operation (``--stub``) to the
@@ -32,16 +31,15 @@ Where:
 
 - SPEC_FILE: Your OpenAPI specification file in YAML format. Can also be given
   as a URL, which will be automatically downloaded.
-- BASE_MODULE_PATH (optional): filesystem path where the API endpoints
-  handlers are going to be imported from. In short, where your Python
-  code is saved.
+- BASE_MODULE_PATH (optional): file system path from which the API endpoint 
+  handlers will be imported. In short, where your Python code is saved.
 
 There are more options available for the ``run`` command, for a full
 list run:
 
 .. code-block:: bash
 
-     $ connexion run --help
+    $ connexion run --help
 
 Running a mock server
 ---------------------
@@ -49,9 +47,9 @@ Running a mock server
 You can run a simple server which returns example responses on every request.
 
 The example responses can be defined in the ``examples`` response property of
-the OpenAPI specification. If no examples are specified, and you have installed connexion with the `mock` extra (`pip install connexion[mock]`), an example is generated based on the provided schema.
+the OpenAPI specification. If no examples are specified, and you have installed Connexion with the `mock` extra (``pip install connexion[mock]``), an example is generated based on the provided schema.
 
-Your API specification file is not required to have any ``operationId``.
+Your API specification file does not need to have any ``operationId``.
 
 .. code-block:: bash
 

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -11,8 +11,11 @@ You can access them by importing them from ``connexion.context``:
     from connexion.context import context, operation, receive, request, scope
     from connexion import request  # alias for connexion.context.request
 
-Note that when trying to access these context variables outside of the request handling flow, or
-without running the ``ContextMiddleware``, the following ``RuntimeError`` will be thrown:
+The ``connexion.request`` is an alias for ``connexion.context.request``, providing a convenient way 
+to access the request object.
+
+When trying to access these context variables outside of the request handling flow, or without 
+running the ``ContextMiddleware``, the following ``RuntimeError`` will be thrown:
 
 .. code-block:: text
 
@@ -80,7 +83,8 @@ scope
 -----
 
 The ASGI scope as received by the ``ContextMiddleware``, thus containing any changes propagated by
-upstream middleware. The ASGI scope is presented as a ``dict``. Please refer to the `ASGI spec`_
+upstream middleware. The ASGI scope is presented as a ``dict``. It includes information about the
+connection, such as HTTP headers, query strings, and server information. Please refer to the `ASGI spec`_
 for more information on its contents.
 
 context.context
@@ -102,10 +106,14 @@ receive
 
 .. warning:: Advanced usage
 
-The receive channel as received by the ``ContextMiddleware``. Note that the receive channel might
-already be read by other parts of Connexion (eg. when accessing the body via the ``Request``, or
-when it is injected into your Python function), and that reading it yourself might make it
-unavailable for those parts of the application.
+The receive channel as received by the ``ContextMiddleware``. The receive channel is an asynchronous
+communication channel used in ASGI applications to receive incoming request data. It allows the
+application to read the request body in a non-blocking manner, which is essential for handling
+concurrent requests efficiently.
+
+Note that the receive channel might already be read by other parts of Connexion (e.g., when accessing
+the body via the ``Request``, or when it is injected into your Python function), and that reading it
+yourself might make it unavailable for those parts of the application.
 
 The receive channel can only be accessed from an ``async`` context and is therefore not relevant
 when using the ``FlaskApp``.

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -1,7 +1,7 @@
 Connexion Cookbook
 ==================
 
-This page provides recipes with Connexion as an ingredient.
+This section offers practical examples and recipes for using Connexion in your projects.
 
 CORS
 ----
@@ -120,8 +120,9 @@ Starlette. You can add it to your application, ideally in front of the ``Routing
 Reverse Proxy
 -------------
 
-When running behind a reverse proxy with stripped path prefix, you need to configure your
-application to properly handle this.
+When running behind a reverse proxy with a stripped path prefix, you need to configure your
+application to handle this properly. This ensures that your application correctly interprets 
+the original request path.
 
 Single known path prefix
 ''''''''''''''''''''''''

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -121,8 +121,8 @@ You can register error handlers on:
 
 Default Exception Handling
 --------------------------
-By default connexion exceptions are JSON serialized according to
-`Problem Details for HTTP APIs`_
+By default, Connexion exceptions are JSON serialized according to
+`Problem Details for HTTP APIs`_.
 
 Application can return errors using ``connexion.problem.problem`` or raise exceptions that inherit
 either from ``connexion.ProblemException`` or one of its subclasses to achieve the same behavior.
@@ -150,7 +150,7 @@ Using this, we can rewrite the handler above:
 
 Connexion Exceptions
 --------------------
-There are several exception types in connexion that contain extra information to help you render appropriate
+There are several exception types in Connexion that contain extra information to help you render appropriate
 messages to your user beyond the default description and status code:
 
 .. automodule:: connexion.exceptions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@
 Welcome to Connexion's documentation!
 =====================================
 
-Connexion is a modern Python web framework that makes spec-first and api-first development easy. You
+Connexion is a modern Python web framework that simplifies spec-first and API-first development. You
 describe your API in an `OpenAPI`_ (or swagger) specification with as much detail as you want and
 Connexion will guarantee that it works as you specified.
 
@@ -29,8 +29,8 @@ Based on your specification, Connexion provides the following functionality:
 * Response validation
 * A Swagger UI console with live documentation and 'try it out' feature
 
-Connexion also helps you write your OpenAPI specification and develop against it by providing a
-command line interface which lets you test and mock your specification.
+Connexion also assists in writing your OpenAPI Specification and developing against it by providing a 
+command-line interface for testing and mocking your specification.
 
 .. code-block:: bash
 
@@ -60,8 +60,8 @@ Sponsors help us dedicate time to maintain Connexion. Want to help?
 Why Connexion?
 --------------
 
-Being spec-first is what makes Connexion unique in the Python ecosystem. With Connexion, you write
-your API specification first, and automatically get a lot of functionality. With all other popular
+The spec-first approach is what makes Connexion unique in the Python ecosystem. With Connexion, you 
+write your API specification first, and automatically get a lot of functionality. With all other popular
 Python web frameworks, you write your functionality first, and automatically get your specification.
 
 We choose the spec-first approach because it:
@@ -73,7 +73,7 @@ We choose the spec-first approach because it:
 * Allows for orchestrating multiple layers of your API stack from one contract (eg. API Gateway)
 
 For a more detailed explanation about the benefits of working spec-first, or an overview of helpful
-tooling, have a look at our `recommended resources`_.
+tooling, have a look at our `recommended resources`_ section.
 
 Documentation
 -------------

--- a/docs/lifespan.rst
+++ b/docs/lifespan.rst
@@ -2,8 +2,9 @@ Lifespan
 ========
 
 You can register lifespan handlers to run code before the app starts, or after it shuts down.
-This ideal for setting up and tearing down database connections or machine learning models for
-instance.
+This is ideal for setting up and tearing down database connections or machine learning models, 
+for instance.
+
 
 .. tab-set::
 
@@ -25,7 +26,7 @@ instance.
                 yield {"client": client}
                 client.close()
 
-            def route():
+            def endpoint():
                 """Endpoint function called when receiving a request, you can access the state
                 on the request here."""
                 client = request.state.client
@@ -51,7 +52,7 @@ instance.
                 yield {"client": client}
                 client.close()
 
-            def route():
+            def endpoint():
                 """Endpoint function called when receiving a request, you can access the state
                 on the request here."""
                 client = request.state.client

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -10,13 +10,13 @@ following order:
 
     **ServerErrorMiddleware**, "Returns server errors for any exceptions not caught by the
     ExceptionMiddleware"
-    **ExceptionMiddleware**, Handles exceptions raised by the middleware stack or application
-    **SwaggerUIMiddleware**, Adds a Swagger UI to your application
+    **ExceptionMiddleware**, "Handles exceptions raised by the middleware stack or application"
+    **SwaggerUIMiddleware**, "Adds a Swagger UI to your application"
     **RoutingMiddleware**, "Routes incoming requests to the right operation defined in the
     specification"
     **SecurityMiddleware**, "Checks incoming requests against the security defined in the
     specification"
-    **RequestValidationMiddleware**, Validates the incoming requests against the spec
+    **RequestValidationMiddleware**, "Validates the incoming requests against the spec"
     **ResponseValidationMiddleware**, "Validates the returned responses against the spec, if
     activated"
     **LifespanMiddleware**, "Allows registration of code to run before application start-up or
@@ -191,12 +191,12 @@ Writing custom middleware
 -------------------------
 
 You can add any custom middleware as long as it implements the ASGI interface. To learn how to
-write pure ASGI middleware, please refer to the `documentation of starlette`_.
+write pure ASGI middleware, please refer to the `documentation of Starlette`_.
 
 List of useful middleware
 -------------------------
 
-Starlette provides a bunch of useful middleware such as:
+Starlette provides a variety of useful middleware such as:
 
 * `CORSMiddleware`_
 * `SessionMiddleware`_
@@ -204,13 +204,13 @@ Starlette provides a bunch of useful middleware such as:
 * `TrustedHostMiddleware`_
 * `GZipMiddleware`_
 
-Other useful middleware:
+Other useful middleware includes:
 
 * `ProxyHeadersMiddleware`_ by Uvicorn
 * `SentryASGIMiddleware`_ by Sentry
 * `MetricsMiddleware`_ by Prometheus
 
-For more, check the `asgi-middleware topic`_ on github.
+For more, check the `asgi-middleware topic`_ on GitHub.
 
 .. _documentation of starlette: https://www.starlette.io/middleware/#writing-pure-asgi-middleware
 .. _CORSMiddleware: https://www.starlette.io/middleware/#corsmiddleware

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ Connexion provides 'extras' with optional dependencies to unlock additional feat
 - :code:`flask`: Enables the :code:`FlaskApp` to build applications compatible with the Flask
   ecosystem.
 - :code:`swagger-ui`: Enables a Swagger UI console for your application.
-- :code:`uvicorn`: Enables to run the your application using :code:`app.run()` for
+- :code:`uvicorn`: Enables running your application using :code:`app.run()` for
   development instead of using an external ASGI server.
 
 You can install them as follows:
@@ -23,7 +23,7 @@ You can install them as follows:
 .. code-block:: bash
 
     $ pip install connexion[<extra>]
-    $ pip install connexion[<extra1>,<extra2>].
+    $ pip install connexion[<extra1>,<extra2>]
 
 Creating your application
 -------------------------
@@ -38,7 +38,7 @@ built using either the :code:`AsyncApp` or :code:`FlaskApp`.
   connexion 2.X or you want to leverage the `Flask` ecosystem.
 - The :code:`ConnexionMiddleware` can be wrapped around any existing ASGI or WSGI application.
   Use it if you already have an application written in a different framework and want to add
-  functionality provided by connexion
+  functionality provided by Connexion.
 
 .. tab-set::
 
@@ -198,7 +198,7 @@ You can run your application using an ASGI server such as `uvicorn`. If you defi
     # assuming your application is defined as ``app`` in ``run.py``
     $ uvicorn run:app
 
-Or with gunicorn (which is recommended in production).
+Or with Gunicorn (which is recommended in production).
 
 .. code-block:: bash
 
@@ -257,7 +257,7 @@ The Swagger UI
 
 If you installed connexion using the :code:`swagger-ui` extra, a Swagger UI is available for each
 API, providing interactive documentation. By default the UI is hosted at :code:`{base_path}/ui/`
-where :code:`base_path`` is the base path of the API.
+where :code:`base_path` is the base path of the API.
 
 **https://{host}/{base_path}/ui/**
 

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -20,7 +20,7 @@ Automatic parameter handling
         :sync: AsyncApp
 
         Connexion automatically maps the parameters defined in your endpoint specification to the
-        arguments defined your associated Python function, parsing and casting values when
+        arguments defined in your associated Python function, parsing and casting values when
         possible. All you need to do, is make sure the arguments of your function match the
         parameters in your specification.
 
@@ -28,7 +28,7 @@ Automatic parameter handling
         :sync: FlaskApp
 
         Connexion automatically maps the parameters defined in your endpoint specification to the
-        arguments defined your associated Python function, parsing and casting values when
+        arguments defined in your associated Python function, parsing and casting values when
         possible. All you need to do, is make sure the arguments of your function match the
         parameters in your specification.
 
@@ -36,7 +36,7 @@ Automatic parameter handling
         :sync: ConnexionMiddleware
 
         Connexion can automatically map the parameters defined in your endpoint specification to
-        the arguments defined your associated Python function, parsing and casting values when
+        the arguments defined in your associated Python function, parsing and casting values when
         possible. All you need to do, is make sure the arguments of your function match the
         parameters in your specification.
 
@@ -157,11 +157,11 @@ The body will also be passed to your function.
             :caption: **api.py**
 
             # Default
-            def foo_get(body)
+            def foo_get(body):
                 ...
 
             # Based on x-body-name
-            def foo_get(payload)
+            def foo_get(payload):
                 ...
 
     .. tab-item:: Swagger 2
@@ -187,7 +187,7 @@ The body will also be passed to your function.
         .. code-block:: python
             :caption: **api.py**
 
-            def foo_get(payload)
+            def foo_get(payload):
                 ...
 
         Form data
@@ -217,7 +217,7 @@ The body will also be passed to your function.
         .. code-block:: python
             :caption: **api.py**
 
-            def foo_get(field1, field2)
+            def foo_get(field1, field2):
                 ...
 
 Connexion will not automatically pass in the default values defined in your ``requestBody``
@@ -281,7 +281,7 @@ Connexion extracts the files from the body and passes them into your view functi
         .. code-block:: python
             :caption: **api.py**
 
-                    def foo_get(file)
+                    def foo_get(file):
                         assert isinstance(file, starlette.UploadFile)
                         ...
 
@@ -294,7 +294,7 @@ Connexion extracts the files from the body and passes them into your view functi
         .. code-block:: python
             :caption: **api.py**
 
-                    def foo_get(file)
+                    def foo_get(file):
                         assert isinstance(file, werkzeug.FileStorage)
                         ...
 
@@ -317,7 +317,7 @@ They will be provided to your view function as a list.
         .. code-block:: python
             :caption: **api.py**
 
-                    def foo_get(file)
+                    def foo_get(file):
                         assert isinstance(file, list)
                         assert isinstance(file[0], starlette.UploadFile)
                         ...
@@ -329,7 +329,7 @@ They will be provided to your view function as a list.
         .. code-block:: python
             :caption: **api.py**
 
-                    def foo_get(file)
+                    def foo_get(file):
                         assert isinstance(file, list)
                         assert isinstance(file[0], werkzeug.FileStorage)
                         ...
@@ -352,7 +352,7 @@ default value:
 .. code-block:: python
     :caption: **api.py**
 
-    def foo_get(optional_argument=None)
+    def foo_get(optional_argument=None):
         ...
 
 Missing arguments and kwargs
@@ -409,7 +409,7 @@ either the application or the API:
             from connexion import FlaskApp
 
             app = FlaskApp(__name__, pythonic_params=True)
-            app.add_api("openapi.yaml", pythonic_params=True):
+            app.add_api("openapi.yaml", pythonic_params=True)
 
     .. tab-item:: ConnexionMiddleware
         :sync: ConnexionMiddleware

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -19,19 +19,19 @@ Response Serialization
         :sync: AsyncApp
 
 
-        When working with Connexion, you can return ordinary Python types, and connexion will serialize
+        When working with Connexion, you can return ordinary Python types, and Connexion will serialize
         them into a network response.
 
     .. tab-item:: FlaskApp
         :sync: FlaskApp
 
-        When working with Connexion, you can return ordinary Python types, and connexion will serialize
+        When working with Connexion, you can return ordinary Python types, and Connexion will serialize
         them into a network response.
 
     .. tab-item:: ConnexionMiddleware
         :sync: ConnexionMiddleware
 
-        When working with Connexion, you can return ordinary Python types, and connexion will serialize
+        When working with Connexion, you can return ordinary Python types, and Connexion will serialize
         them into a network response.
 
         To activate this behavior when using the ``ConnexionMiddleware`` wrapping a third party
@@ -131,7 +131,7 @@ an API:
             from connexion import FlaskApp
 
             app = FlaskApp(__name__, jsonifier=...)
-            app.add_api("openapi.yaml", jsonifier=...):
+            app.add_api("openapi.yaml", jsonifier=...)
 
     .. tab-item:: ConnexionMiddleware
         :sync: ConnexionMiddleware
@@ -179,7 +179,6 @@ If your endpoint returns an instance of ``connexion.lifecycle.ConnexionResponse`
 framework-specific response (``flask.Response`` or ``starlette.responses.Response``), response
 serialization is skipped, and the response is passed directly to the underlying framework.
 
-If your endpoint returns a `Response`
-If the endpoint returns a `Response` object this response will be used as is.
+If your endpoint returns a `Response` object, this response will be used as is.
 
 .. _Frameworks: https://github.com/spec-first/connexion/tree/main/examples/frameworks

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -10,7 +10,7 @@ be done in two ways:
 Explicit routing
 ----------------
 
-Connexion uses the :code:`operation_id` to link each `operation`_ in your API contract to
+Connexion uses the :code:`operationId` to link each `operation`_ in your API contract to
 the python function that should handle it.
 
 .. code-block:: python

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -10,14 +10,14 @@ some of the most popular security schemes.
 
     **Swagger 2**, **Connexion support**
     Basic Authentication, |:white_check_mark:|
-    API key, |:white_check_mark:|
-    Oauth2, |:white_check_mark:|
+    API Key, |:white_check_mark:|
+    OAuth2, |:white_check_mark:|
     **OpenAPI**,
     HTTP Basic, |:white_check_mark:|
     HTTP Bearer, |:white_check_mark:|
-    Other HTTP schemes (RFC 7253), "No built-in support, use a `custom security handler <#custom-security-handlers>`_"
-    API key, |:white_check_mark:|
-    Oauth2, |:white_check_mark:|
+    Other HTTP Schemes (RFC 7253), "No built-in support, use a `custom security handler <#custom-security-handlers>`_"
+    API Key, |:white_check_mark:|
+    OAuth2, |:white_check_mark:|
     OpenID, "No built-in support, use a `custom security handler <#custom-security-handlers>`_"
 
 General authentication flow
@@ -29,7 +29,7 @@ validate the incoming credentials, and return information about the authenticate
 The validation function must either be defined in the API security definition
 as ``x-{type}InfoFunc``, or in the environment variables as ``{TYPE}INFO_FUNC``. The function
 should be referenced as a string using the same syntax that is used to connect an ``operationId``
-to a Python function when :ref:`routing <Routing:Explicit routing>`. Note that even if you used a resolver for the operation id, it is not applied to the validation function, and you need to specify the complete path to the security module
+to a Python function when :ref:`routing <Routing:Explicit routing>`. Note that even if you used a resolver for the operation id, it is not applied to the validation function, and you need to specify the complete path to the security module.
 
 While the validation functions should accept different arguments based on the authentication type
 (as documented below), they should all return a dict which complies with `RFC 7662 <rfc7662_>`_:
@@ -55,7 +55,7 @@ The token information is made available to your endpoint view functions via the
 
 .. note::
 
-    Note that you are responsible to validate any fields other than the scopes yourself.
+    Note that you are responsible for validate any fields other than the scopes yourself.
 
 .. _rfc7662: https://tools.ietf.org/html/rfc7662
 
@@ -120,16 +120,16 @@ The function should accept the following arguments:
 - required_scopes (optional)
 - request (optional)
 
-As alternative to an ``x-tokenInfoFunc`` definition, you can set an ``x-tokenInfoUrl`` definition or
-``TOKENINFO_URL`` environment variable, and connexion will call the url instead of a local
-function instead. Connexion expects the authorization server to receive the OAuth token in the
+As an alternative to an ``x-tokenInfoFunc`` definition, you can set an ``x-tokenInfoUrl`` definition or
+``TOKENINFO_URL`` environment variable, and Connexion will call the URL instead of a local
+function. Connexion expects the authorization server to receive the OAuth token in the
 ``Authorization`` header field in the format described in `RFC 6750 <rfc6750_>`_ section 2.1 and
 return the token information in the same format as a validation function. When both
 ``x-tokenInfoUrl`` and ``x-tokenInfoFunc`` are used, Connexion will prioritize the function.
 
 The list of scopes returned in the token information will be validated against the scopes
 required by the API security definition to determine if the user is authorized.
-You can supply a custom scope validation func by defining ``x-scopeValidateFunc``
+You can supply a custom scope validation function by defining ``x-scopeValidateFunc``
 or setting a ``SCOPEVALIDATE_FUNC`` environment variable.
 
 The function should accept the following arguments:

--- a/docs/swagger_ui.rst
+++ b/docs/swagger_ui.rst
@@ -3,7 +3,7 @@ The Swagger UI
 
 If you installed connexion using the :code:`swagger-ui` extra, a Swagger UI is available for each
 API, providing interactive documentation. By default the UI is hosted at :code:`{base_path}/ui/`
-where :code:`base_path`` is the base path of the API.
+where :code:`base_path` is the base path of the API.
 
 **https://{host}/{base_path}/ui/**
 
@@ -12,8 +12,8 @@ where :code:`base_path`` is the base path of the API.
 Configuring the Swagger UI
 --------------------------
 
-You can change this path through the ``swagger_ui_options`` argument, either whe instantiating
-your application, or when adding your api:
+You can change this path through the :code:`swagger_ui_options` argument, either when instantiating
+your application, or when adding your API:
 
 
 .. tab-set::
@@ -60,7 +60,7 @@ your application, or when adding your api:
 
             app = App(__name__)
             app = ConnexionMiddleware(app, swagger_ui_options=options)
-            app.add_api("openapi.yaml", swagger_ui_options=options):
+            app.add_api("openapi.yaml", swagger_ui_options=options)
 
 For a description of all available options, check the :class:`.SwaggerUIOptions`
 class.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,6 +1,9 @@
 Testing
 =======
 
+This document provides guidelines and examples for testing Connexion applications, including how 
+to use the `test_client` and `TestContext` to facilitate testing.
+
 test_client
 -----------
 
@@ -17,7 +20,7 @@ Connexion application during tests.
             assert response.status_code == 200
 
 
-The passed in keywords used to create a `Starlette` ``TestClient`` which is then returned.
+The passed-in keywords used to create a `Starlette` ``TestClient``, which is then returned.
 
 For more information, please check the `Starlette documentation`_.
 
@@ -45,6 +48,6 @@ provided by Connexion.
         operation = MagicMock(name="operation")
         operation.method = "post"
         with TestContext(operation=operation):
-            assert get_method() == "post
+            assert get_method() == "post"
 
-If you don't pass in a certain context variable, the `TestContext` will generate a dummy one.
+If a specific context variable is not provided, the `TestContext` will automatically generate a dummy value for it.

--- a/docs/v3.rst
+++ b/docs/v3.rst
@@ -189,7 +189,7 @@ For more information, check the :doc:`exceptions` documentation.
 Flask extensions and WSGI middleware
 ````````````````````````````````````
 
-Certain Flask extensions and WSGI middleware might no longer work, since some functionaity was
+Certain Flask extensions and WSGI middleware might no longer work, since some functionality was
 moved outside the scope of the Flask application. Extensions and middleware impacting the
 following functionality should now be implemented as ASGI middleware instead:
 

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -23,12 +23,12 @@ Request validation
 ------------------
 
 Connexion will validate any incoming requests against your specification and automatically
-returns the correct 4XX error on failure.
+return the correct 4XX error on failure.
 
 Parameter validation
 ````````````````````
 
-By default, Connexion checks all the request for any parameters defined in your specification and
+By default, Connexion checks all request for any parameters defined in your specification and
 validates them against their definition. This includes their schema (``type``, ``format``,
 ``range``, ...) and whether or not they are required or whether they can be ``null``.
 


### PR DESCRIPTION
Fixes [#2032](https://github.com/spec-first/connexion/issues/2032).

## Changes proposed in this pull request:  
- Improved clarity and formatting in CLI documentation  
- Enhanced documentation for context variables and ASGI scope  
- Refined language and clarity in the Connexion Cookbook  
- Fixed grammar, punctuation, and typos in multiple `.rst` and `.md` files, including:  
  - `index.rst`  
  - `lifespan.rst`  
  - `middleware.rst`  
  - `quickstart.rst`  
  - `request.rst`  
  - `response.rst`  
  - `security.rst`  
  - `swagger_ui.rst`  
  - `testing.rst`  
  - `v3.rst`  
  - `validation.rst`  
  - `README.md`  

These updates enhance readability and maintain consistency across the documentation.  