### PR TITLE
(v2) Pin black to version 26.3.1 in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 26.3.1
     hooks:
       - id: black
         name: black

--- a/connexion/apis/__init__.py
+++ b/connexion/apis/__init__.py
@@ -12,5 +12,4 @@ When the API is registered on the Connexion APP, the underlying framework bluepr
 on the framework app.
 """
 
-
 from .abstract import AbstractAPI  # NOQA

--- a/connexion/operations/abstract.py
+++ b/connexion/operations/abstract.py
@@ -27,7 +27,6 @@ VALIDATOR_MAP = {
 
 
 class AbstractOperation(SecureOperation, metaclass=abc.ABCMeta):
-
     """
     An API routes requests to an Operation by a (path, method) pair.
     The operation uses a resolver to resolve its handler function.

--- a/connexion/operations/compat.py
+++ b/connexion/operations/compat.py
@@ -1,5 +1,6 @@
 """
 This is a dummy module for backwards compatibility with < v2.0.
 """
+
 from .secure import *  # noqa
 from .swagger2 import *  # noqa

--- a/connexion/operations/openapi.py
+++ b/connexion/operations/openapi.py
@@ -16,7 +16,6 @@ logger = logging.getLogger("connexion.operations.openapi3")
 
 
 class OpenAPIOperation(AbstractOperation):
-
     """
     A single API operation on a path.
     """

--- a/connexion/operations/secure.py
+++ b/connexion/operations/secure.py
@@ -106,10 +106,10 @@ class SecureOperation:
                         logger.warning("... x-tokenInfoFunc missing", extra=vars(self))
                         break
 
-                    sec_req_funcs[
-                        scheme_name
-                    ] = self._api.security_handler_factory.verify_oauth(
-                        token_info_func, scope_validate_func, required_scopes
+                    sec_req_funcs[scheme_name] = (
+                        self._api.security_handler_factory.verify_oauth(
+                            token_info_func, scope_validate_func, required_scopes
+                        )
                     )
 
                 # Swagger 2.0
@@ -123,9 +123,9 @@ class SecureOperation:
                         logger.warning("... x-basicInfoFunc missing", extra=vars(self))
                         break
 
-                    sec_req_funcs[
-                        scheme_name
-                    ] = self._api.security_handler_factory.verify_basic(basic_info_func)
+                    sec_req_funcs[scheme_name] = (
+                        self._api.security_handler_factory.verify_basic(basic_info_func)
+                    )
 
                 # OpenAPI 3.0.0
                 elif security_scheme["type"] == "http":
@@ -142,10 +142,10 @@ class SecureOperation:
                             )
                             break
 
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self._api.security_handler_factory.verify_basic(
-                            basic_info_func
+                        sec_req_funcs[scheme_name] = (
+                            self._api.security_handler_factory.verify_basic(
+                                basic_info_func
+                            )
                         )
                     elif scheme == "bearer":
                         bearer_info_func = (
@@ -158,10 +158,10 @@ class SecureOperation:
                                 "... x-bearerInfoFunc missing", extra=vars(self)
                             )
                             break
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self._api.security_handler_factory.verify_bearer(
-                            bearer_info_func
+                        sec_req_funcs[scheme_name] = (
+                            self._api.security_handler_factory.verify_bearer(
+                                bearer_info_func
+                            )
                         )
                     else:
                         logger.warning(
@@ -183,10 +183,10 @@ class SecureOperation:
                                 "... x-bearerInfoFunc missing", extra=vars(self)
                             )
                             break
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self._api.security_handler_factory.verify_bearer(
-                            bearer_info_func
+                        sec_req_funcs[scheme_name] = (
+                            self._api.security_handler_factory.verify_bearer(
+                                bearer_info_func
+                            )
                         )
                     else:
                         apikey_info_func = (
@@ -200,12 +200,12 @@ class SecureOperation:
                             )
                             break
 
-                        sec_req_funcs[
-                            scheme_name
-                        ] = self._api.security_handler_factory.verify_api_key(
-                            apikey_info_func,
-                            security_scheme["in"],
-                            security_scheme["name"],
+                        sec_req_funcs[scheme_name] = (
+                            self._api.security_handler_factory.verify_api_key(
+                                apikey_info_func,
+                                security_scheme["in"],
+                                security_scheme["name"],
+                            )
                         )
 
                 else:

--- a/connexion/operations/swagger2.py
+++ b/connexion/operations/swagger2.py
@@ -15,7 +15,6 @@ logger = logging.getLogger("connexion.operations.swagger2")
 
 
 class Swagger2Operation(AbstractOperation):
-
     """
     Exposes a Swagger 2.0 operation under the AbstractOperation interface.
     The primary purpose of this class is to provide the `function()` method

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -171,11 +171,9 @@ class AbstractSecurityHandlerFactory(abc.ABC):
         logger.debug("... Token scopes: %s", token_scopes)
         if not required_scopes <= token_scopes:
             logger.info(
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                         ... Token scopes (%s) do not match the scopes necessary to call endpoint (%s).
-                         Aborting with 403."""
-                ).replace("\n", ""),
+                         Aborting with 403.""").replace("\n", ""),
                 token_scopes,
                 required_scopes,
             )

--- a/examples/openapi3/jwt/app.py
+++ b/examples/openapi3/jwt/app.py
@@ -38,9 +38,7 @@ def get_secret(user, token_info) -> str:
     return """
     You are user_id {user} and the secret is 'wbevuec'.
     Decoded token claims: {token_info}.
-    """.format(
-        user=user, token_info=token_info
-    )
+    """.format(user=user, token_info=token_info)
 
 
 def _current_timestamp() -> int:

--- a/examples/openapi3/reverseproxy/app.py
+++ b/examples/openapi3/reverseproxy/app.py
@@ -7,6 +7,7 @@ You'll want to make sure these headers are coming from your proxy, and not
 directly from users on the web!
 
 """
+
 import logging
 
 import connexion


### PR DESCRIPTION
Fixes these failures at pre-commit.ci when using black 22.3.0 in Python 3.14:

    RuntimeError: There is no current event loop in thread 'MainThread'.