### PR TITLE
Replace deprecated datetime.datetime.utcnow()

### DIFF
--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -18,7 +18,10 @@ def test_json_encoder():
     s = json.dumps(datetime.date.today(), cls=json_encoder)
     assert len(s) == 12
 
-    s = json.dumps(datetime.datetime.utcnow(), cls=json_encoder)
+    s = json.dumps(
+        datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None),
+        cls=json_encoder,
+    )
     assert s.endswith('Z"')
 
     s = json.dumps(Decimal(1.01), cls=json_encoder)


### PR DESCRIPTION
Changes proposed in this pull request:

 - Replace datetime.datetime.utcnow, which was deprecated in Python 3.12[1]

[1] https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow
