### PR TITLE
Fix relative schema file paths on Windows

### DIFF
--- a/connexion/json_schema.py
+++ b/connexion/json_schema.py
@@ -47,7 +47,9 @@ class FileHandler:
     @staticmethod
     def _uri_to_path(uri):
         parsed = urllib.parse.urlparse(uri)
-        host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=parsed.netloc)
+        host = ""
+        if parsed.netloc:
+            host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=parsed.netloc)
         return os.path.abspath(
             os.path.join(host, urllib.request.url2pathname(parsed.path))
         )

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,7 +1,8 @@
+import os
 from unittest import mock
 
 import pytest
-from connexion.json_schema import resolve_refs
+from connexion.json_schema import FileHandler, resolve_refs
 from connexion.jsonifier import Jsonifier
 from referencing.exceptions import Unresolvable
 
@@ -98,6 +99,34 @@ def test_resolve_web_reference(api):
 
     spec = resolve_refs(op_spec, store=store)
     assert spec["parameters"][0]["name"] == "test"
+
+
+@pytest.mark.parametrize("ref", ["./schema.yaml", "schema.yaml"])
+def test_resolve_relative_file_reference(tmp_path, monkeypatch, ref):
+    (tmp_path / "schema.yaml").write_text("type: string\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert FileHandler()(ref) == {"type": "string"}
+    assert resolve_refs({"properties": {"value": {"$ref": ref}}}) == {
+        "properties": {"value": {"type": "string"}}
+    }
+
+
+def test_resolve_file_uri(tmp_path):
+    schema = tmp_path / "schema with spaces.yaml"
+    schema.write_text("type: string\n", encoding="utf-8")
+
+    assert resolve_refs({"properties": {"value": {"$ref": schema.as_uri()}}}) == {
+        "properties": {"value": {"type": "string"}}
+    }
+
+
+@pytest.mark.skipif(os.name != "nt", reason="UNC paths require Windows")
+def test_file_uri_with_host():
+    assert (
+        FileHandler._uri_to_path("file://server/share/schema.yaml")
+        == r"\\server\share\schema.yaml"
+    )
 
 
 def test_resolve_ref_referring_to_another_ref(api):


### PR DESCRIPTION
Fixes #2109.

Relative schema references such as `./schema.yaml` receive a malformed UNC prefix on Windows because `FileHandler` builds a host prefix even when the URI has no host. Only add that prefix when a host is present, so relative references resolve from the working directory while UNC file URIs retain their host.

Changes proposed in this pull request:

- Cover relative references through `FileHandler` and `resolve_refs`.
- Verify absolute file URIs with escaped spaces and Windows UNC path conversion.

Validation on Windows 11 / Python 3.12.7:

- The two new relative-reference cases fail before the fix and pass afterward.
- `pytest tests/test_references.py tests/test_operation2.py tests/test_json_validation.py -q`: 42 passed.
- Black, isort, and flake8 checks pass for the changed files.

The existing `test_api.py::test_relative_refs` cases fail on both the base and this branch: their Windows drive path is used as a URI base, causing `urljoin` to discard the specification directory.