### PR TITLE
Make FlaskApp WSGI worker count configurable (#1979)

### DIFF
--- a/connexion/apps/flask.py
+++ b/connexion/apps/flask.py
@@ -127,7 +127,13 @@ class FlaskApi(AbstractRoutingAPI):
 
 
 class FlaskASGIApp(SpecMiddleware):
-    def __init__(self, import_name, server_args: dict, **kwargs):
+    def __init__(
+        self,
+        import_name,
+        server_args: dict,
+        wsgi_workers: t.Optional[int] = None,
+        **kwargs,
+    ):
         self.app = flask.Flask(import_name, **server_args)
         self.app.json = flask_utils.FlaskJSONProvider(self.app)
         self.app.url_map.converters["float"] = flask_utils.NumberConverter
@@ -138,7 +144,13 @@ class FlaskASGIApp(SpecMiddleware):
         self.app.config["TRAP_BAD_REQUEST_ERRORS"] = True
         self.app.config["TRAP_HTTP_EXCEPTIONS"] = True
 
-        self.asgi_app = WSGIMiddleware(self.app.wsgi_app)
+        # When wsgi_workers is provided, forward it to a2wsgi's WSGIMiddleware
+        # so users can size the WSGI ThreadPoolExecutor. Otherwise we let
+        # a2wsgi pick its own default (currently 10).
+        wsgi_kwargs: t.Dict[str, t.Any] = {}
+        if wsgi_workers is not None:
+            wsgi_kwargs["workers"] = wsgi_workers
+        self.asgi_app = WSGIMiddleware(self.app.wsgi_app, **wsgi_kwargs)
 
     def add_api(self, specification, *, name: t.Optional[str] = None, **kwargs):
         api = FlaskApi(specification, **kwargs)
@@ -188,6 +200,7 @@ class FlaskApp(AbstractApp):
         validate_responses: t.Optional[bool] = None,
         validator_map: t.Optional[dict] = None,
         security_map: t.Optional[dict] = None,
+        wsgi_workers: t.Optional[int] = None,
     ):
         """
         :param import_name: The name of the package or module that this object belongs to. If you
@@ -223,8 +236,14 @@ class FlaskApp(AbstractApp):
             :obj:`validators.VALIDATOR_MAP`.
         :param security_map: A dictionary of security handlers to use. Defaults to
             :obj:`security.SECURITY_HANDLERS`
+        :param wsgi_workers: Number of WSGI worker threads used by the WSGI-to-ASGI bridge
+            (:class:`a2wsgi.WSGIMiddleware`) when serving the wrapped Flask app. When omitted,
+            ``a2wsgi``'s own default is used (currently 10). Raise this when your WSGI handlers
+            block on I/O and you observe contention on the WSGI thread pool.
         """
-        self._middleware_app = FlaskASGIApp(import_name, server_args or {})
+        self._middleware_app = FlaskASGIApp(
+            import_name, server_args or {}, wsgi_workers=wsgi_workers
+        )
 
         super().__init__(
             import_name,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -109,3 +109,22 @@ def test_add_wsgi_middleware(spec):
     app_client.post("/v1.0/greeting/robbe")
 
     mock.assert_called_once()
+
+
+def test_flask_wsgi_workers_default():
+    """When wsgi_workers is not set, FlaskApp falls back to a2wsgi's default (10)."""
+    app = FlaskApp(__name__)
+    # a2wsgi's WSGIMiddleware exposes the ThreadPoolExecutor via .executor;
+    # its _max_workers reflects the requested pool size.
+    assert app._middleware_app.asgi_app.executor._max_workers == 10
+
+
+def test_flask_wsgi_workers_configurable():
+    """FlaskApp(wsgi_workers=N) sizes the WSGI ThreadPoolExecutor to N.
+
+    Regression test for https://github.com/spec-first/connexion/issues/1979
+    where the WSGI worker count was hard-coded to a2wsgi's default of 10
+    and could only be changed by monkey-patching.
+    """
+    app = FlaskApp(__name__, wsgi_workers=42)
+    assert app._middleware_app.asgi_app.executor._max_workers == 42


### PR DESCRIPTION
## Summary

`FlaskApp` wraps Flask in `a2wsgi.WSGIMiddleware` to bridge WSGI to ASGI. `WSGIMiddleware` runs WSGI handlers on a `ThreadPoolExecutor` whose size defaults to 10, and Connexion did not surface a way to tune it. Apps with blocking WSGI handlers had to monkey-patch the executor (as the issue author asked for) to raise that cap.

This PR adds a `wsgi_workers` keyword to `FlaskApp` (and `FlaskASGIApp`) that forwards to `WSGIMiddleware(workers=...)`. Leaving it unset preserves the upstream default of 10, so existing apps see no behavior change.

Fixes #1979.

## Context

- `FlaskASGIApp.__init__` in [`connexion/apps/flask.py`](https://github.com/spec-first/connexion/blob/main/connexion/apps/flask.py) builds the bridge via `WSGIMiddleware(self.app.wsgi_app)` with no way to pass `workers`.
- `a2wsgi.WSGIMiddleware.__init__` accepts `workers: int = 10` and stores it on a `ThreadPoolExecutor` exposed as `self.executor`.
- Maintainer @RobbeSneyders welcomed a PR for this in [issue #1979](https://github.com/spec-first/connexion/issues/1979#issuecomment-2466475830) on 2024-11-09.

## Changes

- `connexion/apps/flask.py`
  - `FlaskASGIApp.__init__` now accepts `wsgi_workers: Optional[int] = None`. When provided, it is forwarded as `workers=` to `WSGIMiddleware`; when omitted, no override is sent so `a2wsgi`'s own default (currently 10) is preserved.
  - `FlaskApp.__init__` gains the matching `wsgi_workers` keyword and threads it through to `FlaskASGIApp`. Docstring describes the parameter and the rationale.
- `tests/test_middleware.py`
  - `test_flask_wsgi_workers_default` documents the unset path stays at `10`.
  - `test_flask_wsgi_workers_configurable` is the regression test: it constructs `FlaskApp(__name__, wsgi_workers=42)` and asserts `app._middleware_app.asgi_app.executor._max_workers == 42`. On `origin/main` this raises `TypeError: FlaskApp.__init__() got an unexpected keyword argument 'wsgi_workers'`.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/spec-first/connexion.git /tmp/connexion-repro && cd /tmp/connexion-repro
python3.11 -m venv .venv && source .venv/bin/activate
pip install -e ".[flask]" >/dev/null

# --- BEFORE: origin/main, expect TypeError ---
git checkout origin/main -- connexion/apps/flask.py
python -c "
from connexion import FlaskApp
try:
    app = FlaskApp(__name__, wsgi_workers=42)
    print('workers =', app._middleware_app.asgi_app.executor._max_workers)
except TypeError as e:
    print('TypeError:', e)
"
# Expected: TypeError: FlaskApp.__init__() got an unexpected keyword argument 'wsgi_workers'

# --- AFTER: this branch, expect workers=42 ---
git fetch https://github.com/jbbqqf/connexion.git fix/1979-flaskapp-wsgi-workers
git checkout FETCH_HEAD -- connexion/apps/flask.py
python -c "
from connexion import FlaskApp
app = FlaskApp(__name__, wsgi_workers=42)
print('workers =', app._middleware_app.asgi_app.executor._max_workers)
"
# Expected: workers = 42
```

## What I ran locally

```
$ pytest tests/test_middleware.py -v
...
tests/test_middleware.py::test_add_wsgi_middleware[openapi.yaml] PASSED
tests/test_middleware.py::test_add_wsgi_middleware[swagger.yaml] PASSED
tests/test_middleware.py::test_flask_wsgi_workers_default PASSED
tests/test_middleware.py::test_flask_wsgi_workers_configurable PASSED
============================== 16 passed in 1.18s ==============================

$ pytest tests/
============================== 804 passed in 13.79s =============================
```

Also verified the regression test fails on `origin/main`:

```
$ git stash && python -c "from connexion import FlaskApp; FlaskApp(__name__, wsgi_workers=42)"
TypeError: FlaskApp.__init__() got an unexpected keyword argument 'wsgi_workers'
```

## Edge cases

| # | Scenario | Input | Expected | Verified by |
|---|---|---|---|---|
| 1 | Backward compat: existing call site without `wsgi_workers` | `FlaskApp(__name__)` | `_max_workers == 10` (a2wsgi default) | `test_flask_wsgi_workers_default` |
| 2 | New positional / kwarg path | `FlaskApp(__name__, wsgi_workers=42)` | `_max_workers == 42` | `test_flask_wsgi_workers_configurable` |
| 3 | Existing test suite still green | full `pytest tests/` | 804 passed | full suite run |
| 4 | `add_wsgi_middleware` still works (asgi_app composition unchanged) | `app.add_wsgi_middleware(M, mock_counter=mock)` | middleware called once per request | `test_add_wsgi_middleware` |

## Risk / blast radius

- The parameter is keyword-only and defaults to `None`, so no existing call site changes behavior. `WSGIMiddleware` is only invoked with `workers=...` when the user opts in.
- `FlaskASGIApp` already accepted `**kwargs` in its signature; the new `wsgi_workers` is consumed before reaching it, so no change to how subclassers pass extra args.
- No public API removed or renamed.

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against connexion's source and a2wsgi's `WSGIMiddleware` signature. The BEFORE/AFTER reproducer block above is the one I used during development; reviewers can paste it verbatim.*
