### PR TITLE
(v2) Migrate to importlib.util.find_spec for Python 3.14 compatibility

### DIFF
--- a/connexion/apps/aiohttp_app.py
+++ b/connexion/apps/aiohttp_app.py
@@ -2,9 +2,9 @@
 This module defines an AioHttpApp, a Connexion application to wrap an AioHttp application.
 """
 
+import importlib.util
 import logging
 import pathlib
-import pkgutil
 import sys
 
 from aiohttp import web
@@ -30,11 +30,11 @@ class AioHttpApp(AbstractApp):
         if mod is not None and hasattr(mod, "__file__"):
             return pathlib.Path(mod.__file__).resolve().parent
 
-        loader = pkgutil.get_loader(self.import_name)
+        spec = importlib.util.find_spec(self.import_name)
         filepath = None
 
-        if hasattr(loader, "get_filename"):
-            filepath = loader.get_filename(self.import_name)
+        if hasattr(spec, "loader") and hasattr(spec.loader, "get_filename"):
+            filepath = spec.loader.get_filename(self.import_name)
 
         if filepath is None:
             raise RuntimeError(f"Invalid import name '{self.import_name}'")


### PR DESCRIPTION
Migrate `aiohttp_app.py` away from `pkgutil.get_loader()` which
was deprecated in Python 3.12 and removed in Python 3.14.
