### PR TITLE
fix: parse charset when Content-Type has whitespace after ';'

### DIFF
--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -330,10 +330,13 @@ def split_content_type(
     # Check for parameters
     if ";" in content_type:
         mime_type, parameters = content_type.split(";", maxsplit=1)
+        mime_type = mime_type.strip()
 
         # Find parameter describing the charset
         prefix = "charset="
         for parameter in parameters.split(";"):
+            # Parameters may be surrounded by optional whitespace (RFC 7231)
+            parameter = parameter.strip()
             if parameter.startswith(prefix):
                 encoding = parameter[len(prefix) :]
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,6 +74,25 @@ def test_is_json_mimetype():
     assert not utils.is_json_mimetype("text/html")
 
 
+def test_split_content_type():
+    # No parameters
+    assert utils.split_content_type("application/json") == ("application/json", None)
+    # charset directly after the separator
+    assert utils.split_content_type("application/json;charset=utf-8") == (
+        "application/json",
+        "utf-8",
+    )
+    # charset after optional whitespace, as allowed by RFC 7231
+    assert utils.split_content_type("application/json; charset=utf-8") == (
+        "application/json",
+        "utf-8",
+    )
+    # charset preceded by another parameter
+    assert utils.split_content_type(
+        "multipart/form-data; boundary=foo; charset=iso-8859-1"
+    ) == ("multipart/form-data", "iso-8859-1")
+
+
 def test_sort_routes():
     routes = ["/users/me", "/users/{username}"]
     expected = ["/users/me", "/users/{username}"]


### PR DESCRIPTION
Fixes # .

`split_content_type()` failed to pick up the charset when the Content-Type header has a space after the `;`, e.g. `application/json; charset=utf-8`. It matched parameters with `startswith("charset=")` on the raw semicolon-split parts, without trimming the optional whitespace that RFC 7231 allows. So the common spaced form returned `encoding=None`, and the request/response validators silently fell back to utf-8 and mis-decoded bodies sent in another charset.

Reproduction on current `main`:

```
'application/json;charset=utf-8'   -> ('application/json', 'utf-8')   # worked
'application/json; charset=utf-8'  -> ('application/json', None)      # bug (expected 'utf-8')
'text/html; charset=UTF-8'         -> ('text/html', None)             # bug
```

Changes proposed in this pull request:

 - Strip optional whitespace around the media type and each parameter in `split_content_type` before matching the charset parameter.
 - Add a regression test covering the no-parameter, unspaced-charset, spaced-charset, and charset-after-another-parameter cases.
