### PR TITLE
(v2) Replace deprecated datetime.datetime.utcnow()

### DIFF
--- a/examples/openapi3/sqlalchemy/app.py
+++ b/examples/openapi3/sqlalchemy/app.py
@@ -29,7 +29,9 @@ def put_pet(pet_id, pet):
         p.update(**pet)
     else:
         logging.info("Creating pet %s..", pet_id)
-        pet["created"] = datetime.datetime.utcnow()
+        pet["created"] = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         db_session.add(orm.Pet(**pet))
     db_session.commit()
     return NoContent, (200 if p is not None else 201)

--- a/examples/swagger2/sqlalchemy/app.py
+++ b/examples/swagger2/sqlalchemy/app.py
@@ -29,7 +29,9 @@ def put_pet(pet_id, pet):
         p.update(**pet)
     else:
         logging.info("Creating pet %s..", pet_id)
-        pet["created"] = datetime.datetime.utcnow()
+        pet["created"] = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         db_session.add(orm.Pet(**pet))
     db_session.commit()
     return NoContent, (200 if p is not None else 201)

--- a/tests/test_flask_encoder.py
+++ b/tests/test_flask_encoder.py
@@ -18,7 +18,10 @@ def test_json_encoder():
     s = json.dumps(datetime.date.today(), cls=FlaskJSONEncoder)
     assert len(s) == 12
 
-    s = json.dumps(datetime.datetime.utcnow(), cls=FlaskJSONEncoder)
+    s = json.dumps(
+        datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None),
+        cls=FlaskJSONEncoder,
+    )
     assert s.endswith('Z"')
 
     s = json.dumps(Decimal(1.01), cls=FlaskJSONEncoder)


### PR DESCRIPTION
Changes proposed in this pull request:

 - Replace datetime.datetime.utcnow, which was deprecated in Python 3.12[1]

[1] https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow