### PR TITLE
Extend tox.ini with `testpaths` and {posargs} in poetry-pytest invocation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,14 @@
+# Run all tests:
+#   tox
+# Run all tests in one file in all test environments:
+#   tox -- tests/test_api.py
+# Run one test in all test environments:
+#   tox -- tests/test_api.py::test_api
+# Run all tests in one file in one test environment:
+#   tox -e py39 -- tests/test_api.py
+# Run one test in one test environment:
+#   tox -e py39 -- tests/test_api.py::test_api
+
 [flake8]
 exclude=connexion/__init__.py
 rst-roles=class,mod,obj
@@ -21,6 +32,9 @@ python =
     3.11: py311-pypi,pre-commit
     3.12: py312-pypi
 
+[pytest]
+testpaths = tests
+
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
 deps=
@@ -34,7 +48,7 @@ commands=
     poetry lock
     poetry install --all-extras --with tests
     poetry show
-    poetry run python -m pytest tests --cov connexion --cov-report term-missing
+    poetry run python -m pytest --cov connexion --cov-report term-missing {posargs}
     min: mv -f pyproject.toml.bak pyproject.toml
 
 [testenv:pre-commit]


### PR DESCRIPTION
This allows limiting the scope of the test run, which can save much time.
    
Run one test in one test environment:
    
    tox -e py39 -- tests/test_api.py::test_api
    
Run one test in all test environments:
    
    tox -- tests/test_api.py::test_api
    
Run all tests in one file in one test environment:
    
    tox -e py39 -- tests/test_api.py
    
Run all tests in one file in all test environments:
    
    tox -- tests/test_api.py
