### PR TITLE
(v2) Fix build of OpenAPI Console UI URL if servers/url is empty or "/"

### DIFF
--- a/connexion/apis/flask_api.py
+++ b/connexion/apis/flask_api.py
@@ -323,7 +323,7 @@ class InternalHandlers:
         :return:
         """
         openapi_json_route_name = "{blueprint}.{prefix}_openapi_json"
-        escaped = flask_utils.flaskify_endpoint(self.base_path)
+        escaped = flask_utils.flaskify_endpoint(self.base_path) or "/"
         openapi_json_route_name = openapi_json_route_name.format(
             blueprint=escaped, prefix=escaped
         )

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -98,6 +98,16 @@ def test_swagger_ui(simple_api_spec_dir, spec):
         assert b"swagger-ui-config.json" not in swagger_ui.data
 
 
+@pytest.mark.parametrize("spec", ["basepath-slash.yaml", "servers-url-slash.yaml"])
+def test_swagger_ui_for_basepath_slash(simple_api_spec_dir, spec):
+    """Verify the Swagger UI is returned when spec has trivial base path."""
+    app = App(__name__, port=5001, specification_dir=simple_api_spec_dir, debug=True)
+    app.add_api(spec)
+    app_client = app.app.test_client()
+    swagger_ui = app_client.get("/ui/")  # type: flask.Response
+    assert swagger_ui.status_code == 200
+
+
 @pytest.mark.parametrize("spec", SPECS)
 def test_swagger_ui_with_config(simple_api_spec_dir, spec):
     swagger_ui_config = {"displayOperationId": True}

--- a/tests/fixtures/simple/servers-url-slash.yaml
+++ b/tests/fixtures/simple/servers-url-slash.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: "Test servers/url == /"
+  version: '1.0'
+
+servers:
+  - url: /
+
+paths:
+  '/greeting/{name}':
+    post:
+      summary: Generate greeting
+      description: Generates a greeting message.
+      operationId: fakeapi.hello.post_greeting
+      responses:
+        '200':
+          description: greeting response
+          content:
+            'application/json':
+              schema:
+                type: object
+      parameters:
+        - name: name
+          in: path
+          description: Name of the person to greet.
+          required: true
+          schema:
+            type: string

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,10 @@ def test_api_base_path_slash():
     assert api.blueprint.name == "/"
     assert api.blueprint.url_prefix == ""
 
+    api2 = FlaskApi(TEST_FOLDER / "fixtures/simple/servers-url-slash.yaml")
+    assert api2.blueprint.name == "/"
+    assert api2.blueprint.url_prefix == ""
+
 
 def test_template():
     api1 = FlaskApi(


### PR DESCRIPTION
Fixes #2093

Changes proposed in this pull request:
- Use "/" if the escaped app base path is the empty string, to adjust for
      new behavior of Flask and/or Werkzeug, which raises this error if the
      swagger.yaml file has no servers/url entry or servers/url with value "/":
        
      werkzeug.routing.exceptions.BuildError: Could not build url for endpoint '/._openapi_json'.
    
- Add new test case to check blueprint and url prefix of open API specification
      with servers/url value "/"
    
- Add new test case to confirm Swagger UI is returned when the specification
      (either OpenAPI or Swagger) has a trivial base path
