### PR TITLE
feat(validators): clarify error when content-length is missing

### DIFF
--- a/connexion/validators/abstract.py
+++ b/connexion/validators/abstract.py
@@ -126,7 +126,9 @@ class AbstractRequestBodyValidator:
         if not int(headers.get("content-length", 0)):
             body = self._schema.get("default")
             if body is None and self._required:
-                raise BadRequestProblem("RequestBody is required")
+                raise BadRequestProblem(
+                    "RequestBody is empty or the Content-Length header is missing or zero"
+                )
             # The default body is encoded as a `receive` channel to mimic an incoming body
             receive, scope = self._insert_body(receive, body=body, scope=scope)
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -268,6 +268,7 @@ def test_required_body(simple_app):
         "/v1.0/test-required-body", headers={"content-type": "application/json"}
     )
     assert resp.status_code == 400
+    assert "Content-Length" in resp.json()["detail"]
 
     resp = app_client.post("/v1.0/test-required-body", json={"foo": "bar"})
     assert resp.status_code == 200


### PR DESCRIPTION
Fixes #2020.

Changes proposed in this pull request:
 - Replace the "RequestBody is required" 400 message with "RequestBody is empty or the Content-Length header is missing or zero", so callers can tell their client omitted Content-Length rather than actually sending an empty body.