### PR TITLE
Now will distinguish between status codes the expected inferred type

### DIFF
--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -27,7 +27,7 @@ class BaseResponseDecorator:
 
     def build_framework_response(self, handler_response):
         data, status_code, headers = self._unpack_handler_response(handler_response)
-        content_type = self._infer_content_type(data, headers)
+        content_type = self._infer_content_type(data, status_code, headers)
         if not self.framework.is_framework_response(data):
             data = self._serialize_data(data, content_type=content_type)
             status_code = status_code or self._infer_status_code(data)
@@ -37,7 +37,7 @@ class BaseResponseDecorator:
         )
 
     @staticmethod
-    def _infer_content_type(data: t.Any, headers: dict) -> t.Optional[str]:
+    def _infer_content_type(data: t.Any, status_code: int, headers: dict) -> t.Optional[str]:
         """Infer the response content type from the returned data, headers and operation spec.
 
         :param data: Response data
@@ -50,7 +50,7 @@ class BaseResponseDecorator:
         content_type = utils.extract_content_type(headers)
 
         # TODO: don't default
-        produces = list(set(operation.produces))
+        produces = list(set(operation.responses.get(str(status_code), {}).get("content", {}).keys()))
         if data is not None and not produces:
             produces = ["application/json"]
 

--- a/connexion/decorators/response.py
+++ b/connexion/decorators/response.py
@@ -37,7 +37,9 @@ class BaseResponseDecorator:
         )
 
     @staticmethod
-    def _infer_content_type(data: t.Any, status_code: int, headers: dict) -> t.Optional[str]:
+    def _infer_content_type(
+        data: t.Any, status_code: int, headers: dict
+    ) -> t.Optional[str]:
         """Infer the response content type from the returned data, headers and operation spec.
 
         :param data: Response data
@@ -50,7 +52,9 @@ class BaseResponseDecorator:
         content_type = utils.extract_content_type(headers)
 
         # TODO: don't default
-        produces = list(set(operation.responses.get(str(status_code), {}).get("content", {}).keys()))
+        produces = list(
+            set(operation.responses.get(str(status_code), {}).get("content", {}).keys())
+        )
         if data is not None and not produces:
             produces = ["application/json"]
 

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -172,6 +172,35 @@ Responses defined in your OpenAPI spec:
   because of backward-compatibility, and can be circumvented easily by defining a response
   content type in your OpenAPI specification.
 
+Status-Code-Specific Content-Type Inference
+````````````````````````````````````````````
+
+Connexion can infer different content types based on the specific HTTP status code being returned.
+This allows you to define APIs where different status codes return different content types.
+
+For example, you can define an API where successful responses return JSON, but error responses
+return plain text:
+
+.. code-block:: yaml
+
+    responses:
+      '200':
+        description: Success response
+        content:
+          application/json:
+            schema:
+              type: object
+      '400':
+        description: Error response
+        content:
+          text/plain:
+            schema:
+              type: string
+
+With this specification:
+- A 200 response will automatically use ``application/json`` content-type
+- A 400 response will automatically use ``text/plain`` content-type
+
 Skipping response serialization
 -------------------------------
 

--- a/tests/fakeapi/hello/__init__.py
+++ b/tests/fakeapi/hello/__init__.py
@@ -5,7 +5,9 @@ from http import HTTPStatus
 
 import flask
 from connexion import NoContent, ProblemException, context, request
+from connexion.context import operation
 from connexion.exceptions import OAuthProblem
+from connexion.operations.openapi import OpenAPIOperation
 from flask import redirect, send_file
 from starlette.responses import FileResponse, RedirectResponse
 
@@ -739,6 +741,21 @@ def get_streaming_response():
     except RuntimeError:
         # Not in Flask context
         return FileResponse(__file__)
+
+
+def status_specific_content(body):
+    if body.get("success", True):
+        return {"message": "Success! This should be application/json"}, 200
+    else:
+        if isinstance(operation, OpenAPIOperation):
+            return (
+                "Error! This should be text/plain in OpenAPI 3.0, JSON in Swagger 2.0",
+                400,
+            )
+        else:
+            return {
+                "error": "Error! This should be text/plain in OpenAPI 3.0, JSON in Swagger 2.0"
+            }, 400
 
 
 async def async_route():

--- a/tests/fixtures/simple/openapi.yaml
+++ b/tests/fixtures/simple/openapi.yaml
@@ -1310,6 +1310,35 @@ paths:
       responses:
         '200':
           description: Echo the validated request.
+  '/status-specific-content':
+    post:
+      summary: Returns different content types based on status code
+      operationId: fakeapi.hello.status_specific_content
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                success:
+                  type: boolean
+      responses:
+        '200':
+          description: Success response with JSON content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: Error response with plain text content
+          content:
+            text/plain:
+              schema:
+                type: string
   /async-route:
     get:
       operationId: fakeapi.hello.async_route

--- a/tests/fixtures/simple/swagger.yaml
+++ b/tests/fixtures/simple/swagger.yaml
@@ -1122,6 +1122,39 @@ paths:
           schema:
             type: file
 
+  /status-specific-content:
+    post:
+      summary: In Swagger 2.0, falls back to operation-level produces
+      operationId: fakeapi.hello.status_specific_content
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+      responses:
+        '200':
+          description: Success response with JSON content
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        '400':
+          description: Error response (JSON object in Swagger 2.0)
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+
   /async-route:
     get:
       operationId: fakeapi.hello.async_route


### PR DESCRIPTION
Fixes https://github.com/spec-first/connexion/issues/1956 and https://github.com/spec-first/connexion/issues/1850 .
(this is a duplicate of PR https://github.com/spec-first/connexion/pull/1957 by [carloscbl](https://github.com/carloscbl). Test failed in original PR)

> The test outputs that showed a failure have expired. Please rebase etc. and push, then hopefully the Github workflow will run again here. Thanks.

Changes proposed in this pull request:


 - Now instead merging 2 different responses as available options, will check for the status code the available options, after that if you still have multiple content types it will raise the error, and users should specify in headers the correct one

