### PR TITLE
Bump minimum version of httpx to 0.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ connexion = 'connexion.cli:main'
 [tool.poetry.dependencies]
 python = '^3.9'
 asgiref = ">= 3.4"
-httpx = ">= 0.23"
+httpx = ">= 0.24"
 inflection = ">= 0.3.1"
 jsonschema = ">=4.17.3"
 Jinja2 = ">= 3.0.0"


### PR DESCRIPTION
Make tests work in Python 3.13 by avoiding `httpx` version 0.23  import of package `cgi`

Changes proposed in this pull request:
 - Change pyproject.toml to require `httpx` at minimum version 0.24, which does not use `cgi`