### PR TITLE
Regenerate poetry lock file for each tox test environment run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ allowlist_externals=
 commands=
     # sed in-place flag works on Linux and Mac, writes a .bak file
     min: sed -i.bak -E 's/"(\^|~|>=)([ 0-9])/"==\2/' pyproject.toml
-    poetry lock
+    poetry lock --regenerate
     poetry install --all-extras --with tests
     poetry show
     poetry run python -m pytest tests --cov connexion --cov-report term-missing {posargs}


### PR DESCRIPTION
Extend poetry invocation in `tox.ini` to use `--regenerate` option
This avoids reusing old versions of packages in Python 3.13 and 3.14
