### PR TITLE
Restore `tests` argument to poetry invocation of pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,6 @@ python =
     3.13: py313-pypi
     3.14: py314-pypi
 
-[pytest]
-testpaths = tests
-
 [testenv]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
 deps=
@@ -49,7 +46,7 @@ commands=
     poetry lock
     poetry install --all-extras --with tests
     poetry show
-    poetry run python -m pytest --cov connexion --cov-report term-missing {posargs}
+    poetry run python -m pytest tests --cov connexion --cov-report term-missing {posargs}
     min: mv -f pyproject.toml.bak pyproject.toml
 
 [testenv:pre-commit]


### PR DESCRIPTION
Drop ineffective options section "[pytest]"
