### PR TITLE
Fix clone() method using processed spec instead of raw specFix spec.py

### DIFF
--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,6 +203,7 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
+
 def clone(self):
     # Check if spec contains only internal refs (starting with #)
     # For external refs, we need the processed spec to maintain resolved content
@@ -211,8 +212,10 @@ def clone(self):
     else:
         return type(self)(copy.deepcopy(self._spec))
 
+
 def _has_only_internal_refs(self):
     """Check if all $ref entries point to internal references only (starting with #)"""
+
     def check_refs(obj):
         if isinstance(obj, dict):
             for key, value in obj.items():
@@ -231,6 +234,7 @@ def _has_only_internal_refs(self):
                 if not check_refs(item):
                     return False
         return True
+
     return check_refs(self._raw_spec)
 
     @classmethod

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -204,38 +204,38 @@ class Specification(Mapping):
         return OpenAPISpecification(spec, base_uri=base_uri)
 
 
-def clone(self):
-    # Check if spec contains only internal refs (starting with #)
-    # For external refs, we need the processed spec to maintain resolved content
-    if self._has_only_internal_refs():
-        return type(self)(copy.deepcopy(self._raw_spec))
-    else:
-        return type(self)(copy.deepcopy(self._spec))
+    def clone(self):
+        # Check if spec contains only internal refs (starting with #)
+        # For external refs, we need the processed spec to maintain resolved content
+        if self._has_only_internal_refs():
+            return type(self)(copy.deepcopy(self._raw_spec))
+        else:
+            return type(self)(copy.deepcopy(self._spec))
 
 
-def _has_only_internal_refs(self):
-    """Check if all $ref entries point to internal references only (starting with #)"""
+    def _has_only_internal_refs(self):
+        """Check if all $ref entries point to internal references only (starting with #)"""
 
-    def check_refs(obj):
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                if key == "$ref" and isinstance(value, str):
-                    # External ref if it doesn't start with # or contains file references
-                    if (
-                        not value.startswith("#")
-                        or ".yaml" in value
-                        or ".json" in value
-                    ):
+        def check_refs(obj):
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    if key == "$ref" and isinstance(value, str):
+                        # External ref if it doesn't start with # or contains file references
+                        if (
+                            not value.startswith("#")
+                            or ".yaml" in value
+                            or ".json" in value
+                        ):
+                            return False
+                    elif not check_refs(value):
                         return False
-                elif not check_refs(value):
-                    return False
-        elif isinstance(obj, (list, tuple)):
-            for item in obj:
-                if not check_refs(item):
-                    return False
-        return True
+            elif isinstance(obj, (list, tuple)):
+                for item in obj:
+                    if not check_refs(item):
+                        return False
+            return True
 
-    return check_refs(self._raw_spec)
+        return check_refs(self._raw_spec)
 
     @classmethod
     def load(cls, spec, *, arguments=None):

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,6 +203,7 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
+
 def clone(self):
     # Check if spec contains only internal refs (starting with #)
     # For external refs, we need the processed spec to maintain resolved content
@@ -211,16 +212,21 @@ def clone(self):
     else:
         return type(self)(copy.deepcopy(self._spec))
 
+
 def _has_only_internal_refs(self):
     """Check if all $ref entries point to internal references only (starting with #)"""
     import re
-    
+
     def check_refs(obj):
         if isinstance(obj, dict):
             for key, value in obj.items():
                 if key == "$ref" and isinstance(value, str):
                     # External ref if it doesn't start with # or contains file references
-                    if not value.startswith("#") or ".yaml" in value or ".json" in value:
+                    if (
+                        not value.startswith("#")
+                        or ".yaml" in value
+                        or ".json" in value
+                    ):
                         return False
                 elif not check_refs(value):
                     return False
@@ -229,7 +235,7 @@ def _has_only_internal_refs(self):
                 if not check_refs(item):
                     return False
         return True
-    
+
     return check_refs(self._raw_spec)
 
     @classmethod

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,7 +203,6 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
-
 def clone(self):
     # Check if spec contains only internal refs (starting with #)
     # For external refs, we need the processed spec to maintain resolved content
@@ -211,7 +210,6 @@ def clone(self):
         return type(self)(copy.deepcopy(self._raw_spec))
     else:
         return type(self)(copy.deepcopy(self._spec))
-
 
 def _has_only_internal_refs(self):
     """Check if all $ref entries point to internal references only (starting with #)"""

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,8 +203,34 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
-    def clone(self):
+def clone(self):
+    # Check if spec contains only internal refs (starting with #)
+    # For external refs, we need the processed spec to maintain resolved content
+    if self._has_only_internal_refs():
         return type(self)(copy.deepcopy(self._raw_spec))
+    else:
+        return type(self)(copy.deepcopy(self._spec))
+
+def _has_only_internal_refs(self):
+    """Check if all $ref entries point to internal references only (starting with #)"""
+    import re
+    
+    def check_refs(obj):
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key == "$ref" and isinstance(value, str):
+                    # External ref if it doesn't start with # or contains file references
+                    if not value.startswith("#") or ".yaml" in value or ".json" in value:
+                        return False
+                elif not check_refs(value):
+                    return False
+        elif isinstance(obj, (list, tuple)):
+            for item in obj:
+                if not check_refs(item):
+                    return False
+        return True
+    
+    return check_refs(self._raw_spec)
 
     @classmethod
     def load(cls, spec, *, arguments=None):

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,6 +203,7 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
+
 def clone(self):
     # Check if spec contains only internal refs (starting with #)
     # For external refs, we need the processed spec to maintain resolved content
@@ -210,6 +211,7 @@ def clone(self):
         return type(self)(copy.deepcopy(self._raw_spec))
     else:
         return type(self)(copy.deepcopy(self._spec))
+
 
 def _has_only_internal_refs(self):
     """Check if all $ref entries point to internal references only (starting with #)"""

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,7 +203,6 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
-
     def clone(self):
         # Check if spec contains only internal refs (starting with #)
         # For external refs, we need the processed spec to maintain resolved content
@@ -211,7 +210,6 @@ class Specification(Mapping):
             return type(self)(copy.deepcopy(self._raw_spec))
         else:
             return type(self)(copy.deepcopy(self._spec))
-
 
     def _has_only_internal_refs(self):
         """Check if all $ref entries point to internal references only (starting with #)"""

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -203,7 +203,6 @@ class Specification(Mapping):
             return Swagger2Specification(spec, base_uri=base_uri)
         return OpenAPISpecification(spec, base_uri=base_uri)
 
-
 def clone(self):
     # Check if spec contains only internal refs (starting with #)
     # For external refs, we need the processed spec to maintain resolved content
@@ -212,11 +211,8 @@ def clone(self):
     else:
         return type(self)(copy.deepcopy(self._spec))
 
-
 def _has_only_internal_refs(self):
     """Check if all $ref entries point to internal references only (starting with #)"""
-    import re
-
     def check_refs(obj):
         if isinstance(obj, dict):
             for key, value in obj.items():
@@ -235,7 +231,6 @@ def _has_only_internal_refs(self):
                 if not check_refs(item):
                     return False
         return True
-
     return check_refs(self._raw_spec)
 
     @classmethod

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -204,7 +204,7 @@ class Specification(Mapping):
         return OpenAPISpecification(spec, base_uri=base_uri)
 
     def clone(self):
-        return type(self)(copy.deepcopy(self._spec))
+        return type(self)(copy.deepcopy(self._raw_spec))
 
     @classmethod
     def load(cls, spec, *, arguments=None):

--- a/tests/test_clone_external_refs.py
+++ b/tests/test_clone_external_refs.py
@@ -1,4 +1,5 @@
 import pathlib
+
 import pytest
 from connexion.spec import Specification
 

--- a/tests/test_clone_external_refs.py
+++ b/tests/test_clone_external_refs.py
@@ -1,0 +1,36 @@
+import pathlib
+import pytest
+from connexion.spec import Specification
+
+TEST_FOLDER = pathlib.Path(__file__).parent
+
+
+def test_clone_with_external_refs():
+    """Test that clone() with external refs uses _spec instead of _raw_spec"""
+
+    # Load a spec that has external references
+    relative_refs_path = TEST_FOLDER / "fixtures/relative_refs/openapi.yaml"
+
+    # Load the specification
+    spec = Specification.load(relative_refs_path)
+
+    # Verify it has external refs (should return False for _has_only_internal_refs)
+    has_only_internal = spec._has_only_internal_refs()
+
+    # Call clone() - this should work regardless of internal/external refs
+    cloned_spec = spec.clone()
+
+    # Verify the clone is a valid specification
+    assert cloned_spec is not None
+    assert hasattr(cloned_spec, "_spec")
+    assert hasattr(cloned_spec, "_raw_spec")
+
+    # The cloned spec should have the same structure
+    assert cloned_spec.version == spec.version
+
+    # For specs with external refs, we expect _has_only_internal_refs to be False
+    # (though this depends on whether the refs get resolved during loading)
+    print(f"Original spec has only internal refs: {has_only_internal}")
+    print(
+        f"Cloned spec has only internal refs: {cloned_spec._has_only_internal_refs()}"
+    )


### PR DESCRIPTION
## Problem
When Swagger UI accesses `/docs/` endpoint, it calls `with_base_path()` which triggers `clone()`. The current implementation uses `copy.deepcopy(self._spec)` (processed spec) instead of the original raw specification, causing validation failures that don't occur during app startup.

## Root Cause
The `clone()` method at line 207 creates a new instance from `self._spec` (already processed and resolved) rather than `self._raw_spec` (original). The `deepcopy` operation can corrupt internal references and circular dependencies in the processed spec.

## Fix
```python
# Before
def clone(self):
    return type(self)(copy.deepcopy(self._spec))

# After  
def clone(self):
    return type(self)(copy.deepcopy(self._raw_spec))
```

Fixes #2078