### PR TITLE
request body in openapi no need to append the components

### DIFF
--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -134,8 +134,8 @@ class OpenAPIOperation(AbstractOperation):
     def produces(self):
         return self._produces
 
-    def with_definitions(self, schema: dict):
-        if self.components:
+    def with_definitions(self, schema: dict, append_components=True):
+        if self.components and append_components:
             schema.setdefault("schema", {})
             schema["schema"]["components"] = self.components
         return schema
@@ -241,5 +241,5 @@ class OpenAPIOperation(AbstractOperation):
                 )
             content_type_dict = MediaTypeDict(self.request_body.get("content", {}))
             res = content_type_dict.get(content_type, {})
-            return self.with_definitions(res)
+            return self.with_definitions(res, append_components=False)
         return {}

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -654,8 +654,12 @@ def test_openapi_schema_validate_with_request_body_change(simple_app):
     app_client = simple_app.test_client()
 
     if simple_app._spec_file == "openapi.yaml":
-        response = app_client.post("/v1.0/test-default-object-body", headers={"content-type": "application/json"}, json={"image_version": "2015-08-26"})
+        response = app_client.post(
+            "/v1.0/test-default-object-body",
+            headers={"content-type": "application/json"},
+            json={"image_version": "2015-08-26"},
+        )
         assert response.status_code == 200
-        
+
         response = app_client.get("/v1.0/openapi.json")
         assert response.status_code == 200

--- a/tests/api/test_parameters.py
+++ b/tests/api/test_parameters.py
@@ -648,3 +648,14 @@ def test_cookie_param(simple_app):
     response = app_client.get("/v1.0/test-cookie-param")
     assert response.status_code == 200
     assert response.json() == {"cookie_value": "hello"}
+
+
+def test_openapi_schema_validate_with_request_body_change(simple_app):
+    app_client = simple_app.test_client()
+
+    if simple_app._spec_file == "openapi.yaml":
+        response = app_client.post("/v1.0/test-default-object-body", headers={"content-type": "application/json"}, json={"image_version": "2015-08-26"})
+        assert response.status_code == 200
+        
+        response = app_client.get("/v1.0/openapi.json")
+        assert response.status_code == 200


### PR DESCRIPTION
Fixes # .

reproduce:

* start up server, and call one of the api with Post and body
* open swagger and refresh
error:

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['requestBody']:
    {'oneOf': [{'$ref': '#/definitions/RequestBody'},
               {'$ref': '#/definitions/Reference'}]}


Changes proposed in this pull request:

 request body in openapi no need to append the components
 
