### PR TITLE
feat: add routing hook and scope["route"] for observability instrumentation

### DIFF
--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -113,7 +113,8 @@ class RoutingOperation:
                 except Exception:
                     # Don't let hook errors break request processing
                     logger.debug(
-                        "Routing hook error for %s (ignored)", full_route_path,
+                        "Routing hook error for %s (ignored)",
+                        full_route_path,
                         exc_info=True,
                     )
 

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -1,5 +1,7 @@
+import logging
 import typing as t
 from contextvars import ContextVar
+from types import SimpleNamespace
 
 import starlette.convertors
 from starlette.routing import Router
@@ -15,17 +17,61 @@ from connexion.operations import AbstractOperation
 from connexion.resolver import Resolver
 from connexion.spec import Specification
 
+logger = logging.getLogger(__name__)
+
 _scope: ContextVar[dict] = ContextVar("SCOPE")
+
+# Type for route resolution callbacks
+# Callback receives: (route_path, operation_id, scope)
+RouteResolvedCallback = t.Callable[[str, t.Optional[str], Scope], None]
 
 
 class RoutingOperation:
-    def __init__(self, operation_id: t.Optional[str], next_app: ASGIApp) -> None:
+    """Represents a routed operation that attaches routing context to the ASGI scope."""
+
+    # Class-level list of callbacks invoked when a route is resolved.
+    # Use on_route_resolved() to register callbacks.
+    _route_callbacks: t.ClassVar[t.List[RouteResolvedCallback]] = []
+
+    def __init__(
+        self,
+        operation_id: t.Optional[str],
+        next_app: ASGIApp,
+        path: t.Optional[str] = None,
+    ) -> None:
         self.operation_id = operation_id
         self.next_app = next_app
+        self.path = path
 
     @classmethod
     def from_operation(cls, operation: AbstractOperation, next_app: ASGIApp):
-        return cls(operation.operation_id, next_app)
+        return cls(operation.operation_id, next_app, path=operation.path)
+
+    @classmethod
+    def on_route_resolved(cls, callback: RouteResolvedCallback) -> None:
+        """Register a callback to be invoked when a route is resolved.
+
+        The callback receives (route_path, operation_id, scope) and can be used
+        to integrate with observability tools like OpenTelemetry without adding
+        direct dependencies to Connexion.
+
+        Example:
+            from connexion.middleware.routing import RoutingOperation
+            from opentelemetry import trace
+
+            def update_otel_span(route_path, operation_id, scope):
+                span = trace.get_current_span()
+                if span.is_recording():
+                    span.set_attribute("http.route", route_path)
+
+            RoutingOperation.on_route_resolved(update_otel_span)
+        """
+        cls._route_callbacks.append(callback)
+
+    @classmethod
+    def clear_route_callbacks(cls) -> None:
+        """Clear all registered route callbacks. Useful for testing."""
+        cls._route_callbacks.clear()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Attach operation to scope and pass it to the next app"""
@@ -45,6 +91,26 @@ class RoutingOperation:
         connexion_routing.update(
             {"api_base_path": api_base_path, "operation_id": self.operation_id}
         )
+
+        # Set scope["route"] for OpenTelemetry instrumentation compatibility.
+        # OTEL's ASGI middleware reads scope["route"].path to populate http.route
+        # attribute on spans and metrics, which is required for proper transaction
+        # naming in APM tools like NewRelic.
+        if self.path is not None:
+            full_route_path = f"{api_base_path}{self.path}"
+            original_scope["route"] = SimpleNamespace(path=full_route_path)
+
+            # Invoke registered callbacks for observability integration
+            for callback in self._route_callbacks:
+                try:
+                    callback(full_route_path, self.operation_id, original_scope)
+                except Exception:
+                    # Don't let callback errors break request processing
+                    logger.debug(
+                        "Route callback error for %s (ignored)", full_route_path,
+                        exc_info=True,
+                    )
+
         await self.next_app(original_scope, receive, send)
 
 

--- a/connexion/middleware/routing.py
+++ b/connexion/middleware/routing.py
@@ -21,17 +21,17 @@ logger = logging.getLogger(__name__)
 
 _scope: ContextVar[dict] = ContextVar("SCOPE")
 
-# Type for route resolution callbacks
+# Type for routing hook callbacks
 # Callback receives: (route_path, operation_id, scope)
-RouteResolvedCallback = t.Callable[[str, t.Optional[str], Scope], None]
+RoutingHook = t.Callable[[str, t.Optional[str], Scope], None]
 
 
 class RoutingOperation:
     """Represents a routed operation that attaches routing context to the ASGI scope."""
 
-    # Class-level list of callbacks invoked when a route is resolved.
-    # Use on_route_resolved() to register callbacks.
-    _route_callbacks: t.ClassVar[t.List[RouteResolvedCallback]] = []
+    # Class-level list of hooks invoked after routing resolution completes.
+    # Use after_routing_resolution() to register hooks.
+    _routing_hooks: t.ClassVar[t.List[RoutingHook]] = []
 
     def __init__(
         self,
@@ -48,30 +48,36 @@ class RoutingOperation:
         return cls(operation.operation_id, next_app, path=operation.path)
 
     @classmethod
-    def on_route_resolved(cls, callback: RouteResolvedCallback) -> None:
-        """Register a callback to be invoked when a route is resolved.
+    def after_routing_resolution(cls, hook: RoutingHook) -> None:
+        """Register a hook to run after routing resolution, before the operation is called.
 
-        The callback receives (route_path, operation_id, scope) and can be used
-        to integrate with observability tools like OpenTelemetry without adding
-        direct dependencies to Connexion.
+        This hook runs after Connexion determines which operation handles the request,
+        but before the operation function is invoked. Use cases include:
+
+        - Observability: Set span attributes, update trace names (OTEL, Datadog, etc.)
+        - Logging: Log route information with structured context
+        - Metrics: Record routing metrics or counters
+        - Auditing: Track which operations are called
+
+        The hook receives:
+            - route_path: The OpenAPI path template (e.g., "/v1/users/{user_id}")
+            - operation_id: The operation identifier from the OpenAPI spec
+            - scope: The ASGI scope dict with request information
 
         Example:
             from connexion.middleware.routing import RoutingOperation
-            from opentelemetry import trace
 
-            def update_otel_span(route_path, operation_id, scope):
-                span = trace.get_current_span()
-                if span.is_recording():
-                    span.set_attribute("http.route", route_path)
+            def log_route(route_path, operation_id, scope):
+                print(f"Routing {scope['method']} to {route_path}")
 
-            RoutingOperation.on_route_resolved(update_otel_span)
+            RoutingOperation.after_routing_resolution(log_route)
         """
-        cls._route_callbacks.append(callback)
+        cls._routing_hooks.append(hook)
 
     @classmethod
-    def clear_route_callbacks(cls) -> None:
-        """Clear all registered route callbacks. Useful for testing."""
-        cls._route_callbacks.clear()
+    def clear_routing_hooks(cls) -> None:
+        """Clear all registered routing hooks. Useful for testing."""
+        cls._routing_hooks.clear()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Attach operation to scope and pass it to the next app"""
@@ -100,14 +106,14 @@ class RoutingOperation:
             full_route_path = f"{api_base_path}{self.path}"
             original_scope["route"] = SimpleNamespace(path=full_route_path)
 
-            # Invoke registered callbacks for observability integration
-            for callback in self._route_callbacks:
+            # Invoke registered routing hooks
+            for hook in self._routing_hooks:
                 try:
-                    callback(full_route_path, self.operation_id, original_scope)
+                    hook(full_route_path, self.operation_id, original_scope)
                 except Exception:
-                    # Don't let callback errors break request processing
+                    # Don't let hook errors break request processing
                     logger.debug(
-                        "Route callback error for %s (ignored)", full_route_path,
+                        "Routing hook error for %s (ignored)", full_route_path,
                         exc_info=True,
                     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ exclude_lines = [
     "@t.overload",
 ]
 
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
 [[tool.mypy.overrides]]
 module = "referencing.jsonschema.*"
 follow_imports = "skip"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -200,7 +200,9 @@ class TestRoutingHooks:
             app_client.post("/v1.0/greeting/robbe")
 
             assert captured["route_path"] == "/v1.0/greeting/{name}"  # nosec B101
-            assert captured["operation_id"] == "fakeapi.hello.post_greeting"  # nosec B101
+            assert (
+                captured["operation_id"] == "fakeapi.hello.post_greeting"
+            )  # nosec B101
             assert captured["method"] == "POST"  # nosec B101
         finally:
             RoutingOperation.clear_routing_hooks()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -36,9 +36,44 @@ class TestMiddleware:
         await self.app(scope, receive, patched_send)
 
 
+class RoutePathMiddleware:
+    """Middleware to check if scope["route"].path is set for OTEL compatibility."""
+
+    __test__ = False
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        # Read scope["route"].path which OTEL ASGI middleware uses for http.route
+        route_obj = scope.get("route")
+        route_path = route_obj.path if route_obj else ""
+
+        async def patched_send(message):
+            if message["type"] != "http.response.start":
+                await send(message)
+                return
+
+            message.setdefault("headers", [])
+            headers = MutableHeaders(scope=message)
+            headers["x-route-path"] = route_path
+
+            await send(message)
+
+        await self.app(scope, receive, patched_send)
+
+
 @pytest.fixture(scope="session")
 def middleware_app(spec, app_class):
     middlewares = ConnexionMiddleware.default_middlewares + [TestMiddleware]
+    return build_app_from_fixture(
+        "simple", app_class=app_class, spec_file=spec, middlewares=middlewares
+    )
+
+
+@pytest.fixture(scope="session")
+def route_path_app(spec, app_class):
+    middlewares = ConnexionMiddleware.default_middlewares + [RoutePathMiddleware]
     return build_app_from_fixture(
         "simple", app_class=app_class, spec_file=spec, middlewares=middlewares
     )
@@ -52,6 +87,35 @@ def test_routing_middleware(middleware_app):
     assert (
         response.headers.get("operation_id") == "fakeapi.hello.post_greeting"
     ), response.status_code
+
+
+def test_route_path_for_otel(route_path_app):
+    """Test that scope['route'].path is set for OpenTelemetry instrumentation.
+
+    OTEL ASGI middleware reads scope["route"].path to populate the http.route
+    attribute on spans and metrics, which is required for proper transaction
+    naming in APM tools like NewRelic.
+    """
+    app_client = route_path_app.test_client()
+
+    response = app_client.post("/v1.0/greeting/robbe")
+
+    # The route path should be the OpenAPI path template with base path
+    assert (  # nosec B101
+        response.headers.get("x-route-path") == "/v1.0/greeting/{name}"
+    ), f"Expected /v1.0/greeting/{{name}}, got {response.headers.get('x-route-path')}"
+
+
+def test_route_path_with_multiple_params(route_path_app):
+    """Test route path with multiple path parameters."""
+    app_client = route_path_app.test_client()
+
+    response = app_client.post("/v1.0/greeting/robbe/extra/path")
+
+    # Path with remainder parameter
+    assert (  # nosec B101
+        response.headers.get("x-route-path") == "/v1.0/greeting/{name}/{remainder}"
+    ), f"Expected /v1.0/greeting/{{name}}/{{remainder}}, got {response.headers.get('x-route-path')}"
 
 
 def test_add_middleware(spec, app_class):
@@ -109,3 +173,81 @@ def test_add_wsgi_middleware(spec):
     app_client.post("/v1.0/greeting/robbe")
 
     mock.assert_called_once()
+
+
+class TestRouteResolvedCallback:
+    """Tests for the on_route_resolved callback mechanism."""
+
+    def test_callback_receives_route_info(self, spec, app_class):
+        """Test that registered callbacks receive route path and operation_id."""
+        from connexion.middleware.routing import RoutingOperation
+
+        # Clear any existing callbacks from other tests
+        RoutingOperation.clear_route_callbacks()
+
+        captured = {}
+
+        def capture_route_info(route_path, operation_id, scope):
+            captured["route_path"] = route_path
+            captured["operation_id"] = operation_id
+            captured["method"] = scope.get("method")
+
+        RoutingOperation.on_route_resolved(capture_route_info)
+
+        try:
+            app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
+            app_client = app.test_client()
+            app_client.post("/v1.0/greeting/robbe")
+
+            assert captured["route_path"] == "/v1.0/greeting/{name}"  # nosec B101
+            assert captured["operation_id"] == "fakeapi.hello.post_greeting"  # nosec B101
+            assert captured["method"] == "POST"  # nosec B101
+        finally:
+            RoutingOperation.clear_route_callbacks()
+
+    def test_multiple_callbacks(self, spec, app_class):
+        """Test that multiple callbacks are all invoked."""
+        from connexion.middleware.routing import RoutingOperation
+
+        RoutingOperation.clear_route_callbacks()
+
+        call_count = {"first": 0, "second": 0}
+
+        def first_callback(route_path, operation_id, scope):
+            call_count["first"] += 1
+
+        def second_callback(route_path, operation_id, scope):
+            call_count["second"] += 1
+
+        RoutingOperation.on_route_resolved(first_callback)
+        RoutingOperation.on_route_resolved(second_callback)
+
+        try:
+            app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
+            app_client = app.test_client()
+            app_client.post("/v1.0/greeting/robbe")
+
+            assert call_count["first"] == 1  # nosec B101
+            assert call_count["second"] == 1  # nosec B101
+        finally:
+            RoutingOperation.clear_route_callbacks()
+
+    def test_callback_error_does_not_break_request(self, spec, app_class):
+        """Test that callback errors don't break request processing."""
+        from connexion.middleware.routing import RoutingOperation
+
+        RoutingOperation.clear_route_callbacks()
+
+        def failing_callback(route_path, operation_id, scope):
+            raise RuntimeError("Intentional error")
+
+        RoutingOperation.on_route_resolved(failing_callback)
+
+        try:
+            app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
+            app_client = app.test_client()
+            # Request should still succeed despite callback error
+            response = app_client.post("/v1.0/greeting/robbe")
+            assert response.status_code == 200  # nosec B101
+        finally:
+            RoutingOperation.clear_route_callbacks()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -175,15 +175,15 @@ def test_add_wsgi_middleware(spec):
     mock.assert_called_once()
 
 
-class TestRouteResolvedCallback:
-    """Tests for the on_route_resolved callback mechanism."""
+class TestRoutingHooks:
+    """Tests for the after_routing_resolution hook mechanism."""
 
-    def test_callback_receives_route_info(self, spec, app_class):
-        """Test that registered callbacks receive route path and operation_id."""
+    def test_hook_receives_route_info(self, spec, app_class):
+        """Test that registered hooks receive route path and operation_id."""
         from connexion.middleware.routing import RoutingOperation
 
-        # Clear any existing callbacks from other tests
-        RoutingOperation.clear_route_callbacks()
+        # Clear any existing hooks from other tests
+        RoutingOperation.clear_routing_hooks()
 
         captured = {}
 
@@ -192,7 +192,7 @@ class TestRouteResolvedCallback:
             captured["operation_id"] = operation_id
             captured["method"] = scope.get("method")
 
-        RoutingOperation.on_route_resolved(capture_route_info)
+        RoutingOperation.after_routing_resolution(capture_route_info)
 
         try:
             app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
@@ -203,24 +203,24 @@ class TestRouteResolvedCallback:
             assert captured["operation_id"] == "fakeapi.hello.post_greeting"  # nosec B101
             assert captured["method"] == "POST"  # nosec B101
         finally:
-            RoutingOperation.clear_route_callbacks()
+            RoutingOperation.clear_routing_hooks()
 
-    def test_multiple_callbacks(self, spec, app_class):
-        """Test that multiple callbacks are all invoked."""
+    def test_multiple_hooks(self, spec, app_class):
+        """Test that multiple hooks are all invoked."""
         from connexion.middleware.routing import RoutingOperation
 
-        RoutingOperation.clear_route_callbacks()
+        RoutingOperation.clear_routing_hooks()
 
         call_count = {"first": 0, "second": 0}
 
-        def first_callback(route_path, operation_id, scope):
+        def first_hook(route_path, operation_id, scope):
             call_count["first"] += 1
 
-        def second_callback(route_path, operation_id, scope):
+        def second_hook(route_path, operation_id, scope):
             call_count["second"] += 1
 
-        RoutingOperation.on_route_resolved(first_callback)
-        RoutingOperation.on_route_resolved(second_callback)
+        RoutingOperation.after_routing_resolution(first_hook)
+        RoutingOperation.after_routing_resolution(second_hook)
 
         try:
             app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
@@ -230,24 +230,24 @@ class TestRouteResolvedCallback:
             assert call_count["first"] == 1  # nosec B101
             assert call_count["second"] == 1  # nosec B101
         finally:
-            RoutingOperation.clear_route_callbacks()
+            RoutingOperation.clear_routing_hooks()
 
-    def test_callback_error_does_not_break_request(self, spec, app_class):
-        """Test that callback errors don't break request processing."""
+    def test_hook_error_does_not_break_request(self, spec, app_class):
+        """Test that hook errors don't break request processing."""
         from connexion.middleware.routing import RoutingOperation
 
-        RoutingOperation.clear_route_callbacks()
+        RoutingOperation.clear_routing_hooks()
 
-        def failing_callback(route_path, operation_id, scope):
+        def failing_hook(route_path, operation_id, scope):
             raise RuntimeError("Intentional error")
 
-        RoutingOperation.on_route_resolved(failing_callback)
+        RoutingOperation.after_routing_resolution(failing_hook)
 
         try:
             app = build_app_from_fixture("simple", app_class=app_class, spec_file=spec)
             app_client = app.test_client()
-            # Request should still succeed despite callback error
+            # Request should still succeed despite hook error
             response = app_client.post("/v1.0/greeting/robbe")
             assert response.status_code == 200  # nosec B101
         finally:
-            RoutingOperation.clear_route_callbacks()
+            RoutingOperation.clear_routing_hooks()


### PR DESCRIPTION
## Summary

This PR adds two related features to improve observability instrumentation compatibility.

**Relates to #2036**

### 1. Set `scope["route"]` for OpenTelemetry/ASGI instrumentation

OpenTelemetry's ASGI middleware reads `scope["route"].path` to populate the `http.route` span attribute. Without this, APM tools like NewRelic show transaction names with actual path values (e.g., `/users/12345`) instead of templated routes (e.g., `/users/{user_id}`), making it impossible to aggregate metrics properly.

This change sets `scope["route"]` to a `SimpleNamespace(path=full_route_path)` after routing resolution, where `full_route_path` includes the API base path and the OpenAPI path template.

### 2. Add `after_routing_resolution` hook mechanism

Provides a general-purpose hook that runs after Connexion determines which operation handles a request, but before the operation is invoked. This enables:

- **Observability**: Set span attributes, update trace names (OTEL, Datadog, etc.)
- **Logging**: Log route information with structured context
- **Metrics**: Record routing metrics or counters
- **Auditing**: Track which operations are called

#### Usage

```python
from connexion.middleware.routing import RoutingOperation

def my_hook(route_path: str, operation_id: str | None, scope: dict) -> None:
    # route_path: "/v1/users/{user_id}" (OpenAPI template)
    # operation_id: "get_user" (from OpenAPI spec)
    # scope: ASGI scope dict
    print(f"Routing {scope['method']} to {route_path}")

RoutingOperation.after_routing_resolution(my_hook)
```

Hook errors are caught and logged at DEBUG level to avoid breaking request processing.

## Test Plan

- Added `RoutePathMiddleware` test to verify `scope["route"].path` is set correctly
- Added `TestRoutingHooks` class with tests for:
  - Hook receives correct route_path, operation_id, and scope
  - Multiple hooks are all invoked
  - Hook errors don't break request processing