### PR TITLE
chore: move pre-commit to dev-dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,10 @@ swagger-ui = ["swagger-ui-bundle"]
 uvicorn = ["uvicorn"]
 mock = ["jsf"]
 
-[tool.poetry.group.tests.dependencies]
+[tool.poetry.group.dev.dependencies]
 pre-commit = "~2.21.0"
+
+[tool.poetry.group.tests.dependencies]
 pytest = "7.2.1"
 pytest-asyncio = "~0.18.3"
 pytest-cov = "~2.12.1"


### PR DESCRIPTION
Changes proposed in this pull request:

 - just to move pre-commit out of the test group, and into the dev group.
