### PR TITLE
fix(docs): update sphinxemoji to fix Python 3.12+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sphinx = "5.3.0"
 sphinx_copybutton = "0.5.2"
 sphinx_design = "0.4.1"
 sphinx-rtd-theme = "1.2.0"
-sphinxemoji = "0.2.0"
+sphinxemoji = "0.3.1"  # 0.3.x uses importlib.resources instead of deprecated pkg_resources
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sphinx = "5.3.0"
 sphinx_copybutton = "0.5.2"
 sphinx_design = "0.4.1"
 sphinx-rtd-theme = "1.2.0"
-sphinxemoji = "0.3.1"  # 0.3.x uses importlib.resources instead of deprecated pkg_resources
+sphinxemoji = "0.3.1"
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]


### PR DESCRIPTION
## Summary
- Update `sphinxemoji` from `0.2.0` to `0.3.1` in `pyproject.toml`
- `sphinxemoji 0.2.0` uses `pkg_resources` which was removed in Python 3.12, causing doc builds to fail
- `0.3.1` uses `importlib.resources` instead

Supersedes #2111 (which included unrelated changes).

## Test plan
- [ ] CI passes (doc build succeeds on Python 3.12+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)