### PR TITLE
Do not inject components in schemas of response bodies

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -137,7 +137,6 @@ class OpenAPIOperation(AbstractOperation):
     def with_definitions(self, schema: dict):
         if self.components:
             schema.setdefault("schema", {})
-            schema["schema"]["components"] = self.components
         return schema
 
     def response_schema(self, status_code=None, content_type=None):


### PR DESCRIPTION
On certain cases, the global components of the openapi are injected in the content of schemas of response bodies of some paths

Fixes #2029 .



Changes proposed in this pull request:

 - Removing the line that injects the components