### PR TITLE
Specify skip for separate referencing package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,7 @@ exclude_lines = [
 [[tool.mypy.overrides]]
 module = "referencing.jsonschema.*"
 follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "referencing._core.*"
+follow_imports = "skip"


### PR DESCRIPTION
Fixes the mypy error that is causing all pipelines to fail. Underlying reason seems to be that the `jsonschema` library was updated and factored out some code into a separate package. So updated it to also reference that file in our mypy overrides.

Might be fixed for newer versions by this recent commit https://github.com/python-jsonschema/referencing/commit/f830e4c8d6a3b9b792d091ee8c6ac2eafbcf0de0
