### PR TITLE
Fix spec clone method and usage of raw vs resolved spec

### DIFF
--- a/connexion/middleware/swagger_ui.py
+++ b/connexion/middleware/swagger_ui.py
@@ -70,7 +70,7 @@ class SwaggerUIAPI(AbstractSpecAPI):
         This is needed when behind a path-altering reverse proxy.
         """
         base_path = self._base_path_for_prefix(request)
-        return self.specification.with_base_path(base_path).raw
+        return self.specification.with_base_path(base_path).spec
 
     def add_openapi_json(self):
         """

--- a/connexion/spec.py
+++ b/connexion/spec.py
@@ -81,6 +81,7 @@ class Specification(Mapping):
         self._set_defaults(raw_spec)
         self._validate_spec(raw_spec)
         self._spec = resolve_refs(raw_spec, base_uri=base_uri)
+        self._base_uri = base_uri
 
     @classmethod
     @abc.abstractmethod
@@ -106,6 +107,10 @@ class Specification(Mapping):
     @property
     def raw(self):
         return self._raw_spec
+
+    @property
+    def spec(self):
+        return self._spec
 
     @property
     def version(self):
@@ -204,7 +209,7 @@ class Specification(Mapping):
         return OpenAPISpecification(spec, base_uri=base_uri)
 
     def clone(self):
-        return type(self)(copy.deepcopy(self._spec))
+        return type(self)(copy.deepcopy(self._raw_spec), base_uri=self._base_uri)
 
     @classmethod
     def load(cls, spec, *, arguments=None):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from connexion import FlaskApi
 from connexion.exceptions import InvalidSpecification, ResolverError
+from connexion.jsonifier import Jsonifier
 from connexion.spec import Specification, canonical_base_path
 from yaml import YAMLError
 
@@ -200,7 +201,11 @@ def test_validation_error_on_completely_invalid_swagger_spec():
 def test_relative_refs(relative_refs, spec):
     spec_path = relative_refs / spec
     specification = Specification.load(spec_path)
-    assert "$ref" not in specification.raw
+
+    jsonifier = Jsonifier()
+
+    assert "$ref" in jsonifier.dumps(specification.raw)
+    assert "$ref" not in jsonifier.dumps(specification.spec)
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,13 +199,18 @@ def test_validation_error_on_completely_invalid_swagger_spec():
 
 
 def test_relative_refs(relative_refs, spec):
+    jsonifier = Jsonifier()
+
     spec_path = relative_refs / spec
     specification = Specification.load(spec_path)
 
-    jsonifier = Jsonifier()
-
     assert "$ref" in jsonifier.dumps(specification.raw)
     assert "$ref" not in jsonifier.dumps(specification.spec)
+
+    cloned_specification = specification.clone()
+
+    assert "$ref" in jsonifier.dumps(cloned_specification.raw)
+    assert "$ref" not in jsonifier.dumps(cloned_specification.spec)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes an issue introduced in #2002, and the original issue #2002 was trying to address.

The original issue was that a cloned spec did not have properly resolved references. #2002 fixed this incorrectly by cloning the resolved spec, while the `Spec` initializer expects a raw spec.

This PR fixes this by cloning the raw spec, and passing the `base_uri` required to resolve it along to the initializer of the new `Spec` instance.

The swagger ui was also updated to use the resolved spec instead of the raw spec.

Supersedes:
#1889
#2080

Fixes:
#1890
#1909
#2028 
#2029
