### PR TITLE
(v2) Extend pipeline and tox.ini to run tests on Python 3.13

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
@@ -76,7 +76,7 @@ mock = ["jsf"]
 
 [tool.poetry.group.tests.dependencies]
 pre-commit = "~2.21.0"
-pytest = "7.2.1"
+pytest = "8.4.2"
 pytest-asyncio = "~0.18.3"
 pytest-cov = "~2.12.1"
 pytest-aiohttp="^1.0.5"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ extend-ignore=E203,RST303
 [tox]
 isolated_build = True
 envlist =
-    {py39,py310,py311,py312}-pypi
+    {py39,py310,py311,py312,py313}-pypi
     pre-commit
     # min test modifies pyproject.toml so run it last
     py39-min
@@ -20,6 +20,7 @@ python =
     3.10: py310-pypi
     3.11: py311-pypi,pre-commit
     3.12: py312-pypi
+    3.13: py313-pypi
 
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
@@ -31,7 +32,7 @@ allowlist_externals=
 commands=
     # sed in-place flag works on Linux and Mac, writes a .bak file
     min: sed -i.bak -E 's/"(\^|~|>=)([ 0-9])/"==\2/' pyproject.toml
-    poetry lock
+    poetry lock --regenerate
     poetry install --all-extras --with tests
     poetry show
     poetry run python -m pytest tests --cov connexion --cov-report term-missing


### PR DESCRIPTION
Extend poetry invocation in tox.ini to use --regenerate option
Drop lingering project classifier for Python 3.8