### PR TITLE
Honor nullable on deepObject property values

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -371,6 +371,8 @@ def coerce_type(param, value, parameter_type, parameter_name=None):
 
             def cast_leaves(d, schema):
                 if type(d) is not dict:
+                    if is_nullable(schema) and is_null(d):
+                        return None
                     try:
                         return make_type(d, schema["type"])
                     except (ValueError, TypeError):

--- a/tests/decorators/test_uri_parsing.py
+++ b/tests/decorators/test_uri_parsing.py
@@ -319,3 +319,28 @@ def test_parameter_coercion():
 
     parsed_param = uri_parser.resolve_query(QueryParams(f"a1={quote_plus('1,2,3,4')}"))
     assert parsed_param == {"a1": [4]}  # Swagger2URIParser
+
+
+
+def test_deep_object_nullable_property():
+    """filter[id]=null should coerce to None when the property is nullable (#1503)."""
+    parameters = [
+        {
+            "name": "filter",
+            "in": "query",
+            "style": "deepObject",
+            "explode": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "id": {"type": "integer", "nullable": True},
+                    "name": {"type": "string"},
+                },
+            },
+        }
+    ]
+    parser = OpenAPIURIParser(parameters, {})
+    query = MultiDict([("filter[id]", "null"), ("filter[name]", "Ada")])
+    parsed = parser.resolve_query(query.to_dict(flat=False))
+    assert parsed == {"filter": {"id": None, "name": "Ada"}}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,3 +143,48 @@ def test_sort_apis_by_basepath():
         api4,
         api1,
     ]
+
+
+def test_coerce_type_nullable_object_property():
+    """Nullable deepObject properties should become None, not the string 'null'."""
+    param = {
+        "name": "filter",
+        "in": "query",
+        "style": "deepObject",
+        "explode": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer", "nullable": True},
+                "name": {"type": "string"},
+            },
+        },
+    }
+    assert utils.coerce_type(param, {"id": "null", "name": "Ada"}, "query") == {
+        "id": None,
+        "name": "Ada",
+    }
+    assert utils.coerce_type(param, {"id": "None"}, "query") == {"id": None}
+
+
+def test_coerce_type_x_nullable_object_property():
+    param = {
+        "name": "filter",
+        "schema": {
+            "type": "object",
+            "properties": {"id": {"type": "integer", "x-nullable": True}},
+        },
+    }
+    assert utils.coerce_type(param, {"id": "null"}, "query") == {"id": None}
+
+
+def test_coerce_type_non_nullable_object_property_keeps_null_string():
+    param = {
+        "name": "filter",
+        "schema": {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+        },
+    }
+    # int("null") fails, so the original string is left for the validator to reject
+    assert utils.coerce_type(param, {"id": "null"}, "query") == {"id": "null"}


### PR DESCRIPTION
Fixes #1503

`coerce_type()` already turns a top-level nullable parameter whose value is `"null"` / `"None"` into `None`. Nested object properties — the ones produced by `style: deepObject` query params — skipped that check, so `filter[id]=null` stayed the string `"null"` and then failed integer/type validation.

Changes proposed in this pull request:

- In `cast_leaves()`, treat a nullable / `x-nullable` property whose value is null as `None` before type coercion
- Add unit tests for `nullable` and `x-nullable` object properties, plus a URI-parser regression for `filter[id]=null`

## Test plan
- [x] `tests/test_utils.py` coerce_type cases
- [x] `tests/decorators/test_uri_parsing.py::test_deep_object_nullable_property`
- [x] existing validation / utils / uri-parsing tests