### PR TITLE
Fix/multiple content type headers lead to 415 consistently

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -158,7 +158,7 @@ def is_json_mimetype(mimetype):
     if mimetype is None:
         return False
 
-    maintype, subtype = mimetype.split("/")  # type: str, str
+    maintype, subtype = mimetype.split("/", maxsplit=1)  # type: str, str
     if ";" in subtype:
         subtype, parameter = subtype.split(";", maxsplit=1)
     return maintype == "application" and (

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -310,10 +310,8 @@ def extract_content_type(
 
         if decoded_key.lower() == "content-type":
             if isinstance(value, bytes):
-                content_type = value.decode("latin-1")
-            else:
-                content_type = value
-            break
+                value = value.decode("latin-1")
+            content_type = ",".join([content_type, value] if content_type else [value])
 
     return content_type
 

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -175,3 +175,26 @@ def test_defaults_body(json_validation_spec_dir, spec):
     )
     assert res.status_code == 200
     assert res.json().get("human")
+
+
+def test_multiple_json_content_type(json_validation_spec_dir, spec):
+    """ensure that defaults applied that modify the body"""
+
+    class MyDefaultsJSONBodyValidator(DefaultsJSONRequestBodyValidator):
+        pass
+
+    validator_map = {"body": {"application/json": MyDefaultsJSONBodyValidator}}
+
+    app = App(__name__, specification_dir=json_validation_spec_dir)
+    app.add_api(spec, validate_responses=True, validator_map=validator_map)
+    app_client = app.test_client()
+
+    res = app_client.post(
+        "/v1.0/user",
+        data=json.dumps({"name": "foo"}),
+        headers={
+            "content-type": "application/json",
+            "Content-Type": "application/json",
+        },
+    )
+    assert res.status_code == 415

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,16 +62,29 @@ def test_deep_get_list():
     assert utils.deep_get(obj, ["0", "properties", "id"]) == {"type": "string"}
 
 
-def test_is_json_mimetype():
-    assert utils.is_json_mimetype("application/json")
-    assert utils.is_json_mimetype("application/vnd.com.myEntreprise.v6+json")
-    assert utils.is_json_mimetype(
-        "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
-    )
-    assert utils.is_json_mimetype(
-        "application/vnd.com.myEntreprise.v6+json; charset=UTF-8"
-    )
-    assert not utils.is_json_mimetype("text/html")
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        "application/json",
+        "application/vnd.com.myEntreprise.v6+json",
+        "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",
+        "application/vnd.com.myEntreprise.v6+json; charset=UTF-8",
+    ],
+)
+def test_is_json_mimetype_true(mime_type: str):
+    assert utils.is_json_mimetype(mime_type)
+
+
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        "application/json,application/json",
+        "text/html",
+        "text/json",
+    ],
+)
+def test_is_json_mimetype_false(mime_type: str):
+    assert not utils.is_json_mimetype(mime_type)
 
 
 def test_sort_routes():


### PR DESCRIPTION
I'm pleased to submit a pull request that I believe fixes #2040 on GitHub. The proposed changes aim to improve consistency of the behavior of content-type header inspection in Connexion.

Key modifications include:

* Ensuring that searching for content types does not short-circuit, aligning with other header inspections.
* Adding a test to safeguard against potential regressions.

The reason this fix is effective (tested in an interactive debugger with multiple clients and original tests) is that
the modified method was previously returning 'application/json', while subsequent implementations downstream returned
'application/json,application/json'. This resulted in three parts when splitting by '/' instead of two, which caused
issues.

I did investigate alternative approaches to fixing the '/'-split issue mentioned in the original report. However, this
led me to modify more code, which didn't resolve the 500 error and 415 response from Safari. I opted for a more precise
approach that focused on the specific method modification, as it yielded better results.

Please let me know if you have any questions or concerns about this pull request.